### PR TITLE
Fix bug of custom user widgets and enhance artifact support.

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -516,19 +516,25 @@ def get_storage(storage: Union[str, BaseStorage]) -> BaseStorage:
 
 
 def run_server(
-    storage: Union[str, BaseStorage], host: str = "localhost", port: int = 8080
+    storage: Union[str, BaseStorage],
+    host: str = "localhost",
+    port: int = 8080,
+    artifact_backend: Optional[ArtifactBackend] = None,
 ) -> None:
     """Start running optuna-dashboard and blocks until the server terminates.
     This function uses wsgiref module which is not intended for the production
     use. If you want to run optuna-dashboard more secure and/or more fast,
     please use WSGI server like Gunicorn or uWSGI via `wsgi()` function.
     """
-    app = create_app(get_storage(storage))
+    app = create_app(get_storage(storage), artifact_backend=artifact_backend)
     run(app, host=host, port=port)
 
 
-def wsgi(storage: Union[str, BaseStorage]) -> WSGIApplication:
+def wsgi(
+    storage: Union[str, BaseStorage],
+    artifact_backend: Optional[ArtifactBackend] = None,
+) -> WSGIApplication:
     """This function exposes WSGI interface for people who want to run on the
     production-class WSGI servers like Gunicorn or uWSGI.
     """
-    return create_app(get_storage(storage))
+    return create_app(get_storage(storage), artifact_backend=artifact_backend)

--- a/optuna_dashboard/ts/components/ObjectiveForm.tsx
+++ b/optuna_dashboard/ts/components/ObjectiveForm.tsx
@@ -175,11 +175,23 @@ export const ObjectiveForm: FC<{
                     {getObjectiveName(i)} - {widget.description}
                   </FormLabel>
                   <RadioGroup row defaultValue={widget.values.at(0)}>
-                    {widget.choices.map((c, i) => (
+                    {widget.choices.map((c, j) => (
                       <FormControlLabel
                         key={c}
-                        value={widget.values.at(i)}
-                        control={<Radio />}
+                        control={
+                          <Radio
+                            checked={value === widget.values.at(j)}
+                            onChange={(e) => {
+                              const selected = widget.values.at(j)
+                              if (e.target.checked) {
+                                setValue(
+                                  i,
+                                  selected === undefined ? null : selected
+                                )
+                              }
+                            }}
+                          />
+                        }
                         label={c}
                       />
                     ))}
@@ -194,6 +206,10 @@ export const ObjectiveForm: FC<{
                   </FormLabel>
                   <Box sx={{ padding: theme.spacing(0, 2) }}>
                     <Slider
+                      onChange={(e) => {
+                        // @ts-ignore
+                        setValue(i, e.target.value as number)
+                      }}
                       defaultValue={widget.min}
                       min={widget.min}
                       max={widget.max}

--- a/optuna_dashboard/ts/components/StudyDetailBeta.tsx
+++ b/optuna_dashboard/ts/components/StudyDetailBeta.tsx
@@ -60,7 +60,7 @@ export const StudyDetailBeta: FC<{
   }, [])
 
   useEffect(() => {
-    if (reloadInterval < 0 || page === "trialTable" || page === "trialList") {
+    if (reloadInterval < 0 || page === "trialTable") {
       return
     }
     const intervalId = setInterval(function () {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->


## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

While I created a demo app for human-in-the-loop optimization, I found some issues. This PR fixes them.

```python
from __future__ import annotations

import os
import textwrap
import threading
import time
from typing import NoReturn
from wsgiref.simple_server import make_server

import optuna
from PIL import Image
from optuna.trial import TrialState

from optuna_dashboard import ObjectiveChoiceWidget, save_note, ObjectiveSliderWidget
from optuna_dashboard import register_objective_form_widgets
from optuna_dashboard import set_objective_names
from optuna_dashboard import wsgi
from optuna_dashboard.artifact import upload_artifact
from optuna_dashboard.artifact.file_system import FileSystemBackend


storage = optuna.storages.InMemoryStorage()
base_path = os.path.join(os.path.dirname(__file__), "artifact")
artifact_backend = FileSystemBackend(base_path=base_path)


def suggest_and_generate_image(study: optuna.Study) -> None:
    # Ask new parameters
    trial = study.ask()
    r = trial.suggest_int("r", 0, 255)
    g = trial.suggest_int("g", 0, 255)
    b = trial.suggest_int("b", 0, 255)

    # Generate image
    image_path = f"tmp/sample-{trial.number}.png"
    image = Image.new("RGB", (320, 240), color=(r,g,b))
    image.save(image_path)

    # Upload Artifact
    artifact_id = upload_artifact(artifact_backend, trial, image_path)

    # Save Note
    note = textwrap.dedent(f'''\
    ## Trial {trial.number}
    
    ![generated-image](/artifacts/{study._study_id}/{trial._trial_id}/{artifact_id})
    ''')
    save_note(trial, note)


def start_preferential_optimization() -> NoReturn:
    # Create Study
    study = optuna.create_study(
        study_name="Preferential Optimization",
        storage=storage,
        directions=["minimize", "maximize"]
    )
    set_objective_names(study, ["Human Perception Score", "Looks Yellow?"])
    register_objective_form_widgets(study, widgets=[
        ObjectiveChoiceWidget(
            choices=["Good 👍", "Bad 👎"],
            values=[-1, 1],
            description="Please input your score!",
        ),
        ObjectiveSliderWidget(
            min=1,
            max=10,
            step=1,
            description="Score 10 if it looks YELLOW!",
        ),
    ])

    # Start Preferential Optimization
    n_batch = 2
    while True:
        running_trials = study.get_trials(deepcopy=False, states=(TrialState.RUNNING,))
        if len(running_trials) >= n_batch:
            time.sleep(10)
            continue
        suggest_and_generate_image(study)


def main() -> None:
    if not os.path.exists(base_path):
        os.mkdir(base_path)

    # Start Dashboard server on background
    app = wsgi(storage, artifact_backend=artifact_backend)
    httpd = make_server("127.0.0.1", 8080, app)
    thread = threading.Thread(target=httpd.serve_forever)
    thread.start()

    # Run optimize loop
    try:
        start_preferential_optimization()
    except KeyboardInterrupt:
        httpd.shutdown()
        httpd.server_close()
        thread.join()


if __name__ == "__main__":
    main()
```