### PR TITLE
Fix `union_user_attrs` property of `_CachedExtraStudyProperty`.

### DIFF
--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -18,8 +18,6 @@ SearchSpaceListT = List[Tuple[str, BaseDistribution]]
 cached_extra_study_property_cache_lock = threading.Lock()
 cached_extra_study_property_cache: Dict[int, "_CachedExtraStudyProperty"] = {}
 
-states_of_interest = [TrialState.COMPLETE, TrialState.PRUNED]
-
 
 def get_cached_extra_study_property(
     study_id: int, trials: List[FrozenTrial]
@@ -77,7 +75,9 @@ class _CachedExtraStudyProperty:
             if not trial.state.is_finished():
                 next_cursor = trial.number
 
-            if trial.state not in states_of_interest:
+            current_user_attrs = set(n for n in trial.user_attrs.keys())
+            self._union_user_attrs = self._union_user_attrs.union(current_user_attrs)
+            if trial.state == TrialState.FAIL:
                 continue
 
             if not self.has_intermediate_values and len(trial.intermediate_values) > 0:
@@ -90,8 +90,5 @@ class _CachedExtraStudyProperty:
                 self._intersection = copy.copy(current)
             else:
                 self._intersection = self._intersection.intersection(current)
-
-            current_user_attrs = set(n for n in trial.user_attrs.keys())
-            self._union_user_attrs = self._union_user_attrs.union(current_user_attrs)
 
         self._cursor = next_cursor


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #288

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
See https://github.com/optuna/optuna-dashboard/pull/288#issuecomment-1341945746 for details.