### PR TITLE
Add hyperparameter importance chart

### DIFF
--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -196,7 +196,7 @@ def create_app(storage: BaseStorage) -> Bottle:
     @app.get("/api/studies/<study_id:int>/param_importances")
     @handle_json_api_exception
     def get_param_importances(study_id: int) -> BottleViewReturn:
-        # TODO: add support for selecting params and targets via query parameters.
+        # TODO(chenghuzi): add support for selecting params and targets via query parameters.
         response.content_type = "application/json"
         study_name = storage.get_study_name_from_id(study_id)
         study = Study(study_name=study_name, storage=storage)

--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -99,7 +99,7 @@ def get_distribution_name(param_name: str, study: Study) -> str:
     for trial in study.trials:
         if param_name in trial.distributions:
             return trial.distributions[param_name].__class__.__name__
-    assert False
+    assert False, "Must not reach here."
 
 
 def create_app(storage: BaseStorage) -> Bottle:

--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -217,11 +217,11 @@ def create_app(storage: BaseStorage) -> Bottle:
             "target_name": target_name,
             "param_importances": [
                 {
-                    "name": i[0],
-                    "importance": i[1],
-                    "distribution": get_distribution_name(i[0], study),
+                    "name": name,
+                    "importance": importance,
+                    "distribution": get_distribution_name(name, study),
                 }
-                for i in importances.items()
+                for name, importance in importances.items()
             ],
         }
 

--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -8,10 +8,11 @@ import traceback
 from typing import Union, Dict, List, Optional, TypeVar, Callable, Any, cast
 
 from bottle import Bottle, BaseResponse, redirect, request, response, static_file
+import optuna
 from optuna.exceptions import DuplicatedStudyError
 from optuna.storages import BaseStorage
-from optuna.trial import FrozenTrial
-from optuna.study import StudyDirection, StudySummary
+from optuna.trial import FrozenTrial, TrialState
+from optuna.study import StudyDirection, StudySummary, Study
 
 from . import serializer
 
@@ -92,6 +93,13 @@ def get_trials(
         trials_last_fetched_at[study_id] = datetime.now()
         trials_cache[study_id] = trials
     return trials
+
+
+def get_distribution_name(param_name: str, study: Study) -> str:
+    for trial in study.trials:
+        if param_name in trial.distributions:
+            return trial.distributions[param_name].__class__.__name__
+    assert False
 
 
 def create_app(storage: BaseStorage) -> Bottle:
@@ -184,6 +192,38 @@ def create_app(storage: BaseStorage) -> Bottle:
             return {"reason": f"study_id={study_id} is not found"}
         trials = get_trials(storage, study_id)
         return serializer.serialize_study_detail(summary, trials)
+
+    @app.get("/api/studies/<study_id:int>/param_importances")
+    @handle_json_api_exception
+    def get_param_importances(study_id: int) -> BottleViewReturn:
+        # TODO: add support for selecting params and targets via query parameters.
+        response.content_type = "application/json"
+        study_name = storage.get_study_name_from_id(study_id)
+        study = Study(study_name=study_name, storage=storage)
+
+        trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
+        if len(trials) == 0:
+            return ""
+        evaluator = None
+        params = None
+        target = None
+        importances = optuna.importance.get_param_importances(
+            study, evaluator=evaluator, params=params, target=target
+        )
+        if target is None:
+            target_name = "Objective Value"
+
+        return {
+            "target_name": target_name,
+            "param_importances": [
+                {
+                    "name": i[0],
+                    "importance": i[1],
+                    "distribution": get_distribution_name(i[0], study),
+                }
+                for i in importances.items()
+            ],
+        }
 
     @app.get("/static/<filename:path>")
     def send_static(filename: str) -> BottleViewReturn:

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -186,5 +186,3 @@ export const getParamImportances = (
       return res.data
     })
 }
-
-export default getParamImportances

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -168,3 +168,23 @@ export const deleteStudyAPI = (studyId: number) => {
     return {}
   })
 }
+
+interface ParamImportancesResponse {
+  target_name: string
+  param_importances: ParamImportance[]
+}
+
+export const getParamImportances = (
+  studyId: number
+): Promise<ParamImportances> => {
+  return axiosInstance
+    .get<ParamImportancesResponse>(
+      `/api/studies/${studyId}/param_importances`,
+      {}
+    )
+    .then((res) => {
+      return res.data
+    })
+}
+
+export default getParamImportances

