### PR TITLE
Revert plotly.js-basic-dist.

### DIFF
--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-basic-dist"
+import * as plotly from "plotly.js-dist"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/static/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/static/components/GraphIntermediateValues.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-basic-dist"
+import * as plotly from "plotly.js-dist"
 import React, { FC, useEffect } from "react"
 
 const plotDomId = "graph-intermediate-values"

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-basic-dist"
+import * as plotly from "plotly.js-dist"
 import React, { FC, useEffect } from "react"
 
 const plotDomId = "graph-parallel-coordinate"

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-basic-dist"
+import * as plotly from "plotly.js-dist"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2246,10 +2246,10 @@
         "find-up": "^4.0.0"
       }
     },
-    "plotly.js-basic-dist": {
-      "version": "1.58.4",
-      "resolved": "https://registry.npmjs.org/plotly.js-basic-dist/-/plotly.js-basic-dist-1.58.4.tgz",
-      "integrity": "sha512-WaxrfR06KGeR73PEEcbQIws4E2TZeI5LFWrqNN3COrT12+y6WI7IONgz0iFSvZouRL/8VQvvzWjJHf5MJ/MwfQ=="
+    "plotly.js-dist": {
+      "version": "1.57.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-1.57.1.tgz",
+      "integrity": "sha512-tOOFxNc6PvdDkOUgWCSYc+CcxQULTpaGTROxrtmmF8NuZghcT3EInsToEzhPH3PcGM6bu61fKo73ZiFqxwYtlg=="
     },
     "popper.js": {
       "version": "1.16.1-lts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@material-ui/icons": "^4.9.1",
     "axios": "^0.21.1",
     "notistack": "^1.0.1",
-    "plotly.js-basic-dist": "^1.58.4",
+    "plotly.js-dist": "^1.57.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-router-dom": "^5.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "alwaysStrict": true,
     "outDir": "./optuna_dashboard/public/",
     "paths": {
-      "plotly.js-basic-dist": ["node_modules/@types/plotly.js"]
+      "plotly.js-dist": ["node_modules/@types/plotly.js"]
     },
     "noImplicitAny": true,
     "lib": ["dom", "esnext"],


### PR DESCRIPTION
`plotly.js-basic-dist` does not support `parcoords` so that the graph of parallel coordinate does not work.
This PR reverts #40.