### PR TITLE
Add annotation for distributions

### DIFF
--- a/python_tests/test_search_space.py
+++ b/python_tests/test_search_space.py
@@ -5,8 +5,8 @@ import warnings
 
 import optuna
 from optuna import create_trial
-from optuna.distributions import UniformDistribution
 from optuna.distributions import BaseDistribution
+from optuna.distributions import UniformDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.trial import TrialState
 

--- a/python_tests/test_search_space.py
+++ b/python_tests/test_search_space.py
@@ -1,9 +1,12 @@
+from typing import Dict
+from typing import List
 from unittest import TestCase
 import warnings
 
 import optuna
 from optuna import create_trial
 from optuna.distributions import UniformDistribution
+from optuna.distributions import BaseDistribution
 from optuna.exceptions import ExperimentalWarning
 from optuna.trial import TrialState
 
@@ -16,7 +19,7 @@ class SearchSpaceTestCase(TestCase):
         warnings.simplefilter("ignore", category=ExperimentalWarning)
 
     def test_same_distributions(self) -> None:
-        distributions = [
+        distributions: List[Dict[str, BaseDistribution]] = [
             {
                 "x0": UniformDistribution(low=0, high=10),
                 "x1": UniformDistribution(low=0, high=10),
@@ -47,7 +50,7 @@ class SearchSpaceTestCase(TestCase):
         self.assertEqual(len(search_space.union), 2)
 
     def test_different_distributions(self) -> None:
-        distributions = [
+        distributions: List[Dict[str, BaseDistribution]] = [
             {
                 "x0": UniformDistribution(low=0, high=10),
                 "x1": UniformDistribution(low=0, high=10),
@@ -78,7 +81,7 @@ class SearchSpaceTestCase(TestCase):
         self.assertEqual(len(search_space.union), 3)
 
     def test_dynamic_search_space(self) -> None:
-        distributions = [
+        distributions: List[Dict[str, BaseDistribution]] = [
             {
                 "x0": UniformDistribution(low=0, high=10),
                 "x1": UniformDistribution(low=0, high=10),


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
N/A

## What does this implement/fix? Explain your changes.

`distributions` in `test_search_space.py` is not compatible with the type annotation of `crate_trial`.
We observe mypy failure like following when a check is run with Optuna v3.0.0b0.

```sh
> mypy python_tests optuna_dashboard                                                                                                                                                                 2022-04-24 16:30:44
python_tests/test_search_space.py:40: error: Argument "distributions" to "create_trial" has incompatible type "Dict[str, UniformDistribution]"; expected "Optional[Dict[str, BaseDistribution]]"
python_tests/test_search_space.py:40: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
python_tests/test_search_space.py:40: note: Consider using "Mapping" instead, which is covariant in the value type
python_tests/test_search_space.py:71: error: Argument "distributions" to "create_trial" has incompatible type "Dict[str, UniformDistribution]"; expected "Optional[Dict[str, BaseDistribution]]"
python_tests/test_search_space.py:71: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
python_tests/test_search_space.py:71: note: Consider using "Mapping" instead, which is covariant in the value type
python_tests/test_search_space.py:108: error: Argument "distributions" to "create_trial" has incompatible type "Dict[str, UniformDistribution]"; expected "Optional[Dict[str, BaseDistribution]]"
python_tests/test_search_space.py:108: note: "Dict" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
python_tests/test_search_space.py:108: note: Consider using "Mapping" instead, which is covariant in the value type
Found 3 errors in 1 file (checked 15 source files)
```

`distributions` has a type `dict[str, UniformDistribution]` that is not compatible with `Dict[str, BaseDistribution]`. It means the type is not valid in the current implementation even if CIs are all green in the latest master branch.

Optuna v2.10.0 unintentionally hides the information because `@experimental` decorator crushes a type hint of a method. Optuna v3.0.0 makes `create_trial` stable (i.e. removes `@experimental`) and exposes type information to third-party libraries correctly. This is why we observe the mypy failure by upgrading the Optuna.

https://github.com/optuna/optuna/blob/v2.10.0/optuna/trial/_frozen.py#L505-L516

v2.10.0 | v3.0.0b0
-- | --
![v2 10 0](https://user-images.githubusercontent.com/5164000/164965495-e6d99ade-16ed-480d-be40-956ce8a3c150.JPG) | ![3 0 0b0](https://user-images.githubusercontent.com/5164000/164965497-04e17629-fdc9-4b27-8fcb-86c6515d1c50.JPG)

This PR adds type hints `List[Dict[str, BaseDistribution]]` for `distributions`, which is compatible with `Optional[Dict[str, BaseDistribution]]` of `create_trial`.