### PR TITLE
Catch ValueError while importing optuna-fast-fanova

### DIFF
--- a/optuna_dashboard/_importance.py
+++ b/optuna_dashboard/_importance.py
@@ -19,7 +19,7 @@ except ImportError:
 
 try:
     from optuna_fast_fanova import FanovaImportanceEvaluator as FastFanovaImportanceEvaluator
-except ImportError:
+except (ImportError, ValueError):
     FastFanovaImportanceEvaluator = None  # type: ignore
 
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
As reported https://github.com/optuna/optuna-fast-fanova/issues/6, `ValueError` may be raised.

```
/usr/lib/python3.7/importlib/_bootstrap.py:219: RuntimeWarning: sklearn.tree._criterion.Criterion size changed, may indicate binary incompatibility. Expected 328 from C header, got 352 from PyObject
return f(*args, **kwds)
ValueError Traceback (most recent call last)
in ()
1 import optuna
----> 2 from optuna_fast_fanova import FanovaImportanceEvaluator
3
4
5 def objective(trial):

2 frames
/usr/local/lib/python3.7/dist-packages/optuna_fast_fanova/_fanova.pyx in init optuna_fast_fanova._fanova()

ValueError: sklearn.tree._criterion.ClassificationCriterion size changed, may indicate binary incompatibility. Expected 1168 from C header, got 368 from PyObject
```