### PR TITLE
Follow-up PR 235: Fix the order of trials and intermediate_values.

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -159,6 +159,11 @@ def get_trials(
         ):
             return trials
     trials = storage.get_all_trials(study_id, deepcopy=False)
+
+    # TODO(c-bata): Avoid to sort trials after fixed https://github.com/optuna/optuna/issues/3605
+    if isinstance(storage, RDBStorage) and storage.url.startswith("postgresql"):
+        trials = sorted(trials, key=lambda t: t.number)
+
     with trials_cache_lock:
         trials_last_fetched_at[study_id] = datetime.now()
         trials_cache[study_id] = trials

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -85,15 +85,20 @@ def serialize_study_detail(
             summary._study_id, summary.best_trial
         )
 
-    serialized["trials"] = [
-        serialize_frozen_trial(summary._study_id, trial) for trial in trials
-    ]
-
+    serialized["trials"] = serialize_frozen_trials(summary._study_id, trials)
     serialized["intersection_search_space"] = serialize_search_space(intersection)
     serialized["union_search_space"] = serialize_search_space(union)
     serialized["has_intermediate_values"] = has_intermediate_values
     serialized["note"] = note.get_note_from_system_attrs(summary.system_attrs)
     return serialized
+
+
+def serialize_frozen_trials(study_id: int, trials: List[FrozenTrial]) -> List[Dict[str, Any]]:
+    serialized = [
+        serialize_frozen_trial(study_id, trial) for trial in trials
+    ]
+
+    return sorted(serialized, key=lambda t: t["number"])
 
 
 def serialize_frozen_trial(study_id: int, trial: FrozenTrial) -> Dict[str, Any]:
@@ -122,7 +127,7 @@ def serialize_frozen_trial(study_id: int, trial: FrozenTrial) -> Dict[str, Any]:
             assert np.isfinite(value)
             serialized_value = value
         serialized_intermediate_values.append({"step": step, "value": serialized_value})
-    serialized["intermediate_values"] = serialized_intermediate_values
+    serialized["intermediate_values"] = sorted(serialized_intermediate_values, key=lambda v: v["step"])
 
     if trial.values is not None:
         serialized_values: List[Union[float, Literal["inf", "-inf"]]] = []

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -85,20 +85,14 @@ def serialize_study_detail(
             summary._study_id, summary.best_trial
         )
 
-    serialized["trials"] = serialize_frozen_trials(summary._study_id, trials)
+    serialized["trials"] = [
+        serialize_frozen_trial(summary._study_id, trial) for trial in trials
+    ]
     serialized["intersection_search_space"] = serialize_search_space(intersection)
     serialized["union_search_space"] = serialize_search_space(union)
     serialized["has_intermediate_values"] = has_intermediate_values
     serialized["note"] = note.get_note_from_system_attrs(summary.system_attrs)
     return serialized
-
-
-def serialize_frozen_trials(study_id: int, trials: List[FrozenTrial]) -> List[Dict[str, Any]]:
-    serialized = [
-        serialize_frozen_trial(study_id, trial) for trial in trials
-    ]
-
-    return sorted(serialized, key=lambda t: t["number"])
 
 
 def serialize_frozen_trial(study_id: int, trial: FrozenTrial) -> Dict[str, Any]:
@@ -127,7 +121,9 @@ def serialize_frozen_trial(study_id: int, trial: FrozenTrial) -> Dict[str, Any]:
             assert np.isfinite(value)
             serialized_value = value
         serialized_intermediate_values.append({"step": step, "value": serialized_value})
-    serialized["intermediate_values"] = sorted(serialized_intermediate_values, key=lambda v: v["step"])
+    serialized["intermediate_values"] = sorted(
+        serialized_intermediate_values, key=lambda v: v["step"]
+    )
 
     if trial.values is not None:
         serialized_values: List[Union[float, Literal["inf", "-inf"]]] = []

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -23,7 +23,9 @@ const convertTrialResponse = (res: TrialResponse): Trial => {
     number: res.number,
     state: res.state,
     values: res.values,
-    intermediate_values: res.intermediate_values,
+    intermediate_values: res.intermediate_values.sort(
+      (a, b) => a.step - b.step
+    ),
     datetime_start: res.datetime_start
       ? new Date(res.datetime_start)
       : undefined,
@@ -62,7 +64,7 @@ export const getStudyDetailAPI = (
       },
     })
     .then((res) => {
-      const trials = res.data.trials.map((trial): Trial => {
+      const trials: Trial[] = res.data.trials.map((trial): Trial => {
         return convertTrialResponse(trial)
       })
       return {
@@ -70,7 +72,7 @@ export const getStudyDetailAPI = (
         name: res.data.name,
         datetime_start: new Date(res.data.datetime_start),
         directions: res.data.directions,
-        trials: trials,
+        trials: trials.sort((a, b) => a.number - b.number),
         union_search_space: res.data.union_search_space,
         intersection_search_space: res.data.intersection_search_space,
         has_intermediate_values: res.data.has_intermediate_values,

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -23,9 +23,7 @@ const convertTrialResponse = (res: TrialResponse): Trial => {
     number: res.number,
     state: res.state,
     values: res.values,
-    intermediate_values: res.intermediate_values.sort(
-      (a, b) => a.step - b.step
-    ),
+    intermediate_values: res.intermediate_values,
     datetime_start: res.datetime_start
       ? new Date(res.datetime_start)
       : undefined,
@@ -64,7 +62,7 @@ export const getStudyDetailAPI = (
       },
     })
     .then((res) => {
-      const trials: Trial[] = res.data.trials.map((trial): Trial => {
+      const trials = res.data.trials.map((trial): Trial => {
         return convertTrialResponse(trial)
       })
       return {
@@ -72,7 +70,7 @@ export const getStudyDetailAPI = (
         name: res.data.name,
         datetime_start: new Date(res.data.datetime_start),
         directions: res.data.directions,
-        trials: trials.sort((a, b) => a.number - b.number),
+        trials: trials,
         union_search_space: res.data.union_search_space,
         intersection_search_space: res.data.intersection_search_space,
         has_intermediate_values: res.data.has_intermediate_values,


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Followup #235

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
* [Sort trials only if using RDBStorage with PostgreSQL](https://github.com/optuna/optuna-dashboard/commit/6de2f224203b1cf26f9c95f3846e99e3f9eafaa7)
* Fix lint errors.