### PR TITLE
Align graph slice between optuna and optuna-dashboard

### DIFF
--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -187,7 +187,7 @@ const plotSlice = (
     return t.params.find((p) => p.name == selected)!.value
   })
 
-  const trialNumbers: number[] = filteredTrials.map((t) => t.number as number)
+  const trialNumbers: number[] = filteredTrials.map((t) => t.number)
 
   const isnum = valueStrings.every((v) => {
     return !isNaN(Number(v))

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -187,6 +187,10 @@ const plotSlice = (
     return t.params.find((p) => p.name == selected)!.value
   })
 
+  const trialNumbers: number[] = filteredTrials.map(
+    (t) => t.number as number
+  )
+
   const isnum = valueStrings.every((v) => {
     return !isNaN(Number(v))
   })
@@ -198,6 +202,13 @@ const plotSlice = (
         x: valuesNum,
         y: objectiveValues,
         mode: "markers",
+        marker: {
+          color: trialNumbers,
+          colorscale: 'Blues',
+          colorbar: {
+            title: "Trial",
+          },
+       },
       },
     ]
     layout["xaxis"] = {

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -187,9 +187,7 @@ const plotSlice = (
     return t.params.find((p) => p.name == selected)!.value
   })
 
-  const trialNumbers: number[] = filteredTrials.map(
-    (t) => t.number as number
-  )
+  const trialNumbers: number[] = filteredTrials.map((t) => t.number as number)
 
   const isnum = valueStrings.every((v) => {
     return !isNaN(Number(v))
@@ -204,7 +202,7 @@ const plotSlice = (
         mode: "markers",
         marker: {
           color: trialNumbers,
-          colorscale: 'Blues',
+          colorscale: "Blues",
           reversescale: true,
           colorbar: {
             title: "Trial",
@@ -238,7 +236,7 @@ const plotSlice = (
         mode: "markers",
         marker: {
           color: trialNumbers,
-          colorscale: 'Blues',
+          colorscale: "Blues",
           reversescale: true,
           colorbar: {
             title: "Trial",

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -162,7 +162,7 @@ const plotSlice = (
       automargin: true,
     },
     yaxis: {
-      title: "Objective Values",
+      title: "Objective Value",
       type: logYScale ? "log" : "linear",
       gridwidth: 1,
       automargin: true,
@@ -205,10 +205,15 @@ const plotSlice = (
         marker: {
           color: trialNumbers,
           colorscale: 'Blues',
+          reversescale: true,
           colorbar: {
             title: "Trial",
           },
-       },
+          line: {
+            color: "Grey",
+            width: 0.5,
+          },
+        },
       },
     ]
     layout["xaxis"] = {
@@ -231,6 +236,18 @@ const plotSlice = (
         x: valuesCategorical,
         y: objectiveValues,
         mode: "markers",
+        marker: {
+          color: trialNumbers,
+          colorscale: 'Blues',
+          reversescale: true,
+          colorbar: {
+            title: "Trial",
+          },
+          line: {
+            color: "Grey",
+            width: 0.5,
+          },
+        },
       },
     ]
     layout["xaxis"] = {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Currently, there are some differences between optuna and optuna-dashboard about plotting optimization history as follows:
| Target (optuna) | Master (optuna-dashboard) | PR (optuna-dashboard) |
|:---|:---:|---:|
|![plot](https://user-images.githubusercontent.com/1277089/195374361-3e3ba042-7b36-4364-8e42-7efbd72cc159.png)|![newplot (2)](https://user-images.githubusercontent.com/1277089/195487719-66c09495-ff20-4c35-96b0-ef68d110c7c0.png)|![newplot (1)](https://user-images.githubusercontent.com/1277089/195487076-5c59e1a1-6789-4156-97e0-a134b3542efa.png)|


* Target (optuna)

```
[
   {
      "marker":{
         "color":[
            0,
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9
         ],
         "colorbar":{
            "title":{
               "text":"Trial"
            },
            "x":1.0,
            "xpad":40
         },
         "colorscale":[...], # Blues
         "line":{
            "color":"Grey",
            "width":0.5
         }
      },
      "mode":"markers",
      "showlegend":false,
      "type":"scatter",
      "x":[...],
      "y":[...]
   }
]
```

* Master (optuna-dashboard)
```
[
   {
      "type":"scatter",
      "x":[...],
      "y":[...],
      "mode":"markers"
   }
]
```

* PR (optuna-dashboard)
```
[
   {
      "type":"scatter",
      "x":[...],
      "y":[...],
      "mode":"markers",
      "marker":{
         "color":[
            0,
            1,
            2,
            3,
            4,
            5,
            6,
            7,
            8,
            9
         ],
         "colorscale":"Blues",
         "reversescale":true,
         "colorbar":{
            "title":{
               "text":"Trial"
            }
         },
         "line":{
            "color":"Grey",
            "width":0.5
         }
      }
   }
]
```
By this PR, I removed the differences.

## Script
```

```

