### PR TITLE
Reduce the size of attr values

### DIFF
--- a/optuna_dashboard/serializer.py
+++ b/optuna_dashboard/serializer.py
@@ -35,7 +35,7 @@ TrialParam = TypedDict(
 
 
 def serialize_attrs(attrs: Dict[str, Any]) -> List[Attribute]:
-    serialized = []
+    serialized: List[Attribute] = []
     for k, v in attrs.items():
         value: str
         if isinstance(v, str):

--- a/optuna_dashboard/serializer.py
+++ b/optuna_dashboard/serializer.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any, Dict, List, Tuple
 
 from optuna.distributions import BaseDistribution
@@ -11,6 +10,7 @@ except ImportError:
     from typing_extensions import TypedDict
 
 
+MAX_ATTR_LENGTH = 128
 Attribute = TypedDict(
     "Attribute",
     {
@@ -35,7 +35,21 @@ TrialParam = TypedDict(
 
 
 def serialize_attrs(attrs: Dict[str, Any]) -> List[Attribute]:
-    return [{"key": k, "value": json.dumps(v)} for k, v in attrs.items()]
+    serialized = []
+    for k, v in attrs.items():
+        value: str
+        if isinstance(v, str):
+            value = v[:MAX_ATTR_LENGTH] if len(v) > MAX_ATTR_LENGTH else v
+        elif isinstance(v, (bool, float, int)):
+            value = str(v)
+        elif isinstance(v, bytes):
+            value = "<binary object>"
+        elif v is None:
+            value = "None"
+        else:  # unsupported type
+            continue
+        serialized.append({"key": k, "value": value})
+    return serialized
 
 
 def serialize_intermediate_values(values: Dict[int, float]) -> List[IntermediateValue]:

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+from optuna_dashboard.serializer import serialize_attrs
+
+
+class SerializeAttrsTestCase(TestCase):
+    def test_serialize_bytes(self) -> None:
+        serialized = serialize_attrs({"bytes": b"This is a bytes object."})
+        self.assertEqual(serialized[0]["value"], "<binary object>")
+
+    def test_serialize_string(self) -> None:
+        for length in [100, 128, 150]:
+            with self.subTest(f"length: {length}"):
+                value = "a" * length
+                serialized = serialize_attrs({
+                    "key": value,
+                })
+                self.assertLessEqual(len(serialized[0]["value"]), 128)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -11,7 +11,9 @@ class SerializeAttrsTestCase(TestCase):
         for length in [100, 128, 150]:
             with self.subTest(f"length: {length}"):
                 value = "a" * length
-                serialized = serialize_attrs({
-                    "key": value,
-                })
+                serialized = serialize_attrs(
+                    {
+                        "key": value,
+                    }
+                )
                 self.assertLessEqual(len(serialized[0]["value"]), 128)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
`system_attrs` and/or `user_attrs` may contain a long string/bytes. For example, CmaEsSampler stores serialized optimizer objects in `system_attrs`. These attr values are not required on optuna-dashboard. In this PR, I add the following changes:

* A long string object (longer than 128 characters) will be trimmed.
* A binary object will be replaced by `"<binary object>"`.