### PR TITLE
Set an empty string as `API_ENDPOINT` at `jest.config.js`.

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   globals: {
     'process.env.NODE_ENV': JSON.stringify(process.env.NODE_ENV),
     'APP_BAR_TITLE': JSON.stringify(process.env.APP_BAR_TITLE || "Optuna Dashboard"),
-    'API_ENDPOINT': JSON.stringify(process.env.API_ENDPOINT),
+    'API_ENDPOINT': JSON.stringify(process.env.API_ENDPOINT || ""),
     'URL_PREFIX': JSON.stringify(process.env.URL_PREFIX || "/dashboard")
   }
 };


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Fix a following error:

```
$ npm run test

> optuna-dashboard@0.0.1 test
> jest typescript_tests

 PASS  typescript_tests/DataGrid.test.tsx
 FAIL  typescript_tests/TrialTable.test.tsx
  ● Test suite failed to run

    ReferenceError: API_ENDPOINT is not defined

      1 | import axios from "axios"
      2 |
    > 3 | const axiosInstance = axios.create({ baseURL: API_ENDPOINT })
        |                                               ^
      4 |
      5 | interface TrialResponse {
      6 |   trial_id: number

      at Object.<anonymous> (optuna_dashboard/ts/apiClient.ts:3:47)
      at Object.<anonymous> (optuna_dashboard/ts/components/GraphHyperparameterImportances.tsx:15:1)
      at Object.<anonymous> (optuna_dashboard/ts/components/StudyDetail.tsx:34:1)
      at Object.<anonymous> (typescript_tests/TrialTable.test.tsx:5:1)

Test Suites: 1 failed, 1 passed, 2 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        7.126 s
Ran all test suites matching /typescript_tests/i.
```