### PR TITLE
Fix `getDominatedTrials`

### DIFF
--- a/optuna_dashboard/ts/dominatedTrials.ts
+++ b/optuna_dashboard/ts/dominatedTrials.ts
@@ -27,7 +27,7 @@ export const getDominatedTrials = (
   const dominatedTrials: boolean[] = []
   normalizedValues.forEach((values0: number[], i: number) => {
     const dominated = normalizedValues.some((values1: number[], j: number) => {
-      if (i === j) {
+      if (i === j || values0.every((v, i) => v == values1[i])) {
         return false
       }
       return values0.every((value0: number, k: number) => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
The definition of `a` dominates `b` for multi-objective minimization problems is to meet the following two conditions.
1: `a_i <= b_i` for all `i`
2: `a != b`
This PR adds condition 2, which was missing in `getDominatedTrials`.