### PR TITLE
Slimming down bundle.js by using plotly.js-basic-dist

### DIFF
--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-basic-dist"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/static/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/static/components/GraphIntermediateValues.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-basic-dist"
 import React, { FC, useEffect } from "react"
 
 const plotDomId = "graph-intermediate-values"

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-basic-dist"
 import React, { FC, useEffect } from "react"
 
 const plotDomId = "graph-parallel-coordinate"

--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,10 +2246,10 @@
         "find-up": "^4.0.0"
       }
     },
-    "plotly.js-dist": {
-      "version": "1.57.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.1.tgz",
-      "integrity": "sha512-tOOFxNc6PvdDkOUgWCSYc+CcxQULTpaGTROxrtmmF8NuZghcT3EInsToEzhPH3PcGM6bu61fKo73ZiFqxwYtlg=="
+    "plotly.js-basic-dist": {
+      "version": "1.58.4",
+      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-1.58.4.tgz",
+      "integrity": "sha512-WaxrfR06KGeR73PEEcbQIws4E2TZeI5LFWrqNN3COrT12+y6WI7IONgz0iFSvZouRL/8VQvvzWjJHf5MJ/MwfQ=="
     },
     "popper.js": {
       "version": "1.16.1-lts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@material-ui/icons": "^4.9.1",
     "axios": "^0.21.1",
     "notistack": "^1.0.1",
-    "plotly.js-dist": "^1.57.0",
+    "plotly.js-basic-dist": "^1.58.4",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "alwaysStrict": true,
     "outDir": "./optuna_dashboard/public/",
     "paths": {
-      "plotly.js-dist": ["node_modules/@types/plotly.js"]
+      "plotly.js-basic-dist": ["node_modules/@types/plotly.js"]
     },
     "noImplicitAny": true,
     "lib": ["dom", "esnext"],


### PR DESCRIPTION
The result of https://github.com/webpack-contrib/webpack-bundle-analyzer is:

| Before (3.7MB) | After (1.3MB) |
| --- | --- |
| ![Screen Shot 2021-02-23 18 18 22](https://user-images.githubusercontent.com/5564044/108824776-7680d200-7605-11eb-9cf6-6d326406b1c0.png) | ![Screen Shot 2021-02-23 18 28 13](https://user-images.githubusercontent.com/5564044/108824792-7b458600-7605-11eb-9704-1c425d45c120.png) |

https://github.com/plotly/plotly.js/tree/master/dist#plotlyjs-basic
