### PR TITLE
Fix a regression bug of attr serialization

### DIFF
--- a/optuna_dashboard/serializer.py
+++ b/optuna_dashboard/serializer.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 from typing import Dict
 from typing import List
@@ -14,7 +15,7 @@ except ImportError:
     from typing_extensions import TypedDict
 
 
-MAX_ATTR_LENGTH = 128
+MAX_ATTR_LENGTH = 1024
 Attribute = TypedDict(
     "Attribute",
     {
@@ -42,16 +43,11 @@ def serialize_attrs(attrs: Dict[str, Any]) -> List[Attribute]:
     serialized: List[Attribute] = []
     for k, v in attrs.items():
         value: str
-        if isinstance(v, str):
-            value = v[:MAX_ATTR_LENGTH] if len(v) > MAX_ATTR_LENGTH else v
-        elif isinstance(v, (bool, float, int)):
-            value = str(v)
-        elif isinstance(v, bytes):
+        if isinstance(v, bytes):
             value = "<binary object>"
-        elif v is None:
-            value = "None"
-        else:  # unsupported type
-            continue
+        else:
+            value = json.dumps(v)
+            value = value[:MAX_ATTR_LENGTH] if len(value) > MAX_ATTR_LENGTH else value
         serialized.append({"key": k, "value": value})
     return serialized
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -9,7 +9,7 @@ class SerializeAttrsTestCase(TestCase):
         self.assertEqual(serialized[0]["value"], "<binary object>")
 
     def test_serialize_string(self) -> None:
-        for length in [100, 128, 150]:
+        for length in [1000, 1024, 1100]:
             with self.subTest(f"length: {length}"):
                 value = "a" * length
                 serialized = serialize_attrs(
@@ -17,4 +17,12 @@ class SerializeAttrsTestCase(TestCase):
                         "key": value,
                     }
                 )
-                self.assertLessEqual(len(serialized[0]["value"]), 128)
+                self.assertLessEqual(len(serialized[0]["value"]), 1024)
+
+    def test_serialize_dict(self) -> None:
+        serialized = serialize_attrs(
+            {
+                "key": {"foo": "bar"},
+            }
+        )
+        self.assertLessEqual(len(serialized), 1)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
to close #87 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
In #65, I forgot to support dict, list, and tuple objects.