### PR TITLE
Add incremental sync for the study summary API

### DIFF
--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -204,11 +204,12 @@ def create_app(storage: BaseStorage) -> Bottle:
     @handle_json_api_exception
     def get_study_detail(study_id: int) -> BottleViewReturn:
         response.content_type = "application/json"
+        ntrials_client = int(request.params["ntrials_client"])
         summary = get_study_summary(storage, study_id)
         if summary is None:
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
-        trials = get_trials(storage, study_id)
+        trials = get_trials(storage, study_id)[ntrials_client:]
         intersection, union = get_search_space(study_id, trials)
         return serializer.serialize_study_detail(summary, trials, intersection, union)
 

--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -204,12 +204,19 @@ def create_app(storage: BaseStorage) -> Bottle:
     @handle_json_api_exception
     def get_study_detail(study_id: int) -> BottleViewReturn:
         response.content_type = "application/json"
-        ntrials_client = int(request.params["ntrials_client"])
+        try:
+            before = int(request.params["before"])
+            assert before >= 0
+        except AssertionError:
+            response.status = 400  # Bad parameter
+            return {"reason": "`before` should be larger or equal 0."}
+        except KeyError:
+            before = 0
         summary = get_study_summary(storage, study_id)
         if summary is None:
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
-        trials = get_trials(storage, study_id)[ntrials_client:]
+        trials = get_trials(storage, study_id)[before:]
         intersection, union = get_search_space(study_id, trials)
         return serializer.serialize_study_detail(summary, trials, intersection, union)
 

--- a/optuna_dashboard/app.py
+++ b/optuna_dashboard/app.py
@@ -205,18 +205,18 @@ def create_app(storage: BaseStorage) -> Bottle:
     def get_study_detail(study_id: int) -> BottleViewReturn:
         response.content_type = "application/json"
         try:
-            before = int(request.params["before"])
-            assert before >= 0
+            after = int(request.params["after"])
+            assert after >= 0
         except AssertionError:
             response.status = 400  # Bad parameter
-            return {"reason": "`before` should be larger or equal 0."}
+            return {"reason": "`after` should be larger or equal 0."}
         except KeyError:
-            before = 0
+            after = 0
         summary = get_study_summary(storage, study_id)
         if summary is None:
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
-        trials = get_trials(storage, study_id)[before:]
+        trials = get_trials(storage, study_id)[after:]
         intersection, union = get_search_space(study_id, trials)
         return serializer.serialize_study_detail(summary, trials, intersection, union)
 

