### PR TITLE
Align intermediate values graph between optuna and optuna-dashboard

### DIFF
--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -64,6 +64,7 @@ const plotIntermediateValue = (trials: Trial[], mode: string) => {
     return {
       x: values.map((iv) => iv.step),
       y: values.map((iv) => iv.value),
+      marker: { maxdisplayed: 10 },
       mode: "lines+markers",
       type: "scatter",
       name:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Currently, there are some differences between optuna and optuna-dashboard about plotting optimization history as follows:
* {'marker': {'maxdisplayed': 10}

| Target (optuna) | Master (optuna-dashboard) | PR (optuna-dashboard) |
|:---|:---:|---:|
|![plot](https://user-images.githubusercontent.com/1277089/202899483-ff0856a4-7adb-4b25-8ad9-946fd5bbc21c.png)|![newplot (2)](https://user-images.githubusercontent.com/1277089/202899431-906649cb-e799-4335-b6b0-186189e9ba4e.png)|![newplot (3)](https://user-images.githubusercontent.com/1277089/202899564-2659af54-048a-40e7-9300-3f7577b92f12.png)|

* Target (optuna)
```
[{'marker': {'maxdisplayed': 10},
  'mode': 'lines+markers',
  'name': 'Trial0',
  'type': 'scatter',
  'x': [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
  'y': [0.0,
        0.47820716467833807,
        0.9564143293566761,
        1.4346214940350142,
        1.9128286587133523,
        2.3910358233916904,
        2.8692429880700283,
        3.3474501527483667,
        3.8256573174267046,
        4.303864482105043,
        4.782071646783381,
        5.260278811461719,
        5.738485976140057,
        6.2166931408183945,
        6.694900305496733,
        7.173107470175071,
        7.651314634853409,
        8.129521799531748,
        8.607728964210086,
        9.085936128888424]},
  {...},
]
```

* Master (optuna-dashboard)
```
[
   {
      "x":[
         0,
         1,
         2,
         3,
         4,
         5,
         6,
         7,
         8,
         9,
         10,
         11,
         12,
         13,
         14,
         15,
         16,
         17,
         18,
         19
      ],
      "y":[
         0,
         0.47820716467833807,
         0.9564143293566761,
         1.4346214940350142,
         1.9128286587133523,
         2.3910358233916904,
         2.8692429880700283,
         3.3474501527483667,
         3.8256573174267046,
         4.303864482105043,
         4.782071646783381,
         5.260278811461719,
         5.738485976140057,
         6.2166931408183945,
         6.694900305496733,
         7.173107470175071,
         7.651314634853409,
         8.129521799531748,
         8.607728964210086,
         9.085936128888424
      ],
      "mode":"lines+markers",
      "type":"scatter",
      "name":"trial #0"
   },
   {...}
]
```

* PR (optuna-dashboard)
```
[
   {
      "x":[
         0,
         1,
         2,
         3,
         4,
         5,
         6,
         7,
         8,
         9,
         10,
         11,
         12,
         13,
         14,
         15,
         16,
         17,
         18,
         19
      ],
      "y":[
         0,
         0.47820716467833807,
         0.9564143293566761,
         1.4346214940350142,
         1.9128286587133523,
         2.3910358233916904,
         2.8692429880700283,
         3.3474501527483667,
         3.8256573174267046,
         4.303864482105043,
         4.782071646783381,
         5.260278811461719,
         5.738485976140057,
         6.2166931408183945,
         6.694900305496733,
         7.173107470175071,
         7.651314634853409,
         8.129521799531748,
         8.607728964210086,
         9.085936128888424
      ],
      "mode":"lines+markers",
      "type":"scatter",
      "marker": {"maxdisplayed": 10},
      "name":"trial #0"
   },
   {...}
]
```
By this PR, I removed the differences.

## Script
```
import pprint

import optuna
from optuna_dashboard import wsgi


def main():
    storage = optuna.storages.InMemoryStorage()
    sampler = optuna.samplers.RandomSampler(seed=1)
    study = optuna.create_study(
        study_name="single-objective",
        storage=storage,
        sampler=sampler,
    )

    def objective_single(trial: optuna.Trial) -> float:
        x1 = trial.suggest_float("x1", 0, 10)
        x2 = trial.suggest_float("x2", 0, 10)
        x3 = trial.suggest_categorical("x3", ["foo", "bar"])

        r = (x1 - 2) ** 2 + (x2 - 5) ** 2

        step = 20
        for i in range(step):
            trial.report(r / step * i, step=i)

        return r

    study.optimize(objective_single, n_trials=10)

    fig = optuna.visualization.plot_intermediate_values(
        study,
    )
    fig.update_layout(
        width=800,
        height=600,
    )
    print("")
    print("Data")
    pprint.pprint(fig._data)
    print("")
    print("Layout")
    pprint.pprint(fig._layout)
    fig.write_image("plot.png")

    app = wsgi(storage)
    app.run(port=8080)


if __name__ == '__main__':
    main()
```