### PR TITLE
Add dict_to_form_widget

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,6 +23,7 @@ Human-in-the-loop
    :nosignatures:
 
    optuna_dashboard.register_objective_form_widgets
+   optuna_dashboard.dict_to_form_widget
    optuna_dashboard.ChoiceWidget
    optuna_dashboard.SliderWidget
    optuna_dashboard.TextInputWidget

--- a/optuna_dashboard/__init__.py
+++ b/optuna_dashboard/__init__.py
@@ -1,6 +1,7 @@
 from ._app import run_server  # noqa
 from ._app import wsgi  # noqa
 from ._form_widget import ChoiceWidget  # noqa
+from ._form_widget import dict_to_form_widget  # noqa
 from ._form_widget import ObjectiveChoiceWidget  # noqa
 from ._form_widget import ObjectiveSliderWidget  # noqa
 from ._form_widget import ObjectiveTextInputWidget  # noqa

--- a/python_tests/test_form_widget.py
+++ b/python_tests/test_form_widget.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest import TestCase
+
+from optuna_dashboard import ChoiceWidget
+from optuna_dashboard import dict_to_form_widget
+from optuna_dashboard import ObjectiveUserAttrRef
+from optuna_dashboard import SliderWidget
+from optuna_dashboard import TextInputWidget
+
+
+class FormWidgetsTestCase(TestCase):
+    def test_widget_to_dict_from_dict(self) -> None:
+        widgets = [
+            ChoiceWidget(choices=["Good", "Bad"], values=[1, -1]),
+            ChoiceWidget(
+                choices=["Good", "Bad"],
+                values=[1, -1],
+                description="description",
+                user_attr_key="key",
+            ),
+            SliderWidget(min=1, max=5),
+            SliderWidget(
+                min=1,
+                max=5,
+                step=1,
+                labels=[(1, "Bad"), (5, "Good")],
+                description="description",
+                user_attr_key="key",
+            ),
+            TextInputWidget(),
+            TextInputWidget(description="description", user_attr_key="key"),
+            ObjectiveUserAttrRef(key="key"),
+        ]
+
+        for i, widget in enumerate(widgets):
+            with self.subTest(f"{widget.__class__}-{i}"):
+                d = widget.to_dict()
+                restored = dict_to_form_widget(d)
+                assert widget == restored


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Provide an api to restore form widgets from the dictionary object.