### PR TITLE
Fast intersection search space

### DIFF
--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -64,7 +64,7 @@ export const getStudyDetailAPI = (studyId: number): Promise<StudyDetail> => {
           : undefined,
         trials: trials,
         union_search_space: res.data.union_search_space,
-        intersection_search_space: res.data.union_search_space,
+        intersection_search_space: res.data.intersection_search_space,
       }
     })
 }

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -42,6 +42,8 @@ interface StudyDetailResponse {
   directions: StudyDirection[]
   best_trial?: TrialResponse
   trials: TrialResponse[]
+  intersection_search_space: SearchSpace[]
+  union_search_space: SearchSpace[]
 }
 
 export const getStudyDetailAPI = (studyId: number): Promise<StudyDetail> => {
@@ -61,6 +63,8 @@ export const getStudyDetailAPI = (studyId: number): Promise<StudyDetail> => {
           ? convertTrialResponse(res.data.best_trial)
           : undefined,
         trials: trials,
+        union_search_space: res.data.union_search_space,
+        intersection_search_space: res.data.union_search_space,
       }
     })
 }

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -32,7 +32,7 @@ export const GraphSlice: FC<{
   const trials: Trial[] = study !== null ? study.trials : []
   const [objectiveId, setObjectiveId] = useState<number>(0)
   const [selected, setSelected] = useState<string | null>(null)
-  const paramNames = study?.union_search_space.map(s => s.name)
+  const paramNames = study?.union_search_space.map((s) => s.name)
   if (selected === null && paramNames && paramNames.length > 0) {
     setSelected(paramNames[0])
   }

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -25,33 +25,17 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 )
 
-const getParamNames = (trials: Trial[]): string[] => {
-  const paramSet = new Set<string>(
-    ...trials.map<string[]>((t) => t.params.map((p) => p.name))
-  )
-  return Array.from(paramSet)
-}
-
 export const GraphSlice: FC<{
   study: StudyDetail | null
 }> = ({ study = null }) => {
   const classes = useStyles()
   const trials: Trial[] = study !== null ? study.trials : []
-  const [paramNames, setParamNames] = useState<string[]>([])
   const [objectiveId, setObjectiveId] = useState<number>(0)
   const [selected, setSelected] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (trials.length === 0 || paramNames.length !== 0) {
-      return
-    }
-
-    const p = getParamNames(trials)
-    setParamNames(p)
-    if (selected === null && p.length !== 0) {
-      setSelected(p[0])
-    }
-  }, [trials])
+  const paramNames = study?.union_search_space.map(s => s.name)
+  if (selected === null && paramNames && paramNames.length > 0) {
+    setSelected(paramNames[0])
+  }
 
   useEffect(() => {
     plotSlice(trials, objectiveId, selected)
@@ -86,18 +70,16 @@ export const GraphSlice: FC<{
               </Select>
             </FormControl>
           ) : null}
-          {paramNames.length !== 0 && selected !== null ? (
-            <FormControl component="fieldset" className={classes.formControl}>
-              <InputLabel id="parameter">Parameter</InputLabel>
-              <Select value={selected || ""} onChange={handleSelectedParam}>
-                {paramNames.map((p, i) => (
-                  <MenuItem value={p} key={i}>
-                    {p}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          ) : null}
+          <FormControl component="fieldset" className={classes.formControl}>
+            <InputLabel id="parameter">Parameter</InputLabel>
+            <Select value={selected || ""} onChange={handleSelectedParam}>
+              {paramNames?.map((p, i) => (
+                <MenuItem value={p} key={i}>
+                  {p}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </Grid>
       </Grid>
       <Grid item xs={9}>

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -194,7 +194,7 @@ export const StudyDetail: FC = () => {
               <Grid item xs={6}>
                 <Card className={classes.card}>
                   <CardContent>
-                    <GraphParallelCoordinate trials={trials} />
+                    <GraphParallelCoordinate study={studyDetail} />
                   </CardContent>
                 </Card>
               </Grid>

--- a/optuna_dashboard/static/types/index.d.ts
+++ b/optuna_dashboard/static/types/index.d.ts
@@ -33,6 +33,11 @@ declare interface ParamImportance {
   distribution: Distribution
 }
 
+declare interface SearchSpace {
+  name: string
+  type: string
+}
+
 declare interface Attribute {
   key: string
   value: string
@@ -68,6 +73,8 @@ declare interface StudyDetail {
   datetime_start: Date
   best_trial?: Trial
   trials: Trial[]
+  intersection_search_space: SearchSpace[]
+  union_search_space: SearchSpace[]
 }
 
 declare interface StudyDetails {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Close #58.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Intersection/Union search space is computationally expensive because it consumes `O(nm)`, where n is the number of trials and m is the number of parameters. So that this change makes optuna-dashboard faster especially when given huge trials.