### PR TITLE
Remove `user_attr_key` attribute from `ObjectiveUserAttrRef`

### DIFF
--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -150,14 +150,13 @@ class TextInputWidget:
 @dataclass
 class ObjectiveUserAttrRef:
     key: str
-    # TODO(c-bata): Remove this attribute
-    user_attr_key: Optional[str] = None
 
     def to_dict(self) -> UserAttrRefJSON:
         return {
             "type": "user_attr",
             "key": self.key,
-            "user_attr_key": self.user_attr_key,
+            # Set 'user_attr_key' to simplify the frontend source code.
+            "user_attr_key": self.key,
         }
 
     @classmethod

--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -46,10 +46,7 @@ if TYPE_CHECKING:
         "TextInputWidgetJSON",
         {"type": Literal["text"], "description": Optional[str], "user_attr_key": Optional[str]},
     )
-    UserAttrRefJSON = TypedDict(
-        "UserAttrRefJSON",
-        {"type": Literal["user_attr"], "key": str, "user_attr_key": Optional[str]},
-    )
+    UserAttrRefJSON = TypedDict("UserAttrRefJSON", {"type": Literal["user_attr"], "key": str})
     FormWidgetJSON = TypedDict(
         "FormWidgetJSON",
         {
@@ -156,8 +153,6 @@ class ObjectiveUserAttrRef:
         return {
             "type": "user_attr",
             "key": self.key,
-            # Set 'user_attr_key' to simplify the frontend source code.
-            "user_attr_key": self.key,
         }
 
     @classmethod
@@ -202,7 +197,9 @@ def register_objective_form_widgets(
 ) -> None:
     if len(study.directions) != len(widgets):
         raise ValueError("The length of actions must be the same with the number of objectives.")
-    if any(not isinstance(w, ObjectiveUserAttrRef) and w.user_attr_key is not None for w in widgets):
+    if any(
+        not isinstance(w, ObjectiveUserAttrRef) and w.user_attr_key is not None for w in widgets
+    ):
         warnings.warn("`user_attr_key` specified, but it will not be used.")
     form_widgets: FormWidgetJSON = {
         "output_type": "objective",
@@ -218,7 +215,7 @@ def register_user_attr_form_widgets(
     widget_dicts: list[Union[ChoiceWidgetJSON, SliderWidgetJSON, TextInputWidgetJSON]] = []
     for w in widgets:
         if isinstance(w, ObjectiveUserAttrRef):
-            raise ValueError("ObjectiveUserAttrRef can't be specified in register_user_attr_form_widgets.")
+            raise ValueError("ObjectiveUserAttrRef can't be specified.")
         if w.user_attr_key is None:
             raise ValueError("`user_attr_key` is not specified.")
         user_attr_keys.add(w.user_attr_key)

--- a/optuna_dashboard/ts/types/index.d.ts
+++ b/optuna_dashboard/ts/types/index.d.ts
@@ -157,20 +157,28 @@ type ObjectiveTextInputWidget = {
 type ObjectiveUserAttrRef = {
   type: "user_attr"
   key: string
-  user_attr_key?: string
 }
 
-// TODO(kenshin): Rename this type to FormWidget or something.
 type ObjectiveFormWidget =
   | ObjectiveChoiceWidget
   | ObjectiveSliderWidget
   | ObjectiveTextInputWidget
   | ObjectiveUserAttrRef
 
-type FormWidgets = {
-  output_type: "objective" | "user_attr"
-  widgets: ObjectiveFormWidget[]
-}
+type UserAttrFormWidget =
+  | ObjectiveChoiceWidget
+  | ObjectiveSliderWidget
+  | ObjectiveTextInputWidget
+
+type FormWidgets =
+  | {
+      output_type: "objective"
+      widgets: ObjectiveFormWidget[]
+    }
+  | {
+      output_type: "user_attr"
+      widgets: UserAttrFormWidget[]
+    }
 
 type StudyDetail = {
   id: number


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #411 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
It is not obvious that how `key` and `user_attr_key` attributes are different. I remove `user_attr_key` attribute from the argument of `ObjectiveUserAttrRef`.