### PR TITLE
Calculate intersection/union of search space.

### DIFF
--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -14,6 +14,7 @@ from optuna.trial import FrozenTrial
 from optuna.study import StudyDirection, StudySummary
 
 from . import serializer
+from .search_space import get_search_space
 
 BottleViewReturn = Union[str, bytes, Dict[str, Any], BaseResponse]
 BottleView = TypeVar("BottleView", bound=Callable[..., BottleViewReturn])
@@ -183,7 +184,8 @@ def create_app(storage: BaseStorage) -> Bottle:
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
         trials = get_trials(storage, study_id)
-        return serializer.serialize_study_detail(summary, trials)
+        intersection, union = get_search_space(study_id, trials)
+        return serializer.serialize_study_detail(summary, trials, intersection, union)
 
     @app.get("/static/<filename:path>")
     def send_static(filename: str) -> BottleViewReturn:

--- a/optuna_dashboard/search_space.py
+++ b/optuna_dashboard/search_space.py
@@ -15,7 +15,9 @@ search_space_cache: Dict[int, "_SearchSpace"] = {}
 states_of_interest = [TrialState.COMPLETE, TrialState.PRUNED]
 
 
-def get_search_space(study_id: int, trials: List[FrozenTrial]) -> Tuple[SearchSpaceListT, SearchSpaceListT]:
+def get_search_space(
+    study_id: int, trials: List[FrozenTrial]
+) -> Tuple[SearchSpaceListT, SearchSpaceListT]:
     with search_space_cache_lock:
         search_space = search_space_cache.get(study_id, None)
         if search_space is None:

--- a/optuna_dashboard/search_space.py
+++ b/optuna_dashboard/search_space.py
@@ -1,0 +1,68 @@
+import copy
+import threading
+from typing import Dict, List, Optional, Set, Tuple
+
+from optuna.distributions import BaseDistribution
+from optuna.study import BaseStudy
+from optuna.trial import TrialState
+
+SearchSpaceSetT = Set[Tuple[str, BaseDistribution]]
+SearchSpaceListT = List[Tuple[str, BaseDistribution]]
+
+# In-memory search space cache
+search_space_cache_lock = threading.Lock()
+search_space_cache: Dict[int, "_SearchSpace"] = {}
+
+states_of_interest = [TrialState.COMPLETE, TrialState.PRUNED]
+
+
+def get_search_space(study: BaseStudy) -> Tuple[SearchSpaceListT, SearchSpaceListT]:
+    with search_space_cache_lock:
+        search_space = search_space_cache.get(study._study_id, None)
+        if search_space is None:
+            search_space = _SearchSpace()
+        search_space.update(study)
+        search_space_cache[study._study_id] = search_space
+        return search_space.intersection, search_space.union
+
+
+class _SearchSpace:
+    def __init__(self) -> None:
+        self._cursor: int = -1
+        self._intersection: Optional[SearchSpaceSetT] = None
+        self._union: SearchSpaceSetT = set()
+
+    @property
+    def intersection(self) -> SearchSpaceListT:
+        if self._intersection is None:
+            return []
+        intersection = list(self._intersection)
+        intersection.sort(key=lambda x: x[0])
+        return intersection
+
+    @property
+    def union(self) -> SearchSpaceListT:
+        union = list(self._union)
+        union.sort(key=lambda x: x[0])
+        return union
+
+    def update(self, study: BaseStudy) -> None:
+        next_cursor = self._cursor
+        for trial in reversed(study.get_trials(deepcopy=False)):
+            if self._cursor > trial.number:
+                break
+
+            if not trial.state.is_finished():
+                next_cursor = trial.number
+
+            if trial.state not in states_of_interest:
+                continue
+
+            current = set([(n, d) for n, d in trial.distributions.items()])
+            self._union = self._union.union(current)
+
+            if self._intersection is None:
+                self._intersection = copy.copy(current)
+            else:
+                self._intersection = self._intersection.intersection(current)
+        self._cursor = next_cursor

--- a/optuna_dashboard/search_space.py
+++ b/optuna_dashboard/search_space.py
@@ -3,8 +3,7 @@ import threading
 from typing import Dict, List, Optional, Set, Tuple
 
 from optuna.distributions import BaseDistribution
-from optuna.study import BaseStudy
-from optuna.trial import TrialState
+from optuna.trial import TrialState, FrozenTrial
 
 SearchSpaceSetT = Set[Tuple[str, BaseDistribution]]
 SearchSpaceListT = List[Tuple[str, BaseDistribution]]
@@ -16,13 +15,13 @@ search_space_cache: Dict[int, "_SearchSpace"] = {}
 states_of_interest = [TrialState.COMPLETE, TrialState.PRUNED]
 
 
-def get_search_space(study: BaseStudy) -> Tuple[SearchSpaceListT, SearchSpaceListT]:
+def get_search_space(study_id: int, trials: List[FrozenTrial]) -> Tuple[SearchSpaceListT, SearchSpaceListT]:
     with search_space_cache_lock:
-        search_space = search_space_cache.get(study._study_id, None)
+        search_space = search_space_cache.get(study_id, None)
         if search_space is None:
             search_space = _SearchSpace()
-        search_space.update(study)
-        search_space_cache[study._study_id] = search_space
+        search_space.update(trials)
+        search_space_cache[study_id] = search_space
         return search_space.intersection, search_space.union
 
 
@@ -46,9 +45,9 @@ class _SearchSpace:
         union.sort(key=lambda x: x[0])
         return union
 
