### PR TITLE
Fix less comparator of DataGrid

### DIFF
--- a/optuna_dashboard/static/components/DataGrid.tsx
+++ b/optuna_dashboard/static/components/DataGrid.tsx
@@ -51,7 +51,7 @@ interface DataGridColumn<T> {
   field: keyof T
   label: string
   sortable?: boolean
-  less?: (i: number, j: number) => number
+  less?: (a: T, b: T) => number
   filterable?: boolean
   toCellValue?: (rowIndex: number) => string | React.ReactNode
   padding?: "default" | "checkbox" | "none"
@@ -342,7 +342,7 @@ function stableSort<T>(
   const stabilizedThis = array.map((el, index) => [el, index] as [T, number])
   stabilizedThis.sort((a, b) => {
     if (less) {
-      const result = order == "asc" ? -less(a[1], b[1]) : less(a[1], b[1])
+      const result = order == "asc" ? -less(a[0], b[0]) : less(a[0], b[0])
       if (result !== 0) return result
     } else {
       const result = comparator(a[0], b[0])

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -265,9 +265,9 @@ const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
       field: "values",
       label: "Value",
       sortable: true,
-      less: (i, j): number => {
-        const firstVal = trials[i].values?.[0]
-        const secondVal = trials[j].values?.[0]
+      less: (firstEl, secondEl): number => {
+        const firstVal = firstEl.values?.[0]
+        const secondVal = secondEl.values?.[0]
 
         if (firstVal === secondVal) {
           return 0
@@ -293,9 +293,9 @@ const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
       field: "values",
       label: `Objective ${objectiveId}`,
       sortable: true,
-      less: (i, j): number => {
-        const firstVal = trials[i].values?.[objectiveId]
-        const secondVal = trials[j].values?.[objectiveId]
+      less: (firstEl, secondEl): number => {
+        const firstVal = firstEl.values?.[objectiveId]
+        const secondVal = secondEl.values?.[objectiveId]
 
         if (firstVal === secondVal) {
           return 0
@@ -328,15 +328,15 @@ const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
       return null
     },
     sortable: true,
-    less: (i, j): number => {
-      const firstStartMs = trials[i].datetime_start?.getTime()
-      const firstCompleteMs = trials[i].datetime_complete?.getTime()
+    less: (firstEl, secondEl): number => {
+      const firstStartMs = firstEl.datetime_start?.getTime()
+      const firstCompleteMs = firstEl.datetime_complete?.getTime()
       const firstDurationMs =
         firstStartMs !== undefined && firstCompleteMs !== undefined
           ? firstCompleteMs - firstStartMs
           : undefined
-      const secondStartMs = trials[j].datetime_start?.getTime()
-      const secondCompleteMs = trials[j].datetime_complete?.getTime()
+      const secondStartMs = secondEl.datetime_start?.getTime()
+      const secondCompleteMs = secondEl.datetime_complete?.getTime()
       const secondDurationMs =
         secondStartMs !== undefined && secondCompleteMs !== undefined
           ? secondCompleteMs - secondStartMs


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
`less` comparator does not work properly when using filter.