### PR TITLE
Use plotly.js-dist-min to reduce bundle.js.

### DIFF
--- a/optuna_dashboard/ts/components/GraphEdf.tsx
+++ b/optuna_dashboard/ts/components/GraphEdf.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/GraphHyperparameterImportances.tsx
+++ b/optuna_dashboard/ts/components/GraphHyperparameterImportances.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { FC, useEffect } from "react"
 import { Box, Grid, Typography, useTheme } from "@mui/material"
 import { plotlyDarkTemplate } from "./PlotlyDarkMode"

--- a/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 import React, { ChangeEvent, FC, useEffect, useState } from "react"
 import {
   Grid,

--- a/optuna_dashboard/ts/components/PlotlyDarkMode.ts
+++ b/optuna_dashboard/ts/components/PlotlyDarkMode.ts
@@ -1,4 +1,4 @@
-import * as plotly from "plotly.js-dist"
+import * as plotly from "plotly.js-dist-min"
 
 // Following template is extracted from the sdist of plotly Python library.
 // See https://github.com/plotly/plotly.py/blob/v5.6.0/packages/python/plotly/templategen/__init__.py and

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@mui/material": "^5.4.4",
         "axios": "^0.21.2",
         "notistack": "^2.0.3",
-        "plotly.js-dist": "^2.10.0",
+        "plotly.js-dist-min": "^2.11.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0",
@@ -10128,10 +10128,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/plotly.js-dist": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.10.0.tgz",
-      "integrity": "sha512-OceBJSwf9q64JK6uHM8/R4KYRNmJ/2UmqTpyWVMXHWuN+aLp8dmF/BMOFi7Vvn1xP/Uj7r6Y/lTuMHnpM7qb0w=="
+    "node_modules/plotly.js-dist-min": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.11.1.tgz",
+      "integrity": "sha512-F9WWNht0D3yBLZGHbLoJNfvplXvy+GUPSsA/lCbMuYd/UwzSu6Vmyprxlps9Einw1LDS1hYBrJeioK0lE3ieXA=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -19381,10 +19381,10 @@
         "find-up": "^4.0.0"
       }
     },
-    "plotly.js-dist": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist/-/plotly.js-dist-2.10.0.tgz",
-      "integrity": "sha512-OceBJSwf9q64JK6uHM8/R4KYRNmJ/2UmqTpyWVMXHWuN+aLp8dmF/BMOFi7Vvn1xP/Uj7r6Y/lTuMHnpM7qb0w=="
+    "plotly.js-dist-min": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.11.1.tgz",
+      "integrity": "sha512-F9WWNht0D3yBLZGHbLoJNfvplXvy+GUPSsA/lCbMuYd/UwzSu6Vmyprxlps9Einw1LDS1hYBrJeioK0lE3ieXA=="
     },
     "prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@mui/material": "^5.4.4",
     "axios": "^0.21.2",
     "notistack": "^2.0.3",
-    "plotly.js-dist": "^2.10.0",
+    "plotly.js-dist-min": "^2.11.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "alwaysStrict": true,
     "outDir": "./optuna_dashboard/public/",
     "paths": {
-      "plotly.js-dist": ["node_modules/@types/plotly.js"]
+      "plotly.js-dist-min": ["node_modules/@types/plotly.js"]
     },
     "noImplicitAny": true,
     "lib": ["dom", "esnext"],


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
The size of bundle.js: 11.8MB → 3.1MB