### PR TITLE
Improve label overlaps

### DIFF
--- a/optuna_dashboard/static/components/GraphHyperparameterImportances.tsx
+++ b/optuna_dashboard/static/components/GraphHyperparameterImportances.tsx
@@ -127,6 +127,7 @@ const plotParamImportances = (paramsImportanceData: ParamImportances) => {
     },
     yaxis: {
       title: "Hyperparameter",
+      automargin: true,
     },
     margin: {
       l: 50,

--- a/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/static/components/GraphParallelCoordinate.tsx
@@ -78,8 +78,8 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
 
   const layout: Partial<plotly.Layout> = {
     margin: {
-      l: 50,
-      t: 50,
+      l: 70,
+      t: 100,
       r: 50,
       b: 0,
     },
@@ -95,6 +95,24 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
       t.state === "Complete" ||
       (t.state === "Pruned" && t.values && t.values.length > 0)
   )
+
+  const maxLabelLength = 40
+  const breakLength = maxLabelLength / 2
+  const ellipsis = "…"
+  const truncateLabelIfTooLong = (originalLabel: string): string => {
+    return originalLabel.length > maxLabelLength
+      ? originalLabel.substring(0, maxLabelLength - ellipsis.length) + ellipsis
+      : originalLabel
+  }
+  const breakLabelIfTooLong = (originalLabel: string): string => {
+    const truncated = truncateLabelIfTooLong(originalLabel)
+    return truncated
+      .split("")
+      .map((c, i) => {
+        return (i + 1) % breakLength == 0 ? c + "<br>" : c
+      })
+      .join("")
+  }
 
   // Intersection param names
   const objectiveValues: number[] = filteredTrials.map(
@@ -118,7 +136,7 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
     if (isnum) {
       const values: number[] = valueStrings.map((v) => parseFloat(v))
       dimensions.push({
-        label: s.name,
+        label: breakLabelIfTooLong(s.name),
         values: values,
         range: [Math.min(...values), Math.max(...values)],
       })
@@ -131,7 +149,7 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
       )
       const tickvals: number[] = vocabArr.map((v, i) => i)
       dimensions.push({
-        label: s.name,
+        label: breakLabelIfTooLong(s.name),
         values: values,
         range: [Math.min(...values), Math.max(...values)],
         // @ts-ignore
@@ -145,6 +163,7 @@ const plotCoordinate = (study: StudyDetail, objectiveId: number) => {
       type: "parcoords",
       // @ts-ignore
       dimensions: dimensions,
+      labelangle: 30,
     },
   ]
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Fixes #99
Relates https://github.com/plotly/plotly.js/issues/1703

<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

* Fix label overlap in Hyperparameter importance graph
  * Before
    <img width="1207" alt="before_hyperparameter" src="https://user-images.githubusercontent.com/16278068/132132358-5eada338-136d-4830-85c8-d30d03cc4326.png">
  * After
    <img width="1208" alt="after_hyperparameter" src="https://user-images.githubusercontent.com/16278068/132132375-b9dae24a-7e18-4fd1-8213-c1a7fe11a3f5.png">

* Improve label visibility in Parallel coordinate graph, it is not fully visible.
  * Rotate, truncate and break label to avoid overlap
  * I tried hover tooltip but I couldn't it.
    * Relates https://github.com/plotly/plotly.js/issues/1703
  * Before
    <img width="1211" alt="before_parcoords" src="https://user-images.githubusercontent.com/16278068/132132419-a78765aa-c275-4d69-850d-41963f11c0b7.png"> 
    * Fictitious long labels for test, base on xgboost sample.
  * After
    <img width="1211" alt="after_parcoords" src="https://user-images.githubusercontent.com/16278068/132132433-7bacd7f0-9ec2-4b15-b5e1-0d01a45a8283.png">


<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
