### PR TITLE
Add Python API to save the note

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,14 @@ This function uses wsgiref module which is not intended for the production use.
 This function exposes WSGI interface for people who want to run on the
 production-class WSGI servers like Gunicorn or uWSGI.
 
+**`save_study_note(study: Study, body: string) -> None`**
+
+Save the note (Markdown format) to the Study.
+
+**`save_trial_note(trial: Trial, body: string) -> None`**
+
+Save the note (Markdown format) to the Trial.
+
 </details>
 
 ## Using an official Docker image

--- a/optuna_dashboard/__init__.py
+++ b/optuna_dashboard/__init__.py
@@ -1,5 +1,7 @@
 from ._app import run_server  # noqa
 from ._app import wsgi  # noqa
+from ._note import save_study_note  # noqa
+from ._note import save_trial_note  # noqa
 
 
 __version__ = "0.9.0b1"

--- a/python_tests/test_note.py
+++ b/python_tests/test_note.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from unittest import TestCase
 from unittest.mock import patch
 
+import optuna
 from optuna_dashboard import _note as note
+from optuna_dashboard import save_study_note
+from optuna_dashboard import save_trial_note
 
 
 class NoteTestCase(TestCase):
@@ -19,3 +22,26 @@ class NoteTestCase(TestCase):
                 assert len(attrs) == attr_len
                 actual = note.concat_body(attrs, None)
                 assert dummy_body_str == actual
+
+    def test_save_and_get_study_note(self) -> None:
+        study = optuna.create_study()
+
+        for body, expected_ver in [("version 1", 1), ("version 2", 2)]:
+            with self.subTest(body):
+                save_study_note(study, body)
+                system_attrs = study._storage.get_study_system_attrs(study._study_id)
+                note_dict = note.get_note_from_system_attrs(system_attrs, None)
+                assert note_dict["body"] == body
+                assert note_dict["version"] == expected_ver
+
+    def test_save_and_get_trial_note(self) -> None:
+        study = optuna.create_study()
+        trial = study.ask({"x1": optuna.distributions.FloatDistribution(0, 10)})
+
+        for body, expected_ver in [("version 1", 1), ("version 2", 2)]:
+            with self.subTest(body):
+                save_trial_note(trial, body)
+                system_attrs = study._storage.get_study_system_attrs(study._study_id)
+                note_dict = note.get_note_from_system_attrs(system_attrs, trial._trial_id)
+                assert note_dict["body"] == body
+                assert note_dict["version"] == expected_ver


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Add Python API to save the note.

<img width="1391" alt="Screenshot 2023-01-04 16 31 18" src="https://user-images.githubusercontent.com/5564044/210505195-74cf7b30-b520-451c-b391-612f5fde46c8.png">

```python
import optuna
from optuna_dashboard import run_server, save_trial_note
import textwrap

def objective(trial: optuna.Trial) -> float:
    x1 = trial.suggest_float("x1", 0, 10)
    x2 = trial.suggest_float("x2", 0, 10)

    note = textwrap.dedent(f'''\
    ## Trial {trial._trial_id}

    $$
    y = (x1 - 2)^{{2}} + (x2 - 5)^{{2}} = ({x1} - 2)^{{2}} + ({x2} - 5)^{{2}}
    $$
    ''')
    save_trial_note(trial, note)
    return (x1 - 2) ** 2 + (x2 - 5) ** 2

if __name__ == "__main__":
    storage = optuna.storages.InMemoryStorage()
    study = optuna.create_study(storage=storage)
    study.optimize(objective, n_trials=100)
    run_server(storage, host="localhost", port=8080)
```