### PR TITLE
Fix typo in WSGI environment variable

### DIFF
--- a/python_tests/wsgi_client.py
+++ b/python_tests/wsgi_client.py
@@ -39,7 +39,7 @@ def create_wsgi_env(
         "wsgi.version": (1, 0),
         "wsgi.errors": io.StringIO(""),
         "wsgi.multithread": True,
-        "wsgi.multitprocess": True,
+        "wsgi.multiprocess": True,
         "wsgi.run_once": False,
     }
     for k, v in headers.items():


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

None

## What does this implement/fix? Explain your changes.

Remove extra `t` from `multitprocess`

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
