### PR TITLE
Show tick labels and add log scale in slice graph

### DIFF
--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -32,14 +32,15 @@ export const GraphSlice: FC<{
   const trials: Trial[] = study !== null ? study.trials : []
   const [objectiveId, setObjectiveId] = useState<number>(0)
   const [selected, setSelected] = useState<string | null>(null)
+  const [log, setLog] = useState<boolean>(false)
   const paramNames = study?.union_search_space.map((s) => s.name)
   if (selected === null && paramNames && paramNames.length > 0) {
     setSelected(paramNames[0])
   }
 
   useEffect(() => {
-    plotSlice(trials, objectiveId, selected)
-  }, [trials, objectiveId, selected])
+    plotSlice(trials, objectiveId, selected, log)
+  }, [trials, objectiveId, selected, log])
 
   const handleObjectiveChange = (
     event: React.ChangeEvent<{ value: unknown }>
@@ -92,7 +93,8 @@ export const GraphSlice: FC<{
 const plotSlice = (
   trials: Trial[],
   objectiveId: number,
-  selected: string | null
+  selected: string | null,
+  log: boolean
 ) => {
   if (document.getElementById(plotDomId) === null) {
     return
@@ -116,6 +118,7 @@ const plotSlice = (
     },
     yaxis: {
       title: "Objective Values",
+      type: log ? "log" : "linear",
       zerolinecolor: "#f2f5fa",
       zerolinewidth: 2,
       linecolor: "#f2f5fa",
@@ -171,6 +174,10 @@ const plotSlice = (
       linewidth: 5,
       gridcolor: "#f2f5fa",
       gridwidth: 1,
+      tickfont: {
+        "color": "#000000"
+      },
+      automargin: true  // Otherwise the label is outside of the plot
     }
     plotly.react(plotDomId, trace, layout)
   } else {
@@ -189,7 +196,7 @@ const plotSlice = (
         // xaxis: paramName,
         marker: {
           color: "#185799",
-        },
+        }
       },
     ]
     layout["xaxis"] = {
@@ -205,7 +212,7 @@ const plotSlice = (
       },
       tickvals: tickvals,
       ticktext: vocabArr,
-      automargin: true
+      automargin: true  // Otherwise the label is outside of the plot
     }
     plotly.react(plotDomId, trace, layout)
   }

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -6,6 +6,7 @@ import {
   FormLabel,
   InputLabel,
   MenuItem,
+  Switch,
   Select,
   Typography,
 } from "@material-ui/core"
@@ -32,15 +33,15 @@ export const GraphSlice: FC<{
   const trials: Trial[] = study !== null ? study.trials : []
   const [objectiveId, setObjectiveId] = useState<number>(0)
   const [selected, setSelected] = useState<string | null>(null)
-  const [log, setLog] = useState<boolean>(false)
+  const [logScale, setLogScale] = useState<boolean>(false)
   const paramNames = study?.union_search_space.map((s) => s.name)
   if (selected === null && paramNames && paramNames.length > 0) {
     setSelected(paramNames[0])
   }
 
   useEffect(() => {
-    plotSlice(trials, objectiveId, selected, log)
-  }, [trials, objectiveId, selected, log])
+    plotSlice(trials, objectiveId, selected, logScale)
+  }, [trials, objectiveId, selected, logScale])
 
   const handleObjectiveChange = (
     event: React.ChangeEvent<{ value: unknown }>
@@ -50,6 +51,11 @@ export const GraphSlice: FC<{
 
   const handleSelectedParam = (e: ChangeEvent<{ value: unknown }>) => {
     setSelected(e.target.value as string)
+  }
+
+  const handleLogScaleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    e.preventDefault()
+    setLogScale(!logScale)
   }
 
   return (
@@ -80,6 +86,14 @@ export const GraphSlice: FC<{
                 </MenuItem>
               ))}
             </Select>
+          </FormControl>
+          <FormControl component="fieldset" className={classes.formControl}>
+            <FormLabel component="legend">Log scale:</FormLabel>
+            <Switch
+              checked={logScale}
+              onChange={handleLogScaleChange}
+              value="enable"
+            />
           </FormControl>
         </Grid>
       </Grid>

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -108,7 +108,7 @@ const plotSlice = (
   trials: Trial[],
   objectiveId: number,
   selected: string | null,
-  log: boolean
+  logScale: boolean
 ) => {
   if (document.getElementById(plotDomId) === null) {
     return
@@ -132,7 +132,7 @@ const plotSlice = (
     },
     yaxis: {
       title: "Objective Values",
-      type: log ? "log" : "linear",
+      type: logScale ? "log" : "linear",
       zerolinecolor: "#f2f5fa",
       zerolinewidth: 2,
       linecolor: "#f2f5fa",

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -189,9 +189,9 @@ const plotSlice = (
       gridcolor: "#f2f5fa",
       gridwidth: 1,
       tickfont: {
-        "color": "#000000"
+        color: "#000000",
       },
-      automargin: true  // Otherwise the label is outside of the plot
+      automargin: true, // Otherwise the label is outside of the plot
     }
     plotly.react(plotDomId, trace, layout)
   } else {
@@ -210,7 +210,7 @@ const plotSlice = (
         // xaxis: paramName,
         marker: {
           color: "#185799",
-        }
+        },
       },
     ]
     layout["xaxis"] = {
@@ -226,7 +226,7 @@ const plotSlice = (
       },
       tickvals: tickvals,
       ticktext: vocabArr,
-      automargin: true  // Otherwise the label is outside of the plot
+      automargin: true, // Otherwise the label is outside of the plot
     }
     plotly.react(plotDomId, trace, layout)
   }

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -129,6 +129,7 @@ const plotSlice = (
       linewidth: 5,
       gridcolor: "#f2f5fa",
       gridwidth: 1,
+      automargin: true,
     },
     yaxis: {
       title: "Objective Values",
@@ -139,6 +140,7 @@ const plotSlice = (
       linewidth: 5,
       gridcolor: "#f2f5fa",
       gridwidth: 1,
+      automargin: true,
     },
     plot_bgcolor: "#E5ecf6",
     showlegend: false,
@@ -174,7 +176,6 @@ const plotSlice = (
         x: valuesNum,
         y: objectiveValues,
         mode: "markers",
-        xaxis: selected,
         marker: {
           color: "#185799",
         },
@@ -207,7 +208,6 @@ const plotSlice = (
         x: valuesCategorical,
         y: objectiveValues,
         mode: "markers",
-        // xaxis: paramName,
         marker: {
           color: "#185799",
         },

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -205,6 +205,7 @@ const plotSlice = (
       },
       tickvals: tickvals,
       ticktext: vocabArr,
+      automargin: true
     }
     plotly.react(plotDomId, trace, layout)
   }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [ x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
No referenced issue as far as I know. I just found this a useful addition and I hope it helps other people too.

## What does this implement/fix? Explain your changes.
There are two additions in the slice graph:

1.  The x axis now shows tick labels (for both numerical and categorical types)
2.  It is now possible to switch between log scale and linear scale