### PR TITLE
Fix mypy failure

### DIFF
--- a/optuna_dashboard/_sql_profiler.py
+++ b/optuna_dashboard/_sql_profiler.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 from bottle import Bottle
 from bottle import SimpleTemplate
 from optuna.storages import RDBStorage
-from optuna_dashboard._app import BottleView
+from optuna_dashboard._app import BottleViewReturn
 from sqlalchemy import event
 
 
@@ -109,7 +109,7 @@ def register_profiler_view(app: Bottle, storage: RDBStorage) -> Bottle:
     EngineDebuggingSignalEvents(storage.engine).register()
 
     @app.get("/sql-profiler")
-    def profile_sql_queries() -> BottleView:
+    def profile_sql_queries() -> BottleViewReturn:
         global sql_queries
         with sql_queries_lock:
             summary = [


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
See https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545
```
mypy optuna_dashboard python_tests
  shell: /usr/bin/bash -e {0}
  env:
    pythonLocation: /opt/hostedtoolcache/Python/[3](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:3).10.8/x6[4](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:4)
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.8/x[6](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:6)4/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.8/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.[8](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:8)/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.8/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.[10](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:10).8/x64/lib
optuna_dashboard/_sql_profiler.py:[11](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:12)2: error: A function returning TypeVar should receive at least one argument containing the same Typevar
optuna_dashboard/_sql_profiler.py:1[12](https://github.com/optuna/optuna-dashboard/actions/runs/3317684709/jobs/5480808545#step:8:13): note: Consider using the upper bound "Callable[..., Union[str, bytes, Dict[str, Any], Any]]" instead
```