### PR TITLE
Remove inner trial user attr table

### DIFF
--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -168,7 +168,7 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
   studyDetail?.union_user_attrs.forEach((attr_spec) => {
     columns.push({
       field: "user_attrs",
-      label: `User attribute ${attr_spec.key}`,
+      label: `UserAttribute ${attr_spec.key}`,
       toCellValue: (i) =>
         trials[i].user_attrs.find((attr) => attr.key === attr_spec.key)
           ?.value || null,
@@ -195,10 +195,6 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
     })
   })
 
-  const collapseParamColumns: DataGridColumn<TrialParam>[] = [
-    { field: "name", label: "Name", sortable: true },
-    { field: "value", label: "Value", sortable: true },
-  ]
   const collapseIntermediateValueColumns: DataGridColumn<TrialIntermediateValue>[] =
     [
       { field: "step", label: "Step", sortable: true },
@@ -237,30 +233,6 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
         <Grid item xs={6}>
           <Box margin={1}>
             <Typography variant="h6" gutterBottom component="div">
-              Parameters
-            </Typography>
-            <DataGrid<TrialParam>
-              columns={collapseParamColumns}
-              rows={trials[index].params}
-              keyField={"name"}
-              dense={true}
-              rowsPerPageOption={[5, 10, { label: "All", value: -1 }]}
-            />
-            <Typography variant="h6" gutterBottom component="div">
-              Trial user attributes
-            </Typography>
-            <DataGrid<Attribute>
-              columns={collapseAttrColumns}
-              rows={trials[index].user_attrs}
-              keyField={"key"}
-              dense={true}
-              rowsPerPageOption={[5, 10, { label: "All", value: -1 }]}
-            />
-          </Box>
-        </Grid>
-        <Grid item xs={6}>
-          <Box margin={1}>
-            <Typography variant="h6" gutterBottom component="div">
               Intermediate values
             </Typography>
             <DataGrid<TrialIntermediateValue>
@@ -270,6 +242,10 @@ export const TrialTable: FC<{ studyDetail: StudyDetail | null }> = ({
               dense={true}
               rowsPerPageOption={[5, 10, { label: "All", value: -1 }]}
             />
+          </Box>
+        </Grid>
+        <Grid item xs={6}>
+          <Box margin={1}>
             <Typography variant="h6" gutterBottom component="div">
               Trial system attributes
             </Typography>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
User attributes are now displayed on TrialTable so that this PR removes inner table to show user attributes.