### PR TITLE
Handle RuntimeError while calculating importance

### DIFF
--- a/optuna_dashboard/_importance.py
+++ b/optuna_dashboard/_importance.py
@@ -11,8 +11,8 @@ from optuna.storages import BaseStorage
 from optuna.study import Study
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
-
 from optuna_dashboard._cached_extra_study_property import get_cached_extra_study_property
+
 
 _logger = logging.getLogger(__name__)
 
@@ -110,7 +110,9 @@ def get_param_importance_from_trials_cache(
             # when all objective values are same.
             _, union_search_space, _, _ = get_cached_extra_study_property(study_id, trials)
             importance_value = 1 / len(union_search_space)
-            importance = {param_name: importance_value for param_name, distribution in union_search_space}
+            importance = {
+                param_name: importance_value for param_name, distribution in union_search_space
+            }
         converted = convert_to_importance_type(importance, trials)
         param_importance_cache[cache_key] = (n_completed_trials, converted)
     return converted


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
When all objective values are same, fANOVA may raise `RuntimeError("Encountered zero total variance in all trees.")`. We should handle it and avoid to display error message since it's expected.


## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Handling RuntimeError while calculating importance.