### PR TITLE
Avoid using Python 3.10 to run integration tests.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
           architecture: x64
       - name: Install dependencies
         run: |

--- a/visual_regression_test.py
+++ b/visual_regression_test.py
@@ -206,7 +206,7 @@ def main() -> None:
     thread = threading.Thread(target=httpd.serve_forever)
     thread.start()
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
     error_messages = loop.run_until_complete(take_screenshots(storage))
     for msg in error_messages:
         print(msg)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

An execution of visual regression tests was very slow when using Python 3.10. Also I replace `get_event_loop` with `new_event_loop`.

> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. In future Python releases, this function will be an alias of get_running_loop().
> https://docs.python.org/3.10/library/asyncio-eventloop.html#asyncio.get_event_loop
