### PR TITLE
Enable auto reload for development

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,6 +36,18 @@ $ pip install .
 $ optuna-dashboard sqlite:///db.sqlite3
 ```
 
+<details>
+
+<summary>Environment variables for development</summary>
+
+If you set `OPTUNA_DASHBOARD_AUTO_RELOAD=1`, the server will automatically restart when the source codes are changed.
+
+```
+$ OPTUNA_DASHBOARD_AUTO_RELOAD=1 optuna-dashboard sqlite:///db.sqlite3
+```
+
+</details>
+
 
 ## Running tests, lint checks and formatters
 

--- a/optuna_dashboard/cli.py
+++ b/optuna_dashboard/cli.py
@@ -1,8 +1,13 @@
 import argparse
+import os
+
 from bottle import run
 
 from .app import create_app
 from .version import __version__
+
+
+AUTO_RELOAD = os.environ.get("OPTUNA_DASHBOARD_AUTO_RELOAD") == "1"
 
 
 def main() -> None:
@@ -19,7 +24,7 @@ def main() -> None:
     args = parser.parse_args()
 
     app = create_app(args.storage)
-    run(app, host=args.host, port=args.port, quiet=args.quiet)
+    run(app, host=args.host, port=args.port, quiet=args.quiet, reloader=AUTO_RELOAD)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Enable auto-reload for development when set `OPTUNA_DASHBOARD_AUTO_RELOAD=1`.

```
$ OPTUNA_DASHBOARD_AUTO_RELOAD=1 optuna-dashboard sqlite://db.sqlite3
```