### PR TITLE
Simplify _CachedExtraStudyProperty.update a little

### DIFF
--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -8,7 +8,6 @@ from typing import Tuple
 
 from optuna.distributions import BaseDistribution
 from optuna.trial import FrozenTrial
-from optuna.trial import TrialState
 
 
 SearchSpaceSetT = Set[Tuple[str, BaseDistribution]]
@@ -17,8 +16,6 @@ SearchSpaceListT = List[Tuple[str, BaseDistribution]]
 #  In-memory cache
 cached_extra_study_property_cache_lock = threading.Lock()
 cached_extra_study_property_cache: Dict[int, "_CachedExtraStudyProperty"] = {}
-
-states_of_interest = [TrialState.COMPLETE, TrialState.PRUNED]
 
 
 def get_cached_extra_study_property(
@@ -76,8 +73,6 @@ class _CachedExtraStudyProperty:
 
             if not trial.state.is_finished():
                 next_cursor = trial.number
-
-            if trial.state not in states_of_interest:
                 continue
 
             if not self.has_intermediate_values and len(trial.intermediate_values) > 0:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [X] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

@c-bata san said that `states_of_interest` should be `[TrialState.COMPLETE, TrialState.PRUNED, TrialState.FAIL]` instead of `[TrialState.COMPLETE, TrialState.PRUNED]`, but then `trial.state not in states_of_interest` is equivalent to `not trial.state.is_finished()`.

https://github.com/optuna/optuna/blob/release-v3.0.3/optuna/trial/_state.py

| TrialState | is_finished() |
|----------|--------------|
| RUNNING | False | 
| COMPLETE | True |
| PRUNED | True |
| FAIL | True |
| WAITING | False |