-    def update(self, study: BaseStudy) -> None:
+    def update(self, trials: List[FrozenTrial]) -> None:
         next_cursor = self._cursor
-        for trial in reversed(study.get_trials(deepcopy=False)):
+        for trial in reversed(trials):
             if self._cursor > trial.number:
                 break
 

--- a/tests/test_search_space.py
+++ b/tests/test_search_space.py
@@ -16,7 +16,6 @@ class SearchSpaceTestCase(TestCase):
         warnings.simplefilter("ignore", category=ExperimentalWarning)
 
     def test_same_distributions(self) -> None:
-        study = optuna.create_study()
         distributions = [
             {
                 "x0": UniformDistribution(low=0, high=10),
@@ -41,16 +40,13 @@ class SearchSpaceTestCase(TestCase):
             create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
             for d, p in zip(distributions, params)
         ]
-        study.add_trials(trials=trials)
-
         search_space = _SearchSpace()
-        search_space.update(study)
+        search_space.update(trials)
 
         self.assertEqual(len(search_space.intersection), 2)
         self.assertEqual(len(search_space.union), 2)
 
     def test_different_distributions(self) -> None:
-        study = optuna.create_study()
         distributions = [
             {
                 "x0": UniformDistribution(low=0, high=10),
@@ -75,16 +71,13 @@ class SearchSpaceTestCase(TestCase):
             create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
             for d, p in zip(distributions, params)
         ]
-        study.add_trials(trials=trials)
-
         search_space = _SearchSpace()
-        search_space.update(study)
+        search_space.update(trials)
 
         self.assertEqual(len(search_space.intersection), 1)
         self.assertEqual(len(search_space.union), 3)
 
     def test_dynamic_search_space(self) -> None:
-        study = optuna.create_study()
         distributions = [
             {
                 "x0": UniformDistribution(low=0, high=10),
@@ -115,10 +108,8 @@ class SearchSpaceTestCase(TestCase):
             create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
             for d, p in zip(distributions, params)
         ]
-        study.add_trials(trials=trials)
-
         search_space = _SearchSpace()
-        search_space.update(study)
+        search_space.update(trials)
 
         self.assertEqual(len(search_space.intersection), 0)
         self.assertEqual(len(search_space.union), 3)

--- a/tests/test_search_space.py
+++ b/tests/test_search_space.py
@@ -1,0 +1,124 @@
+import warnings
+from unittest import TestCase
+
+import optuna
+from optuna import create_trial
+from optuna.distributions import UniformDistribution
+from optuna.exceptions import ExperimentalWarning
+from optuna.trial import TrialState
+
+from optuna_dashboard.search_space import _SearchSpace
+
+
+class SearchSpaceTestCase(TestCase):
+    def setUp(self) -> None:
+        optuna.logging.set_verbosity(optuna.logging.ERROR)
+        warnings.simplefilter("ignore", category=ExperimentalWarning)
+
+    def test_same_distributions(self) -> None:
+        study = optuna.create_study()
+        distributions = [
+            {
+                "x0": UniformDistribution(low=0, high=10),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+            {
+                "x0": UniformDistribution(low=0, high=10),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+        ]
+        params = [
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+        ]
+        trials = [
+            create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
+            for d, p in zip(distributions, params)
+        ]
+        study.add_trials(trials=trials)
+
+        search_space = _SearchSpace()
+        search_space.update(study)
+
+        self.assertEqual(len(search_space.intersection), 2)
+        self.assertEqual(len(search_space.union), 2)
+
+    def test_different_distributions(self) -> None:
+        study = optuna.create_study()
+        distributions = [
+            {
+                "x0": UniformDistribution(low=0, high=10),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+            {
+                "x0": UniformDistribution(low=0, high=5),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+        ]
+        params = [
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+        ]
+        trials = [
+            create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
+            for d, p in zip(distributions, params)
+        ]
+        study.add_trials(trials=trials)
+
+        search_space = _SearchSpace()
+        search_space.update(study)
+
+        self.assertEqual(len(search_space.intersection), 1)
+        self.assertEqual(len(search_space.union), 3)
+
+    def test_dynamic_search_space(self) -> None:
+        study = optuna.create_study()
+        distributions = [
+            {
+                "x0": UniformDistribution(low=0, high=10),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+            {
+                "x0": UniformDistribution(low=0, high=5),
+            },
+            {
+                "x0": UniformDistribution(low=0, high=10),
+                "x1": UniformDistribution(low=0, high=10),
+            },
+        ]
+        params = [
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+            {
+                "x0": 0.5,
+            },
+            {
+                "x0": 0.5,
+                "x1": 0.5,
+            },
+        ]
+        trials = [
+            create_trial(state=TrialState.COMPLETE, value=0, distributions=d, params=p)
+            for d, p in zip(distributions, params)
+        ]
+        study.add_trials(trials=trials)
+
+        search_space = _SearchSpace()
+        search_space.update(study)
+
+        self.assertEqual(len(search_space.intersection), 0)
+        self.assertEqual(len(search_space.union), 3)


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #58 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
The intersection/union search space is calculated to plot the graph, but it's computationally expensive. This PR returns the search space at a server side.

* https://github.com/optuna/optuna-dashboard/blob/4e1f50b8c15b710bd681f5bbc0537d17d9c2b171/optuna_dashboard/static/components/GraphParallelCoordinate.tsx#L38-L44
* https://github.com/optuna/optuna-dashboard/blob/4e1f50b8c15b710bd681f5bbc0537d17d9c2b171/optuna_dashboard/static/components/GraphSlice.tsx#L25-L30