### PR TITLE
Make WSGI servers multithreaded

### DIFF
--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -1,8 +1,9 @@
 import argparse
 import os
-import sys
-from wsgiref.simple_server import make_server, WSGIServer
 from socketserver import ThreadingMixIn
+import sys
+from wsgiref.simple_server import make_server
+from wsgiref.simple_server import WSGIServer
 
 from bottle import Bottle
 from bottle import run
@@ -35,7 +36,7 @@ def run_wsgiref(app: Bottle, host: str, port: int, quiet: bool) -> None:
         )
     else:
         print(f"Listening on http://{host}:{port}/", file=sys.stderr)
-        print(f"Hit Ctrl-C to quit.\n", file=sys.stderr)
+        print("Hit Ctrl-C to quit.\n", file=sys.stderr)
         httpd = make_server(host, port, app, server_class=ThreadedWSGIServer)
         httpd.serve_forever()
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Make WSGI servers multithreaded by default.