### PR TITLE
Align graph history between optuna and optuna-dashboard

### DIFF
--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -239,8 +239,8 @@ const plotHistory = (
   const xForLinePlot: number[] = []
   const yForLinePlot: number[] = []
   let currentBest: number | null = null
-  for (var i = 0; i < filteredTrials.length; i++) {
-    let t = filteredTrials[i]
+  for (let i = 0; i < filteredTrials.length; i++) {
+    const t = filteredTrials[i]
     if (currentBest === null) {
       currentBest = t.values![objectiveId] as number
       xForLinePlot.push(getAxisX(t))
@@ -249,7 +249,7 @@ const plotHistory = (
       study.directions[objectiveId] === "maximize" &&
       t.values![objectiveId] > currentBest
     ) {
-      let p = filteredTrials[i - 1]
+      const p = filteredTrials[i - 1]
       if (!xForLinePlot.includes(getAxisX(p))) {
         xForLinePlot.push(getAxisX(p))
         yForLinePlot.push(currentBest)
@@ -261,7 +261,7 @@ const plotHistory = (
       study.directions[objectiveId] === "minimize" &&
       t.values![objectiveId] < currentBest
     ) {
-      let p = filteredTrials[i - 1]
+      const p = filteredTrials[i - 1]
       if (!xForLinePlot.includes(getAxisX(p))) {
         xForLinePlot.push(getAxisX(p))
         yForLinePlot.push(currentBest)
@@ -289,6 +289,5 @@ const plotHistory = (
       type: "scatter",
     },
   ]
-  console.log(plotData)
   plotly.react(plotDomId, plotData, layout)
 }

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -236,7 +236,7 @@ const plotHistory = (
       : trial.datetime_complete!
   }
 
-  const xForLinePlot: number[] = []
+  const xForLinePlot: (number | Date)[] = []
   const yForLinePlot: number[] = []
   let currentBest: number | null = null
   for (let i = 0; i < filteredTrials.length; i++) {

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -290,7 +290,7 @@ const plotHistory = (
       x: xForLinePlot,
       y: yForLinePlot,
       name: "Best Value",
-      mode :"lines",
+      mode: "lines",
       type: "scatter",
     },
   ]

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -207,12 +207,14 @@ const plotHistory = (
       b: 0,
     },
     yaxis: {
+      title: "Objective Value",
       type: logScale ? "log" : "linear",
     },
     xaxis: {
+      title: xAxis === "number" ? "Trial" : "Time",
       type: xAxis === "number" ? "linear" : "date",
     },
-    showlegend: false,
+    showlegend: true,
     template: mode === "dark" ? plotlyDarkTemplate : {},
   }
 
@@ -280,12 +282,15 @@ const plotHistory = (
       y: filteredTrials.map(
         (t: Trial): number => t.values![objectiveId] as number
       ),
+      name: "Objective Value",
       mode: "markers",
       type: "scatter",
     },
     {
       x: xForLinePlot,
       y: yForLinePlot,
+      name: "Best Value",
+      mode :"lines",
       type: "scatter",
     },
   ]

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -228,24 +228,22 @@ const plotHistory = (
     return
   }
   const trialsForLinePlot: Trial[] = []
-  let currentBest: number | null = null
+  let currentBest: Trial | null = null
   filteredTrials.forEach((t) => {
     if (currentBest === null) {
-      currentBest = t.values![objectiveId] as number
-      trialsForLinePlot.push(t)
+      currentBest = t
     } else if (
       study.directions[objectiveId] === "maximize" &&
-      t.values![objectiveId] > currentBest
+      t.values![objectiveId] > currentBest.values![objectiveId]
     ) {
-      currentBest = t.values![objectiveId] as number
-      trialsForLinePlot.push(t)
+      currentBest = t
     } else if (
       study.directions[objectiveId] === "minimize" &&
-      t.values![objectiveId] < currentBest
+      t.values![objectiveId] < currentBest.values![objectiveId]
     ) {
-      currentBest = t.values![objectiveId] as number
-      trialsForLinePlot.push(t)
+      currentBest = t
     }
+    trialsForLinePlot.push(currentBest)
   })
 
   const getAxisX = (trial: Trial): number | Date => {
@@ -256,12 +254,9 @@ const plotHistory = (
       : trial.datetime_complete!
   }
 
-  const xForLinePlot = trialsForLinePlot.map(getAxisX)
-  xForLinePlot.push(getAxisX(filteredTrials[filteredTrials.length - 1]))
   const yForLinePlot = trialsForLinePlot.map(
     (t: Trial): number => t.values![objectiveId] as number
   )
-  yForLinePlot.push(yForLinePlot[yForLinePlot.length - 1])
 
   const plotData: Partial<plotly.PlotData>[] = [
     {
@@ -273,7 +268,7 @@ const plotHistory = (
       type: "scatter",
     },
     {
-      x: xForLinePlot,
+      x: filteredTrials.map(getAxisX),
       y: yForLinePlot,
       mode: "lines",
       type: "scatter",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Currently, there are some differences between optuna and optuna-dashboard about plotting optimization history as follows:
| Target (optuna) | Master (optuna-dashboard) | PR (optuna-dashboard) |
|:---|:---:|---:|
|![history-plot](https://user-images.githubusercontent.com/1277089/195110569-09dd89aa-39ab-4997-8fad-457e92e31b29.png) |![newplot](https://user-images.githubusercontent.com/1277089/195112350-b0a0399a-6a8e-450c-812d-26849c81f45a.png) |![newplot](https://user-images.githubusercontent.com/1277089/195368008-8f4aa852-ca08-4dc5-a8c3-ed18f407bf7a.png)|


* Target (optuna)

```
[
   {
      "mode":"markers",
      "name":"Objective Value",
      "type":"scatter",
      "x":[...],
      "y":[...]
   },
   {
      "name":"Best Value",
      "type":"scatter",
      "x":[
         0,
         1,
         2,
         3,
         4,
         5,
         6,
         7,
         8,
         9
      ],
      "y":[
         9.564143293566762,
         9.564143293566762,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473,
         4.022417775380473
      ]
   }
]
```

* Master (optuna-dashboard)
```
[
   {
      "x":[...],
      "y":[...],
      "mode":"markers",
      "type":"scatter"
   },
   {
      "x":[
         0,
         2,
         9
      ],
      "y":[
         9.564143293566762,
         4.022417775380473,
         4.022417775380473
      ],
      "mode":"lines",
      "type":"scatter"
   }
]
```

* PR (optuna-dashboard)
```
[
   {
      "x":[...],
      "y":[...],
      "name":"Objective Value",
      "mode":"markers",
      "type":"scatter"
   },
   {
      "x":[
         0,
         1,
         2,
         9
      ],
      "y":[
         9.564143293566762,
         9.564143293566762,
         4.022417775380473,
         4.022417775380473
      ],
      "type":"scatter",
      "name":"Best Value",
      "mode":"lines"
   }
]
```
By this PR, I removed the differences.

## Script
```
import pprint

import optuna
from optuna_dashboard import wsgi


def main():
    storage = optuna.storages.InMemoryStorage()
    sampler = optuna.samplers.RandomSampler(seed=1)
    study = optuna.create_study(study_name="single-objective", storage=storage, sampler=sampler)

    def objective_single(trial: optuna.Trial) -> float:
        x1 = trial.suggest_float("x1", 0, 10)
        x2 = trial.suggest_float("x2", 0, 10)
        x3 = trial.suggest_categorical("x3", ["foo", "bar"])
        return (x1 - 2) ** 2 + (x2 - 5) ** 2

    study.optimize(objective_single, n_trials=10)

    fig = optuna.visualization.plot_optimization_history(study)
    fig.update_layout(
        width=800,
        height=600,
        margin={"l": 10, "r": 10},
    )
    print("")
    print("Data")
    pprint.pprint(fig._data)
    print("")
    print("Layout")
    pprint.pprint(fig._layout)
    fig.write_image("history-plot.png")

    app = wsgi(storage)
    app.run(port=9000)


if __name__ == '__main__':
    main()
```

