### PR TITLE
Add `get_note()` Python API

### DIFF
--- a/optuna_dashboard/__init__.py
+++ b/optuna_dashboard/__init__.py
@@ -1,6 +1,7 @@
 from ._app import run_server  # noqa
 from ._app import wsgi  # noqa
 from ._named_objectives import set_objective_names  # noqa
+from ._note import get_note  # noqa
 from ._note import save_note  # noqa
 from ._objective_form_widget import ObjectiveChoiceWidget  # noqa
 from ._objective_form_widget import ObjectiveSliderWidget  # noqa

--- a/optuna_dashboard/_note.py
+++ b/optuna_dashboard/_note.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:
     from typing import Any
     from typing import Optional
     from typing import TypedDict
-    from typing import Union
 
     NoteType = TypedDict(
         "NoteType",
@@ -24,7 +23,7 @@ if TYPE_CHECKING:
 SYSTEM_ATTR_MAX_LENGTH = 2045
 
 
-def save_note(study_or_trial: Union[optuna.Study, optuna.Trial], body: str) -> None:
+def save_note(study_or_trial: optuna.Study | optuna.Trial, body: str) -> None:
     """Save the note (Markdown format) to the Study or Trial.
 
     Example:
@@ -68,6 +67,37 @@ def save_note(study_or_trial: Union[optuna.Study, optuna.Trial], body: str) -> N
     system_attrs = storage.get_study_system_attrs(study_id)
     next_ver = system_attrs.get(note_ver_key(trial_id), 0) + 1
     save_note_with_version(storage, study_id, trial_id, next_ver, body)
+
+
+def get_note(study_or_trial: optuna.Study | optuna.Trial) -> str:
+    """Get the note (Markdown format) from the Study or Trial.
+
+    Example:
+
+       .. code-block:: python
+
+          import optuna
+          from optuna_dashboard import save_note, get_note
+
+          study = optuna.create_study()
+          save_note(study, "**Hello** World")
+
+          text = get_note(study)
+          print(text)  # '**Hello** World'
+    """
+    storage: BaseStorage
+    study_id: int
+    trial_id: Optional[int] = None
+    if isinstance(study_or_trial, optuna.Study):
+        storage = study_or_trial._storage
+        study_id = study_or_trial._study_id
+    else:
+        storage = study_or_trial.storage
+        study_id = study_or_trial.study._study_id
+        trial_id = study_or_trial._trial_id
+    system_attrs = storage.get_study_system_attrs(study_id)
+    note = get_note_from_system_attrs(system_attrs, trial_id)
+    return note["body"]
 
 
 def note_ver_key(trial_id: Optional[int]) -> str:

--- a/python_tests/test_note.py
+++ b/python_tests/test_note.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import optuna
 from optuna_dashboard import _note as note
+from optuna_dashboard import get_note
 from optuna_dashboard import save_note
 
 
@@ -29,6 +30,10 @@ class NoteTestCase(TestCase):
             with self.subTest(body):
                 save_note(study, body)
                 system_attrs = study._storage.get_study_system_attrs(study._study_id)
+
+                actual = get_note(study)
+                assert actual == body
+
                 note_dict = note.get_note_from_system_attrs(system_attrs, None)
                 assert note_dict["body"] == body
                 assert note_dict["version"] == expected_ver
@@ -41,6 +46,10 @@ class NoteTestCase(TestCase):
             with self.subTest(body):
                 save_note(trial, body)
                 system_attrs = study._storage.get_study_system_attrs(study._study_id)
+
+                actual = get_note(trial)
+                assert actual == body
+
                 note_dict = note.get_note_from_system_attrs(system_attrs, trial._trial_id)
                 assert note_dict["body"] == body
                 assert note_dict["version"] == expected_ver


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs https://github.com/optuna/optuna/issues/4548#issuecomment-1487222142

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Add Python API to get the note string. See https://github.com/optuna/optuna/issues/4548#issuecomment-1487222142 for details.