### PR TITLE
Use `functools.lru_cache` to cache `os.path.exists` call

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -53,9 +53,11 @@ BottleView = TypeVar("BottleView", bound=Callable[..., BottleViewReturn])
 
 logger = logging.getLogger(__name__)
 
+# Static files
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_DIR = os.path.join(BASE_DIR, "public")
 IMG_DIR = os.path.join(BASE_DIR, "img")
+cached_path_exists = functools.lru_cache(maxsize=10)(os.path.exists)
 
 # In-memory trials cache
 trials_cache_lock = threading.Lock()
@@ -366,7 +368,7 @@ def create_app(storage: BaseStorage, debug: bool = False) -> Bottle:
     def send_static(filename: str) -> BottleViewReturn:
         if not debug and "gzip" in request.headers["Accept-Encoding"]:
             gz_filename = filename.strip("/\\") + ".gz"
-            if os.path.exists(os.path.join(STATIC_DIR, gz_filename)):
+            if cached_path_exists(os.path.join(STATIC_DIR, gz_filename)):
                 filename = gz_filename
         return static_file(filename, root=STATIC_DIR)
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
For further performance improvements.