--- a/optuna_dashboard/static/components/HyperparameterImportances.tsx
+++ b/optuna_dashboard/static/components/HyperparameterImportances.tsx
@@ -26,15 +26,15 @@ const distributionColors = {
 }
 
 export const HyperparameterImportances: FC<{
-  studyId: number
-}> = ({ studyId }) => {
+  studyId: number, numOfTrials: number
+}> = ({ studyId, numOfTrials = 0 }) => {
   useEffect(() => {
     async function fetchAndPlotParamImportances(studyId: number) {
       const paramsImportanceData = await getParamImportances(studyId)
       plotParamImportances(paramsImportanceData)
     }
     fetchAndPlotParamImportances(studyId)
-  })
+  }, [numOfTrials])
   return <div id={plotDomId} />
 }
 

--- a/optuna_dashboard/static/components/HyperparameterImportances.tsx
+++ b/optuna_dashboard/static/components/HyperparameterImportances.tsx
@@ -1,0 +1,88 @@
+import * as plotly from "plotly.js-dist"
+import React, { FC, useEffect } from "react"
+import { getParamImportances } from "../apiClient"
+const plotDomId = "graph-hyperparameter-importances"
+
+// To match colors used by plot_param_importances in optuna.
+const plotlyColorsSequentialBlues = [
+  "rgb(247,251,255)",
+  "rgb(222,235,247)",
+  "rgb(198,219,239)",
+  "rgb(158,202,225)",
+  "rgb(107,174,214)",
+  "rgb(66,146,198)",
+  "rgb(33,113,181)",
+  "rgb(8,81,156)",
+  "rgb(8,48,107)",
+]
+
+const distributionColors = {
+  UniformDistribution: plotlyColorsSequentialBlues.slice(-1)[0],
+  LogUniformDistribution: plotlyColorsSequentialBlues.slice(-1)[0],
+  DiscreteUniformDistribution: plotlyColorsSequentialBlues.slice(-1)[0],
+  IntUniformDistribution: plotlyColorsSequentialBlues.slice(-2)[0],
+  IntLogUniformDistribution: plotlyColorsSequentialBlues.slice(-2)[0],
+  CategoricalDistribution: plotlyColorsSequentialBlues.slice(-4)[0],
+}
+
+export const HyperparameterImportances: FC<{
+  studyId: number
+}> = ({ studyId }) => {
+  useEffect(() => {
+    async function fetchAndPlotParamImportances(studyId: number) {
+      const paramsImportanceData = await getParamImportances(studyId)
+      plotParamImportances(paramsImportanceData)
+    }
+    fetchAndPlotParamImportances(studyId)
+  })
+  return <div id={plotDomId} />
+}
+
+const plotParamImportances = (paramsImportanceData: ParamImportances) => {
+  if (document.getElementById(plotDomId) === null) {
+    return
+  }
+  const param_importances = paramsImportanceData.param_importances.reverse()
+  const importance_values = param_importances.map((p) => p.importance)
+  const param_names = param_importances.map((p) => p.name)
+  const param_colors = param_importances.map(
+    (p) => distributionColors[p.distribution]
+  )
+  const param_hover_templates = param_importances.map(
+    (p) => `${p.name} (${p.distribution}): ${p.importance} <extra></extra>`
+  )
+  console.log("param_colors", param_colors)
+
+  const layout: Partial<plotly.Layout> = {
+    title: "Hyperparameter Importance",
+    xaxis: {
+      title: `Importance for ${paramsImportanceData.target_name}`,
+    },
+    yaxis: {
+      title: "Hyperparameter",
+    },
+    margin: {
+      l: 50,
+      r: 50,
+      b: 50,
+    },
+    showlegend: false,
+  }
+
+  const plotData: Partial<plotly.PlotData>[] = [
+    {
+      type: "bar",
+      orientation: "h",
+      x: importance_values,
+      y: param_names,
+      text: importance_values.map((v) => String(v.toFixed(2))),
+      textposition: "outside",
+      hovertemplate: param_hover_templates,
+      marker: {
+        color: param_colors,
+      },
+    },
+  ]
+
+  plotly.react(plotDomId, plotData, layout)
+}

