### PR TITLE
Fix a bug of HyperparameterImportance when given no trials

### DIFF
--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -221,16 +221,16 @@ def create_app(storage: BaseStorage) -> Bottle:
         study = Study(study_name=study_name, storage=storage)
 
         trials = [trial for trial in study.trials if trial.state == TrialState.COMPLETE]
-        if len(trials) == 0:
-            return ""
         evaluator = None
         params = None
         target = None
-        importances = optuna.importance.get_param_importances(
-            study, evaluator=evaluator, params=params, target=target
-        )
-        if target is None:
-            target_name = "Objective Value"
+        if len(trials) > 0:
+            importances = optuna.importance.get_param_importances(
+                study, evaluator=evaluator, params=params, target=target
+            )
+        else:
+            importances = {}
+        target_name = "Objective Value"
 
         return {
             "target_name": target_name,


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
When given a study with no trials, hyperparameter importance component raises an error of undefined property access.