### PR TITLE
Fix bug of pareto front graph

### DIFF
--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -85,8 +85,13 @@ export const GraphParetoFront: FC<{
   )
 }
 
-const filterFunc = (trial: Trial): boolean => {
-  return trial.state !== "Complete" || trial.values!.every((v) => v !== "inf")
+const filterFunc = (trial: Trial, directions: StudyDirection[]): boolean => {
+  return (
+    trial.state === "Complete" &&
+    trial.values !== undefined &&
+    trial.values.length === directions.length &&
+    trial.values.every((v) => v !== "inf")
+  )
 }
 
 const plotParetoFront = (
@@ -110,7 +115,9 @@ const plotParetoFront = (
   }
 
   const trials: Trial[] = study ? study.trials : []
-  const filteredTrials = trials.filter(filterFunc)
+  const filteredTrials = trials.filter((t: Trial) =>
+    filterFunc(t, study.directions)
+  )
 
   if (filteredTrials.length === 0) {
     plotly.react(plotDomId, [], layout)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Fixes #206 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Steps to reproduce:

```python
$ python -c "import optuna; print(optuna.version.__version__)"
3.0.0b0
$ optuna-dashboard --version
0.6.3
$ cat example_failure.py
import optuna


def objective(trial):
    x = trial.suggest_uniform('x', -10, 10)
    y = trial.suggest_uniform('y', -10, 10)
    z = trial.suggest_uniform('z', -10, 10)
    return (x - 2) ** 2, (y - 2) ** 2, (z - 2) ** 2

if __name__ == "__main__":
    sampler = optuna.samplers.TPESampler(n_startup_trials=10, n_ei_candidates=24)
    for i in range(0, 10):
        study = optuna.create_study(storage="sqlite:///multiobjective-failure-db.sqlite3", study_name="issue-206", directions=['minimize','minimize','minimize'], load_if_exists=True)
        study.optimize(objective, n_trials=3)
$ python example_failure.py  # then press Ctrl-C immediately
$ optuna-dashboard sqlite:///multiobjective-failure-db.sqlite3
```

| Before | After |
| ---- | ---- |
| <img width="2131" alt="Screenshot 2022-04-21 10 59 06" src="https://user-images.githubusercontent.com/5564044/164356501-c1f2d7d3-45e1-4668-9d00-670bc973e18e.png"> | <img width="1764" alt="Screenshot 2022-04-21 11 27 06" src="https://user-images.githubusercontent.com/5564044/164359473-53726802-77fe-4804-b468-275ab4c694b0.png"> |

