### PR TITLE
plot intermediate values of running trials

### DIFF
--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -55,7 +55,7 @@ export const actionCreator = () => {
           studyId in studyDetails
             ? studyDetails[studyId].trials.slice(0, nLocalFixedTrials)
             : []
-        study.trials = study.trials.concat(currentFixedTrials)
+        study.trials = currentFixedTrials.concat(study.trials)
         setStudyDetailState(studyId, study)
       })
       .catch((err) => {

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -51,20 +51,31 @@ const plotIntermediateValue = (trials: Trial[], mode: string) => {
     return
   }
 
-  const filteredTrials = trials.filter(
-    (t) =>
-      t.state === "Complete" ||
-      (t.state === "Pruned" && t.values && t.values.length > 0)
-  )
-  const plotData: Partial<plotly.PlotData>[] = filteredTrials.map((trial) => {
-    const values = trial.intermediate_values.filter((iv) => iv.value !== "inf")
-    return {
-      x: values.map((iv) => iv.step),
-      y: values.map((iv) => iv.value),
-      mode: "lines+markers",
-      type: "scatter",
-      name: `trial #${trial.number}`,
+  const sortedFilteredTrials = trials
+    .filter(
+      (t) =>
+        t.state === "Complete" ||
+        (t.state === "Pruned" && t.values && t.values.length > 0) ||
+        t.state == "Running"
+    )
+    .slice()
+    .sort((a: Trial, b: Trial) => a.number - b.number)
+  const plotData: Partial<plotly.PlotData>[] = sortedFilteredTrials.map(
+    (trial) => {
+      const values = trial.intermediate_values.filter(
+        (iv) => iv.value !== "inf"
+      )
+      return {
+        x: values.map((iv) => iv.step),
+        y: values.map((iv) => iv.value),
+        mode: "lines+markers",
+        type: "scatter",
+        name:
+          trial.state !== "Running"
+            ? `trial #${trial.number}`
+            : `trial #${trial.number} (running)`,
+      }
     }
-  })
+  )
   plotly.react(plotDomId, plotData, layout)
 }

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -51,31 +51,24 @@ const plotIntermediateValue = (trials: Trial[], mode: string) => {
     return
   }
 
-  const sortedFilteredTrials = trials
-    .filter(
-      (t) =>
-        t.state === "Complete" ||
-        (t.state === "Pruned" && t.values && t.values.length > 0) ||
-        t.state == "Running"
-    )
-    .slice()
-    .sort((a: Trial, b: Trial) => a.number - b.number)
-  const plotData: Partial<plotly.PlotData>[] = sortedFilteredTrials.map(
-    (trial) => {
-      const values = trial.intermediate_values.filter(
-        (iv) => iv.value !== "inf"
-      )
-      return {
-        x: values.map((iv) => iv.step),
-        y: values.map((iv) => iv.value),
-        mode: "lines+markers",
-        type: "scatter",
-        name:
-          trial.state !== "Running"
-            ? `trial #${trial.number}`
-            : `trial #${trial.number} (running)`,
-      }
-    }
+  const FilteredTrials = trials.filter(
+    (t) =>
+      t.state === "Complete" ||
+      (t.state === "Pruned" && t.values && t.values.length > 0) ||
+      t.state == "Running"
   )
+  const plotData: Partial<plotly.PlotData>[] = FilteredTrials.map((trial) => {
+    const values = trial.intermediate_values.filter((iv) => iv.value !== "inf")
+    return {
+      x: values.map((iv) => iv.step),
+      y: values.map((iv) => iv.value),
+      mode: "lines+markers",
+      type: "scatter",
+      name:
+        trial.state !== "Running"
+          ? `trial #${trial.number}`
+          : `trial #${trial.number} (running)`,
+    }
+  })
   plotly.react(plotDomId, plotData, layout)
 }

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -51,13 +51,13 @@ const plotIntermediateValue = (trials: Trial[], mode: string) => {
     return
   }
 
-  const FilteredTrials = trials.filter(
+  const filteredTrials = trials.filter(
     (t) =>
       t.state === "Complete" ||
       (t.state === "Pruned" && t.values && t.values.length > 0) ||
       t.state == "Running"
   )
-  const plotData: Partial<plotly.PlotData>[] = FilteredTrials.map((trial) => {
+  const plotData: Partial<plotly.PlotData>[] = filteredTrials.map((trial) => {
     const values = trial.intermediate_values.filter((iv) => iv.value !== "inf")
     return {
       x: values.map((iv) => iv.step),


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
This PR fix #92 

## What does this implement/fix? Explain your changes.
### Motivation
plot intermediate values of running trials
### Description of the changes
- Modified filter function for trials in `GraphIntermediateValues.tsx`
- added sorting of trials before plotting
- added the word "running" for running trials
<img width="1829" alt="スクリーンショット 2022-04-28 21 32 55" src="https://user-images.githubusercontent.com/33712536/165752786-71930f6a-bd38-4256-b5f2-86951fcd3e97.png">

