### PR TITLE
Render an empty graph at `plot_contour()` when the length of trials less than two.

### DIFF
--- a/optuna_dashboard/ts/components/GraphContour.tsx
+++ b/optuna_dashboard/ts/components/GraphContour.tsx
@@ -154,7 +154,7 @@ const plotContour = (
 
   const trials: Trial[] = study ? study.trials : []
   const filteredTrials = trials.filter((t) => filterFunc(t, objectiveId))
-  if (filteredTrials.length === 0 || xParam === null || yParam === null) {
+  if (filteredTrials.length < 2 || xParam === null || yParam === null) {
     plotly.react(plotDomId, [], {
       template: mode === "dark" ? plotlyDarkTemplate : {},
     })

--- a/visual_regression_test.py
+++ b/visual_regression_test.py
@@ -48,6 +48,11 @@ def create_dummy_storage() -> optuna.storages.InMemoryStorage:
 
     study.optimize(objective_single, n_trials=50)
 
+    # A single objective study with a single trial
+    # Refs: https://github.com/optuna/optuna-dashboard/issues/401
+    study = optuna.create_study(study_name="single-trial", storage=storage, sampler=sampler)
+    study.optimize(objective_single, n_trials=1)
+
     # Single-objective study with 1 parameter
     study = optuna.create_study(
         study_name="single-1-param", storage=storage, direction="maximize", sampler=sampler


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Fixes #401 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Like Optuna, we need to render empty graph when the length of trials less than two.

https://github.com/optuna/optuna/blob/1aec995acfe7587f0e90034202817a1fd364007d/optuna/visualization/_contour.py#L305-L310

![Screenshot 2023-02-17 22 47 50](https://user-images.githubusercontent.com/5564044/219673357-eb4715f4-ebd4-4550-b87e-0b6c1c23992a.png)
