### PR TITLE
Fix type hints and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,14 @@ Listening on http://localhost:8080/
 Hit Ctrl-C to quit.
 ```
 
-<details>
-
-<summary>Running optuna-dashboard with Gunicorn</summary>
-
-optuna-dashboard uses [wsgiref](https://docs.python.org/3/library/wsgiref.html) module
-which is provided as a Python standard library. But it has not been reviewed for security
-issues, so not suitable for the production use. You can run optuna-dashboard with Gunicorn
-more secure and/or more fast.
+Note that optuna-dashboard uses [wsgiref](https://docs.python.org/3/library/wsgiref.html) module by default.
+Although it requires no additional dependencies, it is NOT suitable for the production use.
+You can use [Gunicorn](https://gunicorn.org/) via "--server gunicorn" option.
 
 ```console
 $ pip install gunicorn
 $ optuna-dashboard sqlite:///db.sqlite3 --server gunicorn
 ```
-
-</details>
-
 
 <details>
 
@@ -75,7 +67,7 @@ optional arguments:
 
 <summary>Python Interface</summary>
 
-**`run_server(storage: Union[str, BaseStorage], host: str = 'localhost', port: int = 8080) -> NoReturn`**
+**`run_server(storage: Union[str, BaseStorage], host: str = 'localhost', port: int = 8080) -> None`**
 
 Start running optuna-dashboard and blocks until the server terminates.
 This function uses wsgiref module which is not intended for the production use.

--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -12,7 +12,6 @@ from typing import Callable
 from typing import cast
 from typing import Dict
 from typing import List
-from typing import NoReturn
 from typing import Optional
 from typing import TypeVar
 from typing import Union
@@ -294,9 +293,9 @@ def get_storage(storage: Union[str, BaseStorage]) -> BaseStorage:
     return storage
 
 
-def run_server(  # type: ignore
+def run_server(
     storage: Union[str, BaseStorage], host: str = "localhost", port: int = 8080
-) -> NoReturn:
+) -> None:
     """Start running optuna-dashboard and blocks until the server terminates.
     This function uses wsgiref module which is not intended for the production
     use. If you want to run optuna-dashboard more secure and/or more fast,

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -1,6 +1,5 @@
 import argparse
 import os
-from typing import NoReturn
 
 from bottle import Bottle
 from bottle import run
@@ -16,7 +15,7 @@ AUTO_RELOAD = os.environ.get("OPTUNA_DASHBOARD_AUTO_RELOAD") == "1"
 SERVER_CHOICES = ["wsgiref", "gunicorn"]
 
 
-def run_wsgiref(app: Bottle, host: str, port: int, quiet: bool) -> NoReturn:  # type: ignore
+def run_wsgiref(app: Bottle, host: str, port: int, quiet: bool) -> None:
     run(
         app,
         host=host,
@@ -27,12 +26,12 @@ def run_wsgiref(app: Bottle, host: str, port: int, quiet: bool) -> NoReturn:  # 
     )
 
 
-def run_gunicorn(app: Bottle, host: str, port: int, quiet: bool) -> NoReturn:  # type: ignore
+def run_gunicorn(app: Bottle, host: str, port: int, quiet: bool) -> None:
     # See https://docs.gunicorn.org/en/latest/custom.html
 
     from gunicorn.app.base import BaseApplication
 
-    class _Application(BaseApplication):
+    class Application(BaseApplication):
         def load_config(self) -> None:
             self.cfg.set("bind", f"{host}:{port}")
             if quiet:
@@ -41,10 +40,10 @@ def run_gunicorn(app: Bottle, host: str, port: int, quiet: bool) -> NoReturn:  #
         def load(self) -> Bottle:
             return app
 
-    _Application().run()
+    Application().run()
 
 
-def main() -> NoReturn:
+def main() -> None:
     parser = argparse.ArgumentParser(description="Real-time dashboard for Optuna.")
     parser.add_argument("storage", help="DB URL (e.g. sqlite:///example.db)", type=str)
     parser.add_argument(


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #167 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
I thought the return type of `run_server()` must be `NoReturn` since it runs forever until user send the terminate signal (it won't literally return). According to the type hints of [uvicorn server](https://github.com/encode/uvicorn/blob/master/uvicorn/main.py), they set `-> None` as a return type. So I decided to follow that.