--- a/optuna_dashboard/static/components/HyperparameterImportances.tsx
+++ b/optuna_dashboard/static/components/HyperparameterImportances.tsx
@@ -26,7 +26,8 @@ const distributionColors = {
 }
 
 export const HyperparameterImportances: FC<{
-  studyId: number, numOfTrials: number
+  studyId: number
+  numOfTrials: number
 }> = ({ studyId, numOfTrials = 0 }) => {
   useEffect(() => {
     async function fetchAndPlotParamImportances(studyId: number) {

--- a/optuna_dashboard/static/components/HyperparameterImportances.tsx
+++ b/optuna_dashboard/static/components/HyperparameterImportances.tsx
@@ -51,7 +51,6 @@ const plotParamImportances = (paramsImportanceData: ParamImportances) => {
   const param_hover_templates = param_importances.map(
     (p) => `${p.name} (${p.distribution}): ${p.importance} <extra></extra>`
   )
-  console.log("param_colors", param_colors)
 
   const layout: Partial<plotly.Layout> = {
     title: "Hyperparameter Importance",

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -202,7 +202,10 @@ export const StudyDetail: FC = () => {
               <Grid item xs={6}>
                 <Card className={classes.card}>
                   <CardContent>
-                    <HyperparameterImportances studyId={studyIdNumber} numOfTrials={trials.length}/>
+                    <HyperparameterImportances
+                      studyId={studyIdNumber}
+                      numOfTrials={trials.length}
+                    />
                   </CardContent>
                 </Card>
               </Grid>

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -202,7 +202,7 @@ export const StudyDetail: FC = () => {
               <Grid item xs={6}>
                 <Card className={classes.card}>
                   <CardContent>
-                    <HyperparameterImportances studyId={studyIdNumber} />
+                    <HyperparameterImportances studyId={studyIdNumber} numOfTrials={trials.length}/>
                   </CardContent>
                 </Card>
               </Grid>

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -20,6 +20,7 @@ import { Home, Cached } from "@material-ui/icons"
 
 import { DataGridColumn, DataGrid } from "./DataGrid"
 import { GraphParallelCoordinate } from "./GraphParallelCoordinate"
+import { HyperparameterImportances } from "./HyperparameterImportances"
 import { GraphIntermediateValues } from "./GraphIntermediateValues"
 import { GraphSlice } from "./GraphSlice"
 import { GraphHistory } from "./GraphHistory"
@@ -191,6 +192,17 @@ export const StudyDetail: FC = () => {
                 <Card className={classes.card}>
                   <CardContent>
                     <GraphIntermediateValues trials={trials} />
+                  </CardContent>
+                </Card>
+              </Grid>
+            </Grid>
+          ) : null}
+          {studyDetail !== null && isSingleObjectiveStudy(studyDetail) ? (
+            <Grid container direction="row">
+              <Grid item xs={6}>
+                <Card className={classes.card}>
+                  <CardContent>
+                    <HyperparameterImportances studyId={studyIdNumber} />
                   </CardContent>
                 </Card>
               </Grid>

--- a/optuna_dashboard/static/types/index.d.ts
+++ b/optuna_dashboard/static/types/index.d.ts
@@ -9,6 +9,13 @@ declare const URL_PREFIX: string
 
 type TrialState = "Running" | "Complete" | "Pruned" | "Fail" | "Waiting"
 type StudyDirection = "maximize" | "minimize" | "not_set"
+type Distribution =
+  | "UniformDistribution"
+  | "LogUniformDistribution"
+  | "DiscreteUniformDistribution"
+  | "IntUniformDistribution"
+  | "IntLogUniformDistribution"
+  | "CategoricalDistribution"
 
 declare interface TrialIntermediateValue {
   step: number
@@ -18,6 +25,12 @@ declare interface TrialIntermediateValue {
 declare interface TrialParam {
   name: string
   value: string
+}
+
+declare interface ParamImportance {
+  name: string
+  importance: number
+  distribution: Distribution
 }
 
 declare interface Attribute {
@@ -59,4 +72,9 @@ declare interface StudyDetail {
 
 declare interface StudyDetails {
   [study_id: string]: StudyDetail
+}
+
+declare interface ParamImportances {
+  target_name: string
+  param_importances: ParamImportance[]
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     optuna>=2.4
     bottle
     typing-extensions;python_version<'3.8'
+    scikit-learn
 
 [options.extras_require]
 lint =


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Fixs #25 
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## Add hyperparameter importance chart

There're two ways to add hyperparameter importance chart. One is to implement the evaluator which completely mirrors the one used by optuna via typescript and another is to use the optuna `optuna.importance.get_param_importances` API directly. 

The former makes the logic cleaner but involves extra computation in the browser, and implementing a complete parameter importance function by ts requires an update whenever the optuna API changes.

The latter one is much more flexible and only requires introducing another API call. But the con is it takes longer for the server to get the importance result.

Here we take the second approach and only consider the single objective function case. For future multi-objective case, we can extend the API with query parameters representing params and target selected by the user.



<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
