### PR TITLE
Fix pypi-publish action

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: gh release download $(jq --raw-output .tag_name "$GITHUB_EVENT_PATH") ./dist
+    - run: gh release download $(jq --raw-output .tag_name "$GITHUB_EVENT_PATH") -p '*.whl' -p '*.tar.gz' -D ./dist
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
See https://github.com/optuna/optuna-dashboard/runs/7682670245?check_suite_focus=true

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
The release of v0.7.2 is failed due to an invalid command options.
I temporary release v0.7.2 like the following.

```
(venv) [x86_64] $ gh release download v0.7.2 -p '*.whl' -p '*.tar.gz' -D ./dist
(venv) [x86_64] $ ls dist
optuna-dashboard-0.7.2.tar.gz           optuna_dashboard-0.7.2-py3-none-any.whl
(venv) [x86_64] $ which twine
/Users/c-bata/go/src/github.com/optuna/optuna-dashboard/venv/bin/twine
(venv) [x86_64] $ twine upload dist/*
...
```