### PR TITLE
Remove typing_extensions from the dependencies

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from datetime import timedelta
 import functools
@@ -425,7 +427,7 @@ def run_server(
     run(app, host=host, port=port)
 
 
-def wsgi(storage: Union[str, BaseStorage]) -> "WSGIApplication":
+def wsgi(storage: Union[str, BaseStorage]) -> WSGIApplication:
     """This function exposes WSGI interface for people who want to run on the
     production-class WSGI servers like Gunicorn or uWSGI.
     """

--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import threading
 from typing import Dict

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import argparse
 import os
 from socketserver import ThreadingMixIn
 import sys
+from typing import TYPE_CHECKING
 from wsgiref.simple_server import make_server
 from wsgiref.simple_server import WSGIServer
 
@@ -16,10 +19,8 @@ from ._app import get_storage
 from ._sql_profiler import register_profiler_view
 
 
-try:
+if TYPE_CHECKING:
     from typing import Literal
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
 
 
 DEBUG = os.environ.get("OPTUNA_DASHBOARD_DEBUG") == "1"

--- a/optuna_dashboard/_importance.py
+++ b/optuna_dashboard/_importance.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import threading
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import TYPE_CHECKING
 import warnings
 
 from optuna.importance import BaseImportanceEvaluator
@@ -14,11 +17,6 @@ from optuna.trial import TrialState
 
 
 try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
-
-try:
     from optuna_fast_fanova import FanovaImportanceEvaluator as FastFanovaImportanceEvaluator
 except ModuleNotFoundError:
     FastFanovaImportanceEvaluator = None  # type: ignore
@@ -27,21 +25,24 @@ except Exception as e:
     FastFanovaImportanceEvaluator = None  # type: ignore
 
 
-ImportanceItemType = TypedDict(
-    "ImportanceItemType",
-    {
-        "name": str,
-        "importance": float,
-        "distribution": str,
-    },
-)
-ImportanceType = TypedDict(
-    "ImportanceType",
-    {
-        "target_name": str,
-        "param_importances": List[ImportanceItemType],
-    },
-)
+if TYPE_CHECKING:
+    from typing import TypedDict
+
+    ImportanceItemType = TypedDict(
+        "ImportanceItemType",
+        {
+            "name": str,
+            "importance": float,
+            "distribution": str,
+        },
+    )
+    ImportanceType = TypedDict(
+        "ImportanceType",
+        {
+            "target_name": str,
+            "param_importances": List[ImportanceItemType],
+        },
+    )
 
 target_name = "Objective Value"
 param_importance_cache_lock = threading.Lock()

--- a/optuna_dashboard/_note.py
+++ b/optuna_dashboard/_note.py
@@ -1,26 +1,27 @@
+from __future__ import annotations
+
 import math
 from typing import Any
 from typing import Dict
+from typing import TYPE_CHECKING
 
 from optuna.storages import BaseStorage
 
 
-try:
+if TYPE_CHECKING:
     from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
+
+    NoteType = TypedDict(
+        "NoteType",
+        {
+            "version": int,
+            "body": str,
+        },
+    )
 
 SYSTEM_ATTR_MAX_LENGTH = 2045
 NOTE_VER_KEY = "dashboard:note_ver"
 NOTE_STR_KEY_PREFIX = "dashboard:note_str:"
-
-NoteType = TypedDict(
-    "NoteType",
-    {
-        "version": int,
-        "body": str,
-    },
-)
 
 
 def get_note_from_system_attrs(system_attrs: Dict[str, Any]) -> NoteType:

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import json
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Tuple
+from typing import TYPE_CHECKING
 from typing import Union
 
 import numpy as np
@@ -13,36 +16,34 @@ from optuna.trial import FrozenTrial
 from . import _note as note
 
 
-try:
+if TYPE_CHECKING:
     from typing import Literal
     from typing import TypedDict
-except ImportError:
-    from typing_extensions import Literal  # type: ignore
-    from typing_extensions import TypedDict
+
+    Attribute = TypedDict(
+        "Attribute",
+        {
+            "key": str,
+            "value": str,
+        },
+    )
+    AttributeSpec = TypedDict(
+        "AttributeSpec",
+        {
+            "key": str,
+            "sortable": bool,
+        },
+    )
+    IntermediateValue = TypedDict(
+        "IntermediateValue",
+        {
+            "step": int,
+            "value": Union[float, Literal["inf", "-inf", "nan"]],
+        },
+    )
 
 
 MAX_ATTR_LENGTH = 1024
-Attribute = TypedDict(
-    "Attribute",
-    {
-        "key": str,
-        "value": str,
-    },
-)
-AttributeSpec = TypedDict(
-    "AttributeSpec",
-    {
-        "key": str,
-        "sortable": bool,
-    },
-)
-IntermediateValue = TypedDict(
-    "IntermediateValue",
-    {
-        "step": int,
-        "value": Union[float, Literal["inf", "-inf", "nan"]],
-    },
-)
 
 
 def serialize_attrs(attrs: Dict[str, Any]) -> List[Attribute]:

--- a/optuna_dashboard/_sql_profiler.py
+++ b/optuna_dashboard/_sql_profiler.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import threading
 from time import perf_counter
 from typing import Dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "optuna>=2.4.0",
     "packaging",
     "scikit-learn",
-    'typing-extensions; python_version<"3.8"',
 ]
 dynamic = ["version"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 # project dependency
 optuna>=2.4
 bottle
-typing-extensions;python_version<'3.8'
 scikit-learn
 
 # lint


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

* Remove `typing_extensions` from the dependencies.
* Use `__future__.annotations`