### PR TITLE
add each param columns

### DIFF
--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -599,12 +599,44 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
       }
     },
   })
-  columns.push({
-    field: "params",
-    label: "Params",
-    toCellValue: (i) =>
-      trials[i].params.map((p) => p.name + ": " + p.value).join(", "),
-  })
+  if (
+    studyDetail?.union_search_space.length ===
+    studyDetail?.intersection_search_space.length
+  ) {
+    studyDetail?.intersection_search_space.forEach((s) => {
+      columns.push({
+        field: "params",
+        label: `Param ${s.name}`,
+        toCellValue: (i) =>
+          trials[i].params.find((p) => p.name === s.name)?.value || null,
+        sortable: true,
+        filterable: false,
+        less: (firstEl, secondEl): number => {
+          const firstVal = firstEl.params.find((p) => p.name === s.name)?.value
+          const secondVal = secondEl.params.find(
+            (p) => p.name === s.name
+          )?.value
+
+          if (firstVal === secondVal) {
+            return 0
+          } else if (firstVal && secondVal) {
+            return firstVal < secondVal ? 1 : -1
+          } else if (firstVal) {
+            return -1
+          } else {
+            return 1
+          }
+        },
+      })
+    })
+  } else {
+    columns.push({
+      field: "params",
+      label: "Params",
+      toCellValue: (i) =>
+        trials[i].params.map((p) => p.name + ": " + p.value).join(", "),
+    })
+  }
 
   const collapseParamColumns: DataGridColumn<TrialParam>[] = [
     { field: "name", label: "Name", sortable: true },

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -604,13 +604,14 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
     studyDetail?.intersection_search_space.length
   ) {
     studyDetail?.intersection_search_space.forEach((s) => {
+      const sortable = s.distribution !== "CategoricalDistribution"
       columns.push({
         field: "params",
         label: `Param ${s.name}`,
         toCellValue: (i) =>
           trials[i].params.find((p) => p.name === s.name)?.value || null,
-        sortable: true,
-        filterable: false,
+        sortable: sortable,
+        filterable: false, // TODO(yoshinobc): Support filtering by categorical parameters
         less: (firstEl, secondEl): number => {
           const firstVal = firstEl.params.find((p) => p.name === s.name)?.value
           const secondVal = secondEl.params.find(

--- a/typescript_tests/TrialTable.test.tsx
+++ b/typescript_tests/TrialTable.test.tsx
@@ -86,13 +86,14 @@ it("Sort TrialTable by trial number", () => {
     <TrialTable studyDetail={studyDetail} />
   )
   const rows = getAllByRole("row")
+
   expect(within(rows[1]).getByText("0")).toBeTruthy()
-  expect(within(rows[3]).getByText("1")).toBeTruthy()
+  expect(within(rows[3]).getAllByText("1")[0]).toBeTruthy()
 
   fireEvent.click(getByText("Number"))
 
   const rows_updated = getAllByRole("row")
-  expect(within(rows_updated[1]).getByText("1")).toBeTruthy()
+  expect(within(rows_updated[1]).getAllByText("1")[0]).toBeTruthy()
   expect(within(rows_updated[3]).getByText("0")).toBeTruthy()
 })
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
### Motivation
Allow displaying a column for each parameter when the search space matches in all trials.

### Description of the changes
- Added processing if `union_search_space.length === intersection_search_space.length`

### TODO
- Categorical parameter filtering is not yet implemented.

The attached zip file is a zipped version of the db file containing the study and the python file used to create it.
[sklearn_simple_all_parameter_intersect.zip](https://github.com/optuna/optuna-dashboard/files/8562918/sklearn_simple_all_parameter_intersect.zip)


