### PR TITLE
Make datetime_start optional

### DIFF
--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -9,7 +9,7 @@ interface TrialResponse {
   state: TrialState
   values?: number[]
   intermediate_values: TrialIntermediateValue[]
-  datetime_start: string
+  datetime_start?: string
   datetime_complete?: string
   params: TrialParam[]
   user_attrs: Attribute[]
@@ -24,7 +24,9 @@ const convertTrialResponse = (res: TrialResponse): Trial => {
     state: res.state,
     values: res.values,
     intermediate_values: res.intermediate_values,
-    datetime_start: new Date(res.datetime_start),
+    datetime_start: res.datetime_start
+      ? new Date(res.datetime_start)
+      : undefined,
     datetime_complete: res.datetime_complete
       ? new Date(res.datetime_complete)
       : undefined,

--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -224,7 +224,7 @@ const plotHistory = (
     return xAxis === "number"
       ? trial.number
       : xAxis === "datetime_start"
-      ? trial.datetime_start
+      ? trial.datetime_start!
       : trial.datetime_complete!
   }
 

--- a/optuna_dashboard/static/types/index.d.ts
+++ b/optuna_dashboard/static/types/index.d.ts
@@ -32,7 +32,7 @@ declare interface Trial {
   state: TrialState
   values?: number[]
   intermediate_values: TrialIntermediateValue[]
-  datetime_start: Date
+  datetime_start?: Date
   datetime_complete?: Date
   params: TrialParam[]
   user_attrs: Attribute[]


### PR DESCRIPTION
`datetime_start` may be undefined from Optuna v2.6.0.
https://github.com/optuna/optuna/pull/2236