### PR TITLE
Fix a bug to crash when trials are pruned with no intermediate values

### DIFF
--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -187,7 +187,7 @@ const plotHistory = (
   }
 
   let filteredTrials = study.trials.filter(
-    (t) => t.state === "Complete" || t.state === "Pruned"
+    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
   )
   if (filterCompleteTrial) {
     filteredTrials = filteredTrials.filter((t) => t.state !== "Complete")

--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -187,7 +187,9 @@ const plotHistory = (
   }
 
   let filteredTrials = study.trials.filter(
-    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
+    (t) =>
+      t.state === "Complete" ||
+      (t.state === "Pruned" && t.values && t.values.length > 0)
   )
   if (filterCompleteTrial) {
     filteredTrials = filteredTrials.filter((t) => t.state !== "Complete")

--- a/optuna_dashboard/static/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/static/components/GraphIntermediateValues.tsx
@@ -31,7 +31,9 @@ const plotIntermediateValue = (trials: Trial[]) => {
   }
 
   const filteredTrials = trials.filter(
-    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
+    (t) =>
+      t.state === "Complete" ||
+      (t.state === "Pruned" && t.values && t.values.length > 0)
   )
   const plotData: Partial<plotly.PlotData>[] = filteredTrials.map((trial) => {
     return {

--- a/optuna_dashboard/static/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/static/components/GraphIntermediateValues.tsx
@@ -31,7 +31,7 @@ const plotIntermediateValue = (trials: Trial[]) => {
   }
 
   const filteredTrials = trials.filter(
-    (t) => t.state === "Complete" || t.state === "Pruned"
+    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
   )
   const plotData: Partial<plotly.PlotData>[] = filteredTrials.map((trial) => {
     return {

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -32,7 +32,7 @@ const plotCoordinate = (trials: Trial[], objectiveId: number) => {
   }
 
   const filteredTrials = trials.filter(
-    (t) => t.state === "Complete" || t.state === "Pruned"
+    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
   )
 
   // Intersection param names

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -32,7 +32,9 @@ const plotCoordinate = (trials: Trial[], objectiveId: number) => {
   }
 
   const filteredTrials = trials.filter(
-    (t) => t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)
+    (t) =>
+      t.state === "Complete" ||
+      (t.state === "Pruned" && t.values && t.values.length > 0)
   )
 
   // Intersection param names

--- a/optuna_dashboard/static/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/static/components/GraphParetoFront.tsx
@@ -103,7 +103,7 @@ const plotParetoFront = (
     },
   }
 
-  const trials: Trial[] = study !== null ? study.trials : []
+  const trials: Trial[] = study ? study.trials : []
   const completedTrials = trials.filter((t) => t.state === "Complete")
 
   if (completedTrials.length === 0) {

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -140,7 +140,7 @@ const plotSlice = (
 
   const filteredTrials = trials.filter(
     (t) =>
-      (t.state === "Complete" || t.state === "Pruned") &&
+      (t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)) &&
       t.params.find((p) => p.name == selected) !== undefined
   )
 

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -140,7 +140,8 @@ const plotSlice = (
 
   const filteredTrials = trials.filter(
     (t) =>
-      (t.state === "Complete" || (t.state === "Pruned" && t.values && t.values.length > 0)) &&
+      (t.state === "Complete" ||
+        (t.state === "Pruned" && t.values && t.values.length > 0)) &&
       t.params.find((p) => p.name == selected) !== undefined
   )
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Fix #68 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
When trials are pruned without intermediate values, `FrozenTrial.values` is None. It is the reason why the application will be crashed.