--- a/optuna_dashboard/static/action.ts
+++ b/optuna_dashboard/static/action.ts
@@ -35,13 +35,12 @@ export const actionCreator = () => {
   const updateStudyDetail = (studyId: number) => {
     let nLocalFixedTrials = 0
     if (studyId in studyDetails) {
-      for (const trial of studyDetails[studyId].trials) {
-        if (!["Running", "Waiting"].includes(trial.state)) {
-          nLocalFixedTrials += 1
-        } else {
-          break
-        }
-      }
+      const currentTrials = studyDetails[studyId].trials
+      const firstUpdatable = currentTrials.findIndex((trial) =>
+        ["Running", "Waiting"].includes(trial.state)
+      )
+      nLocalFixedTrials =
+        firstUpdatable === -1 ? currentTrials.length : firstUpdatable
     }
     getStudyDetailAPI(studyId, nLocalFixedTrials)
       .then((study) => {

--- a/optuna_dashboard/static/action.ts
+++ b/optuna_dashboard/static/action.ts
@@ -33,14 +33,23 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
-    getStudyDetailAPI(
-      studyId,
-      studyId in studyDetails ? studyDetails[studyId].trials.length : 0
-    )
+    let nLocalFixedTrials = 0
+    if (studyId in studyDetails) {
+      for (const trial of studyDetails[studyId].trials) {
+        if (!["Running", "Waiting"].includes(trial.state)) {
+          nLocalFixedTrials += 1
+        } else {
+          break
+        }
+      }
+    }
+    getStudyDetailAPI(studyId, nLocalFixedTrials)
       .then((study) => {
-        const currentTrials =
-          studyId in studyDetails ? studyDetails[studyId].trials : []
-        study.trials = study.trials.concat(currentTrials)
+        const currentFixedTrials =
+          studyId in studyDetails
+            ? studyDetails[studyId].trials.slice(0, nLocalFixedTrials)
+            : []
+        study.trials = study.trials.concat(currentFixedTrials)
         const newVal = Object.assign({}, studyDetails)
         newVal[studyId] = study
         setStudyDetails(newVal)

--- a/optuna_dashboard/static/action.ts
+++ b/optuna_dashboard/static/action.ts
@@ -33,8 +33,14 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
-    getStudyDetailAPI(studyId)
+    getStudyDetailAPI(
+      studyId,
+      studyId in studyDetails ? studyDetails[studyId].trials.length : 0
+    )
       .then((study) => {
+        const currentTrials =
+          studyId in studyDetails ? studyDetails[studyId].trials : []
+        study.trials = study.trials.concat(currentTrials)
         const newVal = Object.assign({}, studyDetails)
         newVal[studyId] = study
         setStudyDetails(newVal)

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -53,7 +53,7 @@ export const getStudyDetailAPI = (
   return axiosInstance
     .get<StudyDetailResponse>(`/api/studies/${studyId}`, {
       params: {
-        ntrials_client: nLocalTrials,
+        before: nLocalTrials,
       },
     })
     .then((res) => {

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -46,9 +46,16 @@ interface StudyDetailResponse {
   union_search_space: SearchSpace[]
 }
 
-export const getStudyDetailAPI = (studyId: number): Promise<StudyDetail> => {
+export const getStudyDetailAPI = (
+  studyId: number,
+  nLocalTrials: number
+): Promise<StudyDetail> => {
   return axiosInstance
-    .get<StudyDetailResponse>(`/api/studies/${studyId}`, {})
+    .get<StudyDetailResponse>(`/api/studies/${studyId}`, {
+      params: {
+        ntrials_client: nLocalTrials,
+      },
+    })
     .then((res) => {
       const trials = res.data.trials.map((trial): Trial => {
         return convertTrialResponse(trial)

--- a/optuna_dashboard/static/apiClient.ts
+++ b/optuna_dashboard/static/apiClient.ts
@@ -53,7 +53,7 @@ export const getStudyDetailAPI = (
   return axiosInstance
     .get<StudyDetailResponse>(`/api/studies/${studyId}`, {
       params: {
-        before: nLocalTrials,
+        after: nLocalTrials,
       },
     })
     .then((res) => {

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -117,7 +117,7 @@ export const StudyDetail: FC = () => {
       action.updateStudyDetail(studyIdNumber)
     }, reloadInterval * 1000)
     return () => clearInterval(intervalId)
-  }, [reloadInterval])
+  }, [reloadInterval, studyDetail])
 
   const title = studyDetail !== null ? studyDetail.name : `Study #${studyId}`
   const trials: Trial[] = studyDetail !== null ? studyDetail.trials : []

--- a/optuna_dashboard/static/components/StudyDetail.tsx
+++ b/optuna_dashboard/static/components/StudyDetail.tsx
@@ -118,6 +118,7 @@ export const StudyDetail: FC = () => {
     }, reloadInterval * 1000)
     return () => clearInterval(intervalId)
   }, [reloadInterval, studyDetail])
+  // TODO(chenghuzi): Reduce the number of calls to setInterval and clearInterval.
 
   const title = studyDetail !== null ? studyDetail.name : `Study #${studyId}`
   const trials: Trial[] = studyDetail !== null ? studyDetail.trials : []

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -26,7 +26,7 @@ class APITestCase(TestCase):
         self.assertEqual(len(study_summaries), 2)
 
     def test_get_study_details(self) -> None:
-        def objective(trial):
+        def objective(trial: optuna.trial.Trial) -> float:
             x = trial.suggest_float("x", -1, 1)
             return x
 
@@ -51,7 +51,7 @@ class APITestCase(TestCase):
             app,
             f"/api/studies/{study_id}",
             "GET",
-            queries={"before": 5},
+            queries={"before": "5"},
             content_type="application/json",
         )
         self.assertEqual(status, 200)
@@ -62,7 +62,7 @@ class APITestCase(TestCase):
             app,
             f"/api/studies/{study_id}",
             "GET",
-            queries={"before": 10},
+            queries={"before": "10"},
             content_type="application/json",
         )
         self.assertEqual(status, 200)
@@ -73,7 +73,7 @@ class APITestCase(TestCase):
             app,
             f"/api/studies/{study_id}",
             "GET",
-            queries={"before": -1},
+            queries={"before": "-1"},
             content_type="application/json",
         )
         self.assertEqual(status, 400)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

Before:
Every time when you call API to update the study, the backend returns all trials, which may be redundant when the study is being updated frequently.

After:
You will only fetch all trials in the first call to study details API and all later calls will only add those updated trials.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
