### PR TITLE
Fix a bug when handling categorical parameter that contain number in the string

### DIFF
--- a/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
@@ -136,7 +136,7 @@ const plotCoordinate = (
       return param!.value
     })
     const isnum = valueStrings.every((v) => {
-      return !isNaN(parseFloat(v))
+      return !isNaN(Number(v))
     })
     if (isnum) {
       const values: number[] = valueStrings.map((v) => parseFloat(v))

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -186,7 +186,7 @@ const plotSlice = (
   })
 
   const isnum = valueStrings.every((v) => {
-    return !isNaN(parseFloat(v))
+    return !isNaN(Number(v))
   })
   if (isnum) {
     const valuesNum: number[] = valueStrings.map((v) => parseFloat(v))


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #198 
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
### Motivation
Fix a bug when handling categorical hyperparameters that contain number in the string.

The `parseFloat()` function used in isnum starts from the beginning and returns the parsed value when it is no longer a number.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseFloat#:~:text=A%20second%20decimal%20point%20also%20stops%20parsing%20(characters%20up%20to%20that%20point%20will%20still%20be%20parsed).
Therefore, a categorical parameter whose first letter is a number is treated as a numeric parameter (`isnum is true`).
`Number()` is now used to determine whether a number is a number or not.
<img width="1900" alt="スクリーンショット 2022-04-29 15 53 03" src="https://user-images.githubusercontent.com/33712536/165900352-f824c2d5-6611-41d7-be52-ea779eca95bc.png">


### Description of changes
- Change from 'parseFloat` to `Number` in `GraphParallelCorrdinate.tsx`, `GraphSlice.tsx`

<img width="1826" alt="スクリーンショット 2022-04-29 16 04 15" src="https://user-images.githubusercontent.com/33712536/165900372-1e1632d2-f4bb-4638-91a4-435fcbe41929.png">
<img width="1810" alt="スクリーンショット 2022-04-29 16 04 04" src="https://user-images.githubusercontent.com/33712536/165900383-a0a1d1e3-221c-423c-b000-a2712ecc2d82.png">

