### PR TITLE
Avoid top-level imports to reduce the size of bundle.js

### DIFF
--- a/optuna_dashboard/static/components/DataGrid.tsx
+++ b/optuna_dashboard/static/components/DataGrid.tsx
@@ -1,20 +1,18 @@
 import React from "react"
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles"
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableHead,
-  TablePagination,
-  TableRow,
-  TableSortLabel,
-  Collapse,
-  IconButton,
-} from "@material-ui/core"
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown"
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp"
-import { Clear } from "@material-ui/icons"
+import Clear from "@material-ui/icons/Clear"
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableContainer from "@material-ui/core/TableContainer";
+import TableHead from "@material-ui/core/TableHead";
+import TablePagination from "@material-ui/core/TablePagination";
+import TableRow from "@material-ui/core/TableRow";
+import TableSortLabel from "@material-ui/core/TableSortLabel";
+import Collapse from "@material-ui/core/Collapse";
+import IconButton from "@material-ui/core/IconButton";
 
 type Order = "asc" | "desc"
 

--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -1,18 +1,16 @@
 import * as plotly from "plotly.js-dist"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
-import {
-  Grid,
-  FormControl,
-  FormLabel,
-  FormControlLabel,
-  Checkbox,
-  MenuItem,
-  Switch,
-  Select,
-  Radio,
-  RadioGroup,
-} from "@material-ui/core"
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles"
+import Grid from "@material-ui/core/Grid";
+import FormControl from "@material-ui/core/FormControl";
+import FormLabel from "@material-ui/core/FormLabel";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
+import MenuItem from "@material-ui/core/MenuItem";
+import Switch from "@material-ui/core/Switch";
+import Select from "@material-ui/core/Select";
+import Radio from "@material-ui/core/Radio";
+import RadioGroup from "@material-ui/core/RadioGroup";
 
 const plotDomId = "graph-history"
 

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -2,21 +2,20 @@ import React, { FC, useEffect, useState } from "react"
 import { useRecoilValue } from "recoil"
 import { Link, useParams } from "react-router-dom"
 import { createStyles, fade, makeStyles, Theme } from "@material-ui/core/styles"
-import {
-  AppBar,
-  Card,
-  Typography,
-  CardContent,
-  Container,
-  Grid,
-  Toolbar,
-  Paper,
-  Box,
-  IconButton,
-  Select,
-  MenuItem,
-} from "@material-ui/core"
-import { Home, Cached } from "@material-ui/icons"
+import AppBar from "@material-ui/core/AppBar";
+import Card from "@material-ui/core/Card";
+import Typography from "@material-ui/core/Typography";
+import CardContent from "@material-ui/core/CardContent";
+import Container from "@material-ui/core/Container";
+import Toolbar from "@material-ui/core/Toolbar";
+import Grid from "@material-ui/core/Grid";
+import Paper from "@material-ui/core/Paper";
+import Box from "@material-ui/core/Box";
+import IconButton from "@material-ui/core/IconButton";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import Home from "@material-ui/icons/Home"
+import Cached from "@material-ui/icons/Cached"
 
 import { DataGridColumn, DataGrid } from "./DataGrid"
 import { GraphParallelCoordinate } from "./GraphParallelCoordinate"

--- a/optuna_dashboard/static/components/StudyList.tsx
+++ b/optuna_dashboard/static/components/StudyList.tsx
@@ -2,31 +2,34 @@ import React, { FC, useEffect } from "react"
 import { useRecoilValue } from "recoil"
 import { Link } from "react-router-dom"
 import { createStyles, makeStyles, Theme } from "@material-ui/core/styles"
-import {
-  AppBar,
-  Toolbar,
-  Typography,
-  Container,
-  Card,
-  Grid,
-  Box,
-  Button,
-  IconButton,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  TextField,
-  DialogActions,
-  FormControlLabel,
-  Checkbox,
-  Menu,
-  MenuItem,
-  FormControl,
-  FormLabel,
-  Select,
-} from "@material-ui/core"
-import { Add, AddBox, Delete, Refresh, Remove } from "@material-ui/icons"
+
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogTitle from "@material-ui/core/DialogTitle";
+import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
+import TextField from "@material-ui/core/TextField";
+import DialogActions from "@material-ui/core/DialogActions";
+import Menu from "@material-ui/core/Menu";
+import FormControl from "@material-ui/core/FormControl";
+import FormLabel from "@material-ui/core/FormLabel";
+import FormControlLabel from "@material-ui/core/FormControlLabel";
+import Checkbox from "@material-ui/core/Checkbox";
+import AppBar from "@material-ui/core/AppBar";
+import Card from "@material-ui/core/Card";
+import Typography from "@material-ui/core/Typography";
+import Container from "@material-ui/core/Container";
+import Toolbar from "@material-ui/core/Toolbar";
+import Grid from "@material-ui/core/Grid";
+import Box from "@material-ui/core/Box";
+import IconButton from "@material-ui/core/IconButton";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+import Add from "@material-ui/icons/Add"
+import AddBox from "@material-ui/icons/AddBox"
+import Delete from "@material-ui/icons/Delete"
+import Refresh from "@material-ui/icons/Refresh"
+import Remove from "@material-ui/icons/Remove"
 
 import { actionCreator } from "../action"
 import { DataGrid, DataGridColumn } from "./DataGrid"


### PR DESCRIPTION
Close #30.
