### PR TITLE
Remove enqueueSnackbar in makeTrialComplete when successful

### DIFF
--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -492,9 +492,6 @@ export const actionCreator = () => {
           return
         }
         setTrialStateValues(studyId, index, "Complete", values)
-        enqueueSnackbar(`Successfully updated trial (${message})`, {
-          variant: "success",
-        })
       })
       .catch((err) => {
         const reason = err.response?.data.reason


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->



## What does this implement/fix? Explain your changes.
This PR removes the successful snackbars that appear in the lower left because they would interfere with clicking other trials.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/23695091/225566655-1e7dddd6-0a8b-4cf5-902a-08f90130139b.png">

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
