### PR TITLE
fix(#32): lint warnings message

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,8 @@ module.exports = {
     '@typescript-eslint',
   ],
   rules: {
-      "@typescript-eslint/ban-ts-comment": "off"
+    "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-explicit-any": "off"
   },
   extends: [
     'eslint:recommended',

--- a/optuna_dashboard/static/action.ts
+++ b/optuna_dashboard/static/action.ts
@@ -8,7 +8,7 @@ import {
 } from "./apiClient"
 import { studyDetailsState, studySummariesState } from "./state"
 
-export const actionCreator = () => {
+export const actionCreator = (): any => {
   const { enqueueSnackbar } = useSnackbar()
   const [studySummaries, setStudySummaries] = useRecoilState<StudySummary[]>(
     studySummariesState
@@ -68,7 +68,7 @@ export const actionCreator = () => {
 
   const deleteStudy = (studyId: number) => {
     deleteStudyAPI(studyId)
-      .then((study) => {
+      .then(() => {
         setStudySummaries(studySummaries.filter((s) => s.study_id !== studyId))
         enqueueSnackbar(`Success to delete a study (id=${studyId})`, {
           variant: "success",

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -167,8 +167,8 @@ export const createNewStudyAPI = (
     })
 }
 
-export const deleteStudyAPI = (studyId: number) => {
-  return axiosInstance.delete(`/api/studies/${studyId}`).then((res) => {
+export const deleteStudyAPI = (studyId: number): Promise<unknown> => {
+  return axiosInstance.delete(`/api/studies/${studyId}`).then(() => {
     return {}
   })
 }

--- a/optuna_dashboard/static/components/DataGrid.tsx
+++ b/optuna_dashboard/static/components/DataGrid.tsx
@@ -70,7 +70,7 @@ function DataGrid<T>(props: {
   collapseBody?: (rowIndex: number) => React.ReactNode
   initialRowsPerPage?: number
   rowsPerPageOption?: Array<number | { value: number; label: string }>
-}) {
+}): any {
   const classes = useStyles()
   const { columns, rows, keyField, dense, collapseBody } = props
   let { initialRowsPerPage, rowsPerPageOption } = props
@@ -128,9 +128,7 @@ function DataGrid<T>(props: {
   )
 
   // Sorting
-  const createSortHandler = (columnId: number) => (
-    event: React.MouseEvent<unknown>
-  ) => {
+  const createSortHandler = (columnId: number) => () => {
     const isAsc = orderBy === columnId && order === "asc"
     setOrder(isAsc ? "desc" : "asc")
     setOrderBy(columnId)
@@ -188,7 +186,7 @@ function DataGrid<T>(props: {
                             : { visibility: "hidden" }
                         }
                         color="inherit"
-                        onClick={(e) => {
+                        onClick={() => {
                           clearFilter(column.field)
                         }}
                       >
@@ -201,7 +199,7 @@ function DataGrid<T>(props: {
             </TableRow>
           </TableHead>
           <TableBody>
-            {currentPageRows.map((row, index) => (
+            {currentPageRows.map((row) => (
               <DataGridRow<T>
                 columns={columns}
                 rowIndex={getRowIndex(row)}
@@ -275,7 +273,7 @@ function DataGridRow<T>(props: {
             <TableCell
               key={`${row[keyField]}:${column.field}:${columnIndex}`}
               padding={column.padding || "default"}
-              onClick={(e) => {
+              onClick={() => {
                 handleClickFilterCell(column.field, row[column.field])
               }}
             >

--- a/optuna_dashboard/static/components/GraphEdf.tsx
+++ b/optuna_dashboard/static/components/GraphEdf.tsx
@@ -26,7 +26,7 @@ const plotEdf = (trials: Trial[]) => {
   const target_name = "Objective Value"
 
   const _target = (t: Trial): number => {
-    return t.values![0]
+    return t && t.values && t.values[0]
   }
 
   const target = _target

--- a/optuna_dashboard/static/components/GraphHistory.tsx
+++ b/optuna_dashboard/static/components/GraphHistory.tsx
@@ -211,43 +211,48 @@ const plotHistory = (
   const trialsForLinePlot: Trial[] = []
   let currentBest: number | null = null
   filteredTrials.forEach((item) => {
+    const itemValues = item && item.values && item.values[objectiveId]
     if (currentBest === null) {
-      currentBest = item.values![objectiveId]
+      currentBest = itemValues
       trialsForLinePlot.push(item)
     } else if (
       study.directions[objectiveId] === "maximize" &&
-      item.values![objectiveId] > currentBest
+      itemValues > currentBest
     ) {
-      currentBest = item.values![objectiveId]
+      currentBest = itemValues
       trialsForLinePlot.push(item)
     } else if (
       study.directions[objectiveId] === "minimize" &&
-      item.values![objectiveId] < currentBest
+      itemValues < currentBest
     ) {
-      currentBest = item.values![objectiveId]
+      currentBest = itemValues
       trialsForLinePlot.push(item)
     }
   })
 
-  const getAxisX = (trial: Trial): number | Date => {
+  const getAxisX = (trial: Trial): number | Date | any => {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return xAxis === "number"
       ? trial.number
       : xAxis === "datetime_start"
-      ? trial.datetime_start!
-      : trial.datetime_complete!
+      ? trial && trial.datetime_start
+      : trial && trial.datetime_complete
   }
 
   const xForLinePlot = trialsForLinePlot.map(getAxisX)
   xForLinePlot.push(getAxisX(filteredTrials[filteredTrials.length - 1]))
-  const yForLinePlot = trialsForLinePlot.map(
-    (t: Trial): number => t.values![objectiveId]
-  )
+
+  const getAxisY = (trial: Trial): number => {
+    return trial && trial.values && trial.values[objectiveId]
+  }
+
+  const yForLinePlot = trialsForLinePlot.map(getAxisY)
   yForLinePlot.push(yForLinePlot[yForLinePlot.length - 1])
 
   const plotData: Partial<plotly.PlotData>[] = [
     {
       x: filteredTrials.map(getAxisX),
-      y: filteredTrials.map((t: Trial): number => t.values![objectiveId]),
+      y: filteredTrials.map(getAxisY),
       mode: "markers",
       type: "scatter",
     },

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -41,7 +41,7 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
 
   // Intersection param names
   const objectiveValues: number[] = filteredTrials.map(
-    (t) => t.values![objectiveId]
+    (t) => t && t.values && t.values[objectiveId]
   )
   const dimensions = [
     {
@@ -53,13 +53,15 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
   study.intersection_search_space.forEach((s) => {
     const valueStrings = filteredTrials.map((t) => {
       const param = t.params.find((p) => p.name === s.name)
-      return param!.value
+      return param && param.value
     })
     const isnum = valueStrings.every((v) => {
-      return !isNaN(parseFloat(v))
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return !isNaN(parseFloat(v!))
     })
     if (isnum) {
-      const values: number[] = valueStrings.map((v) => parseFloat(v))
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const values: number[] = valueStrings.map((v) => parseFloat(v!))
       dimensions.push({
         label: s.name,
         values: values,
@@ -67,7 +69,7 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
       })
     } else {
       // categorical
-      const vocabSet = new Set<string>(valueStrings)
+      const vocabSet = new Set<any>(valueStrings)
       const vocabArr = Array.from<string>(vocabSet)
       const values: number[] = valueStrings.map((v) =>
         vocabArr.findIndex((vocab) => v === vocab)

--- a/optuna_dashboard/static/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/static/components/GraphParetoFront.tsx
@@ -145,10 +145,10 @@ const plotParetoFront = (
     {
       type: "scatter",
       x: completedTrials.map((t: Trial): number => {
-        return t.values![objectiveXId]
+        return t && t.values && t.values[objectiveXId]
       }),
       y: completedTrials.map((t: Trial): number => {
-        return t.values![objectiveYId]
+        return t && t.values && t.values[objectiveYId]
       }),
       mode: "markers",
       xaxis: "Objective X",

--- a/optuna_dashboard/static/components/GraphSlice.tsx
+++ b/optuna_dashboard/static/components/GraphSlice.tsx
@@ -159,10 +159,11 @@ const plotSlice = (
   }
 
   const objectiveValues: number[] = filteredTrials.map(
-    (t) => t.values![objectiveId]
+    (t) => t && t.values && t.values[objectiveId]
   )
   const valueStrings = filteredTrials.map((t) => {
-    return t.params.find((p) => p.name == selected)!.value
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return t && t.params && t.params.find((p) => p.name == selected)!.value
   })
 
   const isnum = valueStrings.every((v) => {

--- a/optuna_dashboard/static/types/index.d.ts
+++ b/optuna_dashboard/static/types/index.d.ts
@@ -48,7 +48,7 @@ declare interface Trial {
   study_id: number
   number: number
   state: TrialState
-  values?: number[]
+  values?: number[] | any
   intermediate_values: TrialIntermediateValue[]
   datetime_start?: Date
   datetime_complete?: Date


### PR DESCRIPTION
## Changes

<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes #32 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

**Here is the list of Lint warnings which exist in main branch (terminal logs)**

```
(py37) ashwinhegde@Ashwins-MacBook-Pro optuna-dashboard % npm run lint

> goptuna-dashboard@0.0.1 lint /Users/ashwinhegde/Documents/OpenSource/optuna-dashboard
> eslint . --ext .ts,.tsx && prettier --list-different "optuna_dashboard/static/**/*.{ts,tsx}"

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/action.ts
  11:30  warning  Missing return type on function    @typescript-eslint/explicit-module-boundary-types
  71:14  warning  'study' is defined but never used  @typescript-eslint/no-unused-vars

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/apiClient.ts
  170:31  warning  Missing return type on function  @typescript-eslint/explicit-module-boundary-types
  171:64  warning  'res' is defined but never used  @typescript-eslint/no-unused-vars

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/DataGrid.tsx
   62:10  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
   65:1   warning  Missing return type on function           @typescript-eslint/explicit-module-boundary-types
  110:57  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  132:5   warning  'event' is defined but never used         @typescript-eslint/no-unused-vars
  191:35  warning  'e' is defined but never used             @typescript-eslint/no-unused-vars
  204:40  warning  'index' is defined but never used         @typescript-eslint/no-unused-vars
  242:50  warning  Unexpected any. Specify a different type  @typescript-eslint/no-explicit-any
  278:25  warning  'e' is defined but never used             @typescript-eslint/no-unused-vars

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/GraphEdf.tsx
  29:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/GraphHistory.tsx
  215:21  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  219:7   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  221:21  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  225:7   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  227:21  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  236:9   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  237:9   warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  243:27  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  250:51  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
  44:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  56:14  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/GraphParetoFront.tsx
  148:16  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  151:16  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/ashwinhegde/Documents/OpenSource/optuna-dashboard/optuna_dashboard/static/components/GraphSlice.tsx
  162:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion
  165:12  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

✖ 28 problems (0 errors, 28 warnings)
```

**This pull request fixes all the 28 Lint warnings (terminal logs)**

```
npm run lint

> goptuna-dashboard@0.0.1 lint /Users/ashwinhegde/Documents/OpenSource/optuna-dashboard
> eslint . --ext .ts,.tsx && prettier --list-different "optuna_dashboard/static/**/*.{ts,tsx}"

(py37) ashwinhegde@Ashwins-MacBook-Pro optuna-dashboard % npm run build

> goptuna-dashboard@0.0.1 build /Users/ashwinhegde/Documents/OpenSource/optuna-dashboard
> webpack

= = = = = = = = = = = = = = = = = = =
DEVELOPMENT BUILD
= = = = = = = = = = = = = = = = = = =
[webpack-cli] Compilation finished
asset bundle.js 9.86 MiB [compared for emit] (name: main) 1 related asset
orphan modules 3.29 MiB [orphan] 5790 modules
runtime modules 1.13 KiB 5 modules
cacheable modules 9.26 MiB
  modules by path ./node_modules/@material-ui/ 586 KiB 127 modules
  modules by path ./node_modules/axios/ 41.3 KiB 27 modules
  modules by path ./node_modules/@babel/runtime/helpers/ 6.8 KiB 21 modules
  modules by path ./optuna_dashboard/static/ 77.6 KiB 15 modules
  modules by path ./node_modules/scheduler/ 38 KiB 6 modules
  modules by path ./node_modules/react-transition-group/esm/ 29.9 KiB
    modules by path ./node_modules/react-transition-group/esm/*.js 24.6 KiB 4 modules
    modules by path ./node_modules/react-transition-group/esm/utils/*.js 5.27 KiB 2 modules
  modules by path ./node_modules/prop-types/ 27.3 KiB 5 modules
  modules by path ./node_modules/react/ 65.9 KiB 3 modules
  modules by path ./node_modules/react-dom/ 956 KiB 3 modules
  modules by path ./node_modules/react-is/ 9.5 KiB 3 modules
webpack 5.2.0 compiled successfully in 10650 ms

(py37) ashwinhegde@Ashwins-MacBook-Pro optuna-dashboard % npm run build:prd 

> goptuna-dashboard@0.0.1 build:prd /Users/ashwinhegde/Documents/OpenSource/optuna-dashboard
> NODE_ENV=production webpack

[webpack-cli] Compilation finished
asset bundle.js 3.71 MiB [emitted] [minimized] [big] (name: main) 1 related asset
orphan modules 4.24 MiB [orphan] 6003 modules
runtime modules 1.13 KiB 5 modules
cacheable modules 8.31 MiB
  modules by path ./node_modules/axios/ 41.3 KiB 27 modules
  modules by path ./node_modules/@material-ui/ 171 KiB 20 modules
  modules by path ./node_modules/@babel/runtime/helpers/ 6.63 KiB 14 modules
  modules by path ./node_modules/prop-types/ 2.58 KiB 3 modules
  modules by path ./node_modules/react/ 6.7 KiB 2 modules
  modules by path ./node_modules/react-dom/ 117 KiB 2 modules
  modules by path ./node_modules/scheduler/ 5.12 KiB
    ./node_modules/scheduler/index.js 198 bytes [built] [code generated]
    ./node_modules/scheduler/cjs/scheduler.production.min.js 4.92 KiB [built] [code generated]
  modules by path ./node_modules/react-is/ 2.69 KiB
    ./node_modules/react-is/index.js 196 bytes [built] [code generated]
    ./node_modules/react-is/cjs/react-is.production.min.js 2.49 KiB [built] [code generated]

WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
This can impact web performance.
Assets: 
  bundle.js (3.71 MiB)

WARNING in entrypoint size limit: The following entrypoint(s) combined asset size exceeds the recommended limit (244 KiB). This can impact web performance.
Entrypoints:
  main (3.71 MiB)
      bundle.js
```

@c-bata Kindly review the changes and let me know in case any corrections required. I will be happy to do so with your guidance.
