### PR TITLE
Allow `TextInputWidget` to accept strings for user attribute forms.

### DIFF
--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -216,7 +216,7 @@ def register_objective_form_widgets(
     ):
         warnings.warn("`user_attr_key` specified, but it will not be used.")
     if any(
-        isinstance(w, TextInputWidget) and w.optional is False for w in widgets
+        isinstance(w, TextInputWidget) and w.optional for w in widgets
     ):
         raise ValueError("TextInputWidget.optional must be False.")
     form_widgets: FormWidgetJSON = {

--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -46,7 +46,7 @@ if TYPE_CHECKING:
     )
     TextInputWidgetJSON = TypedDict(
         "TextInputWidgetJSON",
-        {"type": Literal["text"], "description": Optional[str], "user_attr_key": Optional[str]},
+        {"type": Literal["text"], "description": Optional[str], "user_attr_key": Optional[str], "optional": bool},
     )
     UserAttrRefJSON = TypedDict("UserAttrRefJSON", {"type": Literal["user_attr"], "key": str})
     FormWidgetJSON = TypedDict(
@@ -130,12 +130,14 @@ class SliderWidget:
 class TextInputWidget:
     description: Optional[str] = None
     user_attr_key: Optional[str] = None
+    optional: bool = False
 
     def to_dict(self) -> TextInputWidgetJSON:
         return {
             "type": "text",
             "description": self.description,
             "user_attr_key": self.user_attr_key,
+            "optional": self.optional,
         }
 
     @classmethod
@@ -144,6 +146,7 @@ class TextInputWidget:
         return cls(
             description=d.get("description"),
             user_attr_key=d.get("user_attr_key"),
+            optional=d.get("optional", False),
         )
 
 
@@ -212,6 +215,10 @@ def register_objective_form_widgets(
         not isinstance(w, ObjectiveUserAttrRef) and w.user_attr_key is not None for w in widgets
     ):
         warnings.warn("`user_attr_key` specified, but it will not be used.")
+    if any(
+        isinstance(w, TextInputWidget) and w.optional is False for w in widgets
+    ):
+        raise ValueError("TextInputWidget.optional must be False.")
     form_widgets: FormWidgetJSON = {
         "output_type": "objective",
         "widgets": [w.to_dict() for w in widgets],

--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -46,7 +46,12 @@ if TYPE_CHECKING:
     )
     TextInputWidgetJSON = TypedDict(
         "TextInputWidgetJSON",
-        {"type": Literal["text"], "description": Optional[str], "user_attr_key": Optional[str], "optional": bool},
+        {
+            "type": Literal["text"],
+            "description": Optional[str],
+            "user_attr_key": Optional[str],
+            "optional": bool,
+        },
     )
     UserAttrRefJSON = TypedDict("UserAttrRefJSON", {"type": Literal["user_attr"], "key": str})
     FormWidgetJSON = TypedDict(
@@ -351,9 +356,7 @@ def register_objective_form_widgets(
         not isinstance(w, ObjectiveUserAttrRef) and w.user_attr_key is not None for w in widgets
     ):
         warnings.warn("`user_attr_key` specified, but it will not be used.")
-    if any(
-        isinstance(w, TextInputWidget) and w.optional for w in widgets
-    ):
+    if any(isinstance(w, TextInputWidget) and w.optional for w in widgets):
         raise ValueError("TextInputWidget.optional must be False.")
     form_widgets: FormWidgetJSON = {
         "output_type": "objective",

--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -185,6 +185,7 @@ class TextInputWidget:
         description: A description of the text input field.
         user_attr_key: The key used by `register_user_attr_form_widgets`.
             Form output is saved as `trial.user_attrs[user_attr_key]`. Defaults to None.
+        optional: If True, an empty string is acceptable.
 
     Example:
         .. code-block:: python

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -91,6 +91,8 @@ def serialize_attrs(attrs: dict[str, Any]) -> list[Attribute]:
         value: str
         if isinstance(v, bytes):
             value = "<binary object>"
+        elif isinstance(v, str):
+            value = v
         else:
             value = json.dumps(v)
             value = value[:MAX_ATTR_LENGTH] if len(value) > MAX_ATTR_LENGTH else value

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -155,7 +155,7 @@ export const actionCreator = () => {
   const setTrialUserAttrs = (
     studyId: number,
     index: number,
-    user_attrs: { [key: string]: number }
+    user_attrs: { [key: string]: number | string }
   ) => {
     const newTrial: Trial = Object.assign(
       {},
@@ -529,7 +529,7 @@ export const actionCreator = () => {
   const saveTrialUserAttrs = (
     studyId: number,
     trialId: number,
-    user_attrs: { [key: string]: number }
+    user_attrs: { [key: string]: string | number }
   ): void => {
     console.log("user_attrs", user_attrs)
     const message = `id=${trialId}, user_attrs=${JSON.stringify(user_attrs)}`

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -531,7 +531,6 @@ export const actionCreator = () => {
     trialId: number,
     user_attrs: { [key: string]: string | number }
   ): void => {
-    console.log("user_attrs", user_attrs)
     const message = `id=${trialId}, user_attrs=${JSON.stringify(user_attrs)}`
     saveTrialUserAttrsAPI(trialId, user_attrs)
       .then(() => {

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -283,7 +283,7 @@ export const tellTrialAPI = (
 
 export const saveTrialUserAttrsAPI = (
   trialId: number,
-  user_attrs: { [key: string]: number }
+  user_attrs: { [key: string]: number | string }
 ): Promise<void> => {
   const req = { user_attrs: user_attrs }
 

--- a/optuna_dashboard/ts/components/ObjectiveForm.tsx
+++ b/optuna_dashboard/ts/components/ObjectiveForm.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useState } from "react"
+import React, { FC, ReactNode, useMemo, useState } from "react"
 import {
   Typography,
   Box,
@@ -16,6 +16,12 @@ import {
 import { DebouncedInputTextField } from "./Debounce"
 import { actionCreator } from "../action"
 
+type WidgetState = {
+  isValid: boolean
+  value: number | string
+  render: () => ReactNode
+}
+
 export const ObjectiveForm: FC<{
   trial: Trial
   directions: StudyDirection[]
@@ -24,61 +30,63 @@ export const ObjectiveForm: FC<{
 }> = ({ trial, directions, names, formWidgets }) => {
   const theme = useTheme()
   const action = actionCreator()
-  const [values, setValues] = useState<(number | string)[]>(
-    formWidgets.widgets.map((widget) => {
-      if (widget.type === "text") {
-        return ""
-      } else if (widget.type === "choice") {
-        const value = widget.values.at(0)
-        if (value === undefined) {
-          console.error("Must not reach ehere")
-          return 0
-        }
-        return value
-      } else if (widget.type === "slider") {
-        return widget.min
-      } else if (widget.type === "user_attr") {
-        const attr = trial.user_attrs.find((attr) => attr.key == widget.key)
-        if (attr === undefined) {
-          return 0
-        } else {
-          const n = Number(attr.value)
-          return isNaN(n) ? 0 : n
-        }
-      } else {
-        console.error("Must not reach here")
-        return ""
-      }
-    })
-  )
 
-  const setValue = (objectiveId: number, value: number | string) => {
-    const newValues = [...values]
-    if (newValues.length <= objectiveId) {
-      return
+  const getMetricName = (i: number): string => {
+    if (formWidgets.output_type == "objective") {
+      if (names.at(i) !== undefined) {
+        return names[i]
+      }
+      return directions.length == 1 ? "Objective" : `Objective ${i}`
+    } else if (formWidgets.output_type == "user_attr") {
+      const key = formWidgets.widgets.at(i)?.user_attr_key
+      if (key !== undefined) {
+        return key
+      }
     }
-    newValues[objectiveId] = value
-    setValues(newValues)
+    console.error("Must not reach here")
+    return "Unknown"
   }
 
+  const widgetStates = formWidgets.widgets
+    .map((w, i) => {
+      const key = `${formWidgets.output_type}-${i}`
+      if (w.type === "text") {
+        return useTextInputWidget(
+          key,
+          formWidgets.output_type,
+          w,
+          getMetricName(i)
+        )
+      } else if (w.type === "choice") {
+        return useChoiceWidget(
+          key,
+          formWidgets.output_type,
+          w,
+          getMetricName(i)
+        )
+      } else if (w.type === "slider") {
+        return useSliderWidget(
+          key,
+          formWidgets.output_type,
+          w,
+          getMetricName(i)
+        )
+      } else if (w.type === "user_attr") {
+        return useUserAttrRefWidget(key, w, getMetricName(i), trial)
+      }
+      console.error("Must not reach here")
+      return undefined
+    })
+    .filter((w): w is WidgetState => w !== undefined)
+
   const disableSubmit = useMemo<boolean>(
-    () =>
-      values.findIndex((v, i) => {
-        const w = formWidgets.widgets[i]
-        if (
-          formWidgets.output_type === "user_attr" &&
-          w.type === "text" &&
-          w.optional
-        ) {
-          return false
-        }
-        return v === null
-      }) >= 0,
-    [values, formWidgets]
+    () => !widgetStates.every((ws) => ws.isValid),
+    [widgetStates]
   )
 
   const handleSubmit = (e: React.MouseEvent<HTMLButtonElement>): void => {
     e.preventDefault()
+    const values = widgetStates.map((ws) => ws.value)
     if (formWidgets.output_type == "objective") {
       const filtered = values.filter<number>((v): v is number => v !== null)
       if (filtered.length !== directions.length) {
@@ -94,23 +102,6 @@ export const ObjectiveForm: FC<{
       )
       action.saveTrialUserAttrs(trial.study_id, trial.trial_id, user_attrs)
     }
-  }
-
-  const getMetricName = (i: number): string => {
-    if (formWidgets.output_type == "objective") {
-      const n = names.at(i)
-      if (n !== undefined) {
-        return n
-      }
-      if (directions.length == 1) {
-        return `Objective`
-      } else {
-        return `Objective ${i}`
-      }
-    } else if (formWidgets.output_type == "user_attr") {
-      return formWidgets.widgets[i].user_attr_key as string
-    }
-    return "Unkown metric name"
   }
 
   const headerText =
@@ -138,97 +129,7 @@ export const ObjectiveForm: FC<{
             p: theme.spacing(1),
           }}
         >
-          {formWidgets.widgets.map((widget, i) => {
-            const value = values.at(i) || ""
-            const key = `objective-${i}`
-            if (widget.type === "text") {
-              return (
-                <TextInputWidget
-                  key={key}
-                  metricName={getMetricName(i)}
-                  widget={widget}
-                  widgetType={formWidgets.output_type}
-                  setValue={(value) => {
-                    setValue(i, value)
-                  }}
-                  value={value}
-                />
-              )
-            } else if (widget.type === "choice") {
-              return (
-                <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
-                  <FormLabel>
-                    {getMetricName(i)} - {widget.description}
-                  </FormLabel>
-                  <RadioGroup row defaultValue={widget.values.at(0)}>
-                    {widget.choices.map((c, j) => (
-                      <FormControlLabel
-                        key={c}
-                        control={
-                          <Radio
-                            checked={value === widget.values.at(j)}
-                            onChange={(e) => {
-                              const selected = widget.values.at(j)
-                              if (selected === undefined) {
-                                console.error("Must not reach here.")
-                              }
-                              if (e.target.checked) {
-                                setValue(i, selected || 0)
-                              }
-                            }}
-                          />
-                        }
-                        label={c}
-                      />
-                    ))}
-                  </RadioGroup>
-                </FormControl>
-              )
-            } else if (widget.type === "slider") {
-              return (
-                <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
-                  <FormLabel>
-                    {getMetricName(i)} - {widget.description}
-                  </FormLabel>
-                  <Box sx={{ padding: theme.spacing(0, 2) }}>
-                    <Slider
-                      onChange={(e) => {
-                        // @ts-ignore
-                        setValue(i, e.target.value as number)
-                      }}
-                      defaultValue={widget.min}
-                      min={widget.min}
-                      max={widget.max}
-                      step={widget.step}
-                      marks={
-                        widget.labels === null || widget.labels.length == 0
-                          ? true
-                          : widget.labels
-                      }
-                      valueLabelDisplay="auto"
-                    />
-                  </Box>
-                </FormControl>
-              )
-            } else if (widget.type === "user_attr") {
-              return (
-                <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
-                  <FormLabel>{getMetricName(i)}</FormLabel>
-                  <TextField
-                    inputProps={{ readOnly: true }}
-                    value={value || undefined}
-                    error={value === null}
-                    helperText={
-                      value === null || value === undefined
-                        ? `This objective value is referred from trial.user_attrs[${widget.key}].`
-                        : ""
-                    }
-                  />
-                </FormControl>
-              )
-            }
-            return null
-          })}
+          {widgetStates.map((ws) => ws.render())}
           <Box
             sx={{
               display: "flex",
@@ -262,14 +163,22 @@ export const ObjectiveForm: FC<{
   )
 }
 
-const TextInputWidget: FC<{
-  widget: ObjectiveTextInputWidget
-  widgetType: "user_attr" | "objective"
+export const useTextInputWidget = (
+  key: string,
+  widgetType: "user_attr" | "objective",
+  widget: ObjectiveTextInputWidget,
   metricName: string
-  value: number | string
-  setValue: (value: number | string) => void
-}> = ({ widget, widgetType, metricName, value, setValue }) => {
+): WidgetState => {
   const theme = useTheme()
+  const [value, setValue] = useState<number | string>("")
+  const isValid = useMemo(
+    () =>
+      widgetType === "user_attr"
+        ? value !== "" || widget.optional
+        : value !== "" && !isNaN(Number(value)),
+    [widget, value]
+  )
+
   const inputProps =
     widgetType === "objective"
       ? {
@@ -278,9 +187,8 @@ const TextInputWidget: FC<{
       : undefined
   const helperText =
     !widget.optional && value === "" ? `Please input the float number.` : ""
-
-  return (
-    <FormControl sx={{ margin: theme.spacing(1, 2) }}>
+  const render = () => (
+    <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
       <FormLabel>
         {metricName} - {widget.description}
       </FormLabel>
@@ -294,7 +202,7 @@ const TextInputWidget: FC<{
           const n = Number(s)
           if (s.length > 0 && valid && !isNaN(n)) {
             setValue(n)
-          } else if (value === "") {
+          } else {
             setValue("")
           }
         }}
@@ -310,6 +218,124 @@ const TextInputWidget: FC<{
       />
     </FormControl>
   )
+  return { isValid, value, render }
+}
+
+export const useChoiceWidget = (
+  key: string,
+  widgetType: "user_attr" | "objective",
+  widget: ObjectiveChoiceWidget,
+  metricName: string
+): WidgetState => {
+  const theme = useTheme()
+  const [value, setValue] = useState<number>(widget.values[0])
+  const render = () => (
+    <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
+      <FormLabel>
+        {metricName} - {widget.description}
+      </FormLabel>
+      <RadioGroup row defaultValue={widget.values.at(0)}>
+        {widget.choices.map((c, j) => (
+          <FormControlLabel
+            key={c}
+            control={
+              <Radio
+                checked={value === widget.values.at(j)}
+                onChange={(e) => {
+                  const selected = widget.values.at(j)
+                  if (selected === undefined) {
+                    console.error("Must not reach here.")
+                    return
+                  }
+                  if (e.target.checked) {
+                    setValue(selected)
+                  }
+                }}
+              />
+            }
+            label={c}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  )
+  return { isValid: true, value, render }
+}
+
+export const useSliderWidget = (
+  key: string,
+  widgetType: "user_attr" | "objective",
+  widget: ObjectiveSliderWidget,
+  metricName: string
+): WidgetState => {
+  const theme = useTheme()
+  const [value, setValue] = useState<number>(widget.min)
+  const render = () => (
+    <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
+      <FormLabel>
+        {metricName} - {widget.description}
+      </FormLabel>
+      <Box sx={{ padding: theme.spacing(0, 2) }}>
+        <Slider
+          onChange={(e) => {
+            // @ts-ignore
+            setValue(e.target.value as number)
+          }}
+          defaultValue={widget.min}
+          min={widget.min}
+          max={widget.max}
+          step={widget.step}
+          marks={
+            widget.labels === null || widget.labels.length == 0
+              ? true
+              : widget.labels
+          }
+          valueLabelDisplay="auto"
+        />
+      </Box>
+    </FormControl>
+  )
+  return { isValid: true, value, render }
+}
+
+export const useUserAttrRefWidget = (
+  key: string,
+  widget: ObjectiveUserAttrRef,
+  metricName: string,
+  trial: Trial
+): WidgetState => {
+  const theme = useTheme()
+  const value = useMemo(() => {
+    const attr = trial.user_attrs.find((attr) => attr.key === widget.key)
+    if (attr === undefined) {
+      return null
+    }
+    const n = Number(attr.value)
+    if (isNaN(n)) {
+      return null
+    }
+    return n
+  }, [trial.user_attrs])
+  const render = () => (
+    <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
+      <FormLabel>{metricName}</FormLabel>
+      <TextField
+        inputProps={{ readOnly: true }}
+        value={value || ""}
+        error={value === null}
+        helperText={
+          value === null
+            ? `This objective value is referred from trial.user_attrs[${widget.key}].`
+            : ""
+        }
+      />
+    </FormControl>
+  )
+  return {
+    isValid: value !== null,
+    value: value !== null ? value : "",
+    render,
+  }
 }
 
 export const ReadonlyObjectiveForm: FC<{
@@ -321,19 +347,18 @@ export const ReadonlyObjectiveForm: FC<{
   const theme = useTheme()
   const getMetricName = (i: number): string => {
     if (formWidgets.output_type == "objective") {
-      const n = names.at(i)
-      if (n !== undefined) {
-        return n
+      if (names.at(i) !== undefined) {
+        return names[i]
       }
-      if (directions.length == 1) {
-        return `Objective`
-      } else {
-        return `Objective ${i}`
-      }
+      return directions.length == 1 ? "Objective" : `Objective ${i}`
     } else if (formWidgets.output_type == "user_attr") {
-      return formWidgets.widgets[i].user_attr_key as string
+      const key = formWidgets.widgets.at(i)?.user_attr_key
+      if (key !== undefined) {
+        return key
+      }
     }
-    return "Unkown metric name"
+    console.error("Must not reach here")
+    return "Unknown"
   }
 
   const getValue = (i: number): string | TrialValueNumber => {
@@ -441,6 +466,7 @@ export const ReadonlyObjectiveForm: FC<{
                   <TextField
                     inputProps={{ readOnly: true }}
                     value={trial.values?.at(i)}
+                    disabled
                   />
                 </FormControl>
               )

--- a/optuna_dashboard/ts/components/ObjectiveForm.tsx
+++ b/optuna_dashboard/ts/components/ObjectiveForm.tsx
@@ -31,48 +31,19 @@ export const ObjectiveForm: FC<{
   const theme = useTheme()
   const action = actionCreator()
 
-  const getMetricName = (i: number): string => {
-    if (formWidgets.output_type == "objective") {
-      if (names.at(i) !== undefined) {
-        return names[i]
-      }
-      return directions.length == 1 ? "Objective" : `Objective ${i}`
-    } else if (formWidgets.output_type == "user_attr") {
-      const key = formWidgets.widgets.at(i)?.user_attr_key
-      if (key !== undefined) {
-        return key
-      }
-    }
-    console.error("Must not reach here")
-    return "Unknown"
-  }
-
   const widgetStates = formWidgets.widgets
     .map((w, i) => {
       const key = `${formWidgets.output_type}-${i}`
+      const outputType = formWidgets.output_type
+      const metricName = getMetricName(formWidgets, names, directions, i)
       if (w.type === "text") {
-        return useTextInputWidget(
-          key,
-          formWidgets.output_type,
-          w,
-          getMetricName(i)
-        )
+        return useTextInputWidget(key, outputType, w, metricName)
       } else if (w.type === "choice") {
-        return useChoiceWidget(
-          key,
-          formWidgets.output_type,
-          w,
-          getMetricName(i)
-        )
+        return useChoiceWidget(key, outputType, w, metricName)
       } else if (w.type === "slider") {
-        return useSliderWidget(
-          key,
-          formWidgets.output_type,
-          w,
-          getMetricName(i)
-        )
+        return useSliderWidget(key, outputType, w, metricName)
       } else if (w.type === "user_attr") {
-        return useUserAttrRefWidget(key, w, getMetricName(i), trial)
+        return useUserAttrRefWidget(key, w, metricName, trial)
       }
       console.error("Must not reach here")
       return undefined
@@ -345,22 +316,6 @@ export const ReadonlyObjectiveForm: FC<{
   formWidgets: FormWidgets
 }> = ({ trial, directions, names, formWidgets }) => {
   const theme = useTheme()
-  const getMetricName = (i: number): string => {
-    if (formWidgets.output_type == "objective") {
-      if (names.at(i) !== undefined) {
-        return names[i]
-      }
-      return directions.length == 1 ? "Objective" : `Objective ${i}`
-    } else if (formWidgets.output_type == "user_attr") {
-      const key = formWidgets.widgets.at(i)?.user_attr_key
-      if (key !== undefined) {
-        return key
-      }
-    }
-    console.error("Must not reach here")
-    return "Unknown"
-  }
-
   const getValue = (i: number): string | TrialValueNumber => {
     if (formWidgets.output_type === "user_attr") {
       const widget = formWidgets.widgets[i] as UserAttrFormWidget
@@ -397,11 +352,12 @@ export const ReadonlyObjectiveForm: FC<{
         >
           {formWidgets.widgets.map((widget, i) => {
             const key = `objective-${i}`
+            const metricName = getMetricName(formWidgets, names, directions, i)
             if (widget.type === "text") {
               return (
                 <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
                   <FormLabel>
-                    {getMetricName(i)} - {widget.description}
+                    {metricName} - {widget.description}
                   </FormLabel>
                   <TextField
                     inputProps={{ readOnly: true }}
@@ -413,7 +369,7 @@ export const ReadonlyObjectiveForm: FC<{
               return (
                 <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
                   <FormLabel>
-                    {getMetricName(i)} - {widget.description}
+                    {metricName} - {widget.description}
                   </FormLabel>
                   <RadioGroup row defaultValue={trial.values?.at(i)}>
                     {widget.choices.map((c, j) => (
@@ -438,7 +394,7 @@ export const ReadonlyObjectiveForm: FC<{
               return (
                 <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
                   <FormLabel>
-                    {getMetricName(i)} - {widget.description}
+                    {metricName} - {widget.description}
                   </FormLabel>
                   <Box sx={{ padding: theme.spacing(0, 2) }}>
                     <Slider
@@ -462,7 +418,7 @@ export const ReadonlyObjectiveForm: FC<{
             } else if (widget.type === "user_attr") {
               return (
                 <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
-                  <FormLabel>{getMetricName(i)}</FormLabel>
+                  <FormLabel>{metricName}</FormLabel>
                   <TextField
                     inputProps={{ readOnly: true }}
                     value={trial.values?.at(i)}
@@ -477,4 +433,25 @@ export const ReadonlyObjectiveForm: FC<{
       </Box>
     </>
   )
+}
+
+const getMetricName = (
+  formWidgets: FormWidgets,
+  names: string[],
+  directions: StudyDirection[],
+  i: number
+): string => {
+  if (formWidgets.output_type == "objective") {
+    if (names.at(i) !== undefined) {
+      return names[i]
+    }
+    return directions.length == 1 ? "Objective" : `Objective ${i}`
+  } else if (formWidgets.output_type == "user_attr") {
+    const key = formWidgets.widgets.at(i)?.user_attr_key
+    if (key !== undefined) {
+      return key
+    }
+  }
+  console.error("Must not reach here")
+  return "Unknown"
 }

--- a/optuna_dashboard/ts/components/TrialFormWidgets.tsx
+++ b/optuna_dashboard/ts/components/TrialFormWidgets.tsx
@@ -27,10 +27,17 @@ export const TrialFormWidgets: FC<{
   trial: Trial
   objectiveNames: string[]
   directions: StudyDirection[]
-  formWidgets: FormWidgets
+  formWidgets?: FormWidgets
 }> = ({ trial, objectiveNames, directions, formWidgets }) => {
+  if (
+    formWidgets === undefined ||
+    trial.state === "Pruned" ||
+    trial.state === "Fail"
+  ) {
+    return null
+  }
   const theme = useTheme()
-  const formWidgetLoading = useTrialUpdatingValue(trial.trial_id)
+  const trialNowUpdating = useTrialUpdatingValue(trial.trial_id)
   const headerText =
     formWidgets.output_type === "user_attr"
       ? "Set User Attributes Form"
@@ -51,6 +58,7 @@ export const TrialFormWidgets: FC<{
     console.error("Must not reach here")
     return "Unknown"
   })
+
   return (
     <>
       <Typography
@@ -59,28 +67,24 @@ export const TrialFormWidgets: FC<{
       >
         {headerText}
       </Typography>
-      {trial.state === "Running" &&
-        !formWidgetLoading &&
-        directions.length > 0 && (
-          <_FormWidgets
-            trial={trial}
-            widgetNames={widgetNames}
-            formWidgets={formWidgets}
-          />
-        )}
-      {(trial.state === "Complete" || formWidgetLoading) &&
-        directions.length > 0 && (
-          <ReadonlyFormWidgets
-            trial={trial}
-            widgetNames={widgetNames}
-            formWidgets={formWidgets}
-          />
-        )}
+      {trial.state === "Running" && !trialNowUpdating ? (
+        <UpdatableFormWidgets
+          trial={trial}
+          widgetNames={widgetNames}
+          formWidgets={formWidgets}
+        />
+      ) : (
+        <ReadonlyFormWidgets
+          trial={trial}
+          widgetNames={widgetNames}
+          formWidgets={formWidgets}
+        />
+      )}
     </>
   )
 }
 
-const _FormWidgets: FC<{
+const UpdatableFormWidgets: FC<{
   trial: Trial
   widgetNames: string[]
   formWidgets: FormWidgets

--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -274,14 +274,12 @@ const TrialListDetail: FC<{
         latestNote={trial.note}
         cardSx={{ marginBottom: theme.spacing(2) }}
       />
-      {formWidgets !== undefined && (
-        <TrialFormWidgets
-          trial={trial}
-          directions={directions}
-          objectiveNames={objectiveNames}
-          formWidgets={formWidgets}
-        />
-      )}
+      <TrialFormWidgets
+        trial={trial}
+        directions={directions}
+        objectiveNames={objectiveNames}
+        formWidgets={formWidgets}
+      />
       <Box
         sx={{
           marginBottom: theme.spacing(2),

--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -39,7 +39,7 @@ import { TrialNote } from "./Note"
 import { useHistory, useLocation } from "react-router-dom"
 import ListItemIcon from "@mui/material/ListItemIcon"
 import { useRecoilValue } from "recoil"
-import { artifactIsAvailable } from "../state"
+import { artifactIsAvailable, useTrialUpdatingValue } from "../state"
 import { actionCreator } from "../action"
 import { useDeleteArtifactDialog } from "./DeleteArtifactDialog"
 import { ObjectiveForm, ReadonlyObjectiveForm } from "./ObjectiveForm"
@@ -147,6 +147,7 @@ const TrialListDetail: FC<{
 }> = ({ trial, isBestTrial, directions, objectiveNames, formWidgets }) => {
   const theme = useTheme()
   const artifactEnabled = useRecoilValue<boolean>(artifactIsAvailable)
+  const formWidgetLoading = useTrialUpdatingValue(trial.trial_id)
   const startMs = trial.datetime_start?.getTime()
   const completeMs = trial.datetime_complete?.getTime()
 
@@ -275,6 +276,7 @@ const TrialListDetail: FC<{
         cardSx={{ marginBottom: theme.spacing(2) }}
       />
       {trial.state === "Running" &&
+        !formWidgetLoading &&
         directions.length > 0 &&
         formWidgets !== undefined && (
           <ObjectiveForm
@@ -284,7 +286,7 @@ const TrialListDetail: FC<{
             formWidgets={formWidgets}
           />
         )}
-      {trial.state === "Complete" &&
+      {(trial.state === "Complete" || formWidgetLoading) &&
         directions.length > 0 &&
         formWidgets !== undefined && (
           <ReadonlyObjectiveForm

--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -39,10 +39,10 @@ import { TrialNote } from "./Note"
 import { useHistory, useLocation } from "react-router-dom"
 import ListItemIcon from "@mui/material/ListItemIcon"
 import { useRecoilValue } from "recoil"
-import { artifactIsAvailable, useTrialUpdatingValue } from "../state"
+import { artifactIsAvailable } from "../state"
 import { actionCreator } from "../action"
 import { useDeleteArtifactDialog } from "./DeleteArtifactDialog"
-import { ObjectiveForm, ReadonlyObjectiveForm } from "./ObjectiveForm"
+import { TrialFormWidgets } from "./TrialFormWidgets"
 
 const states: TrialState[] = [
   "Complete",
@@ -147,7 +147,6 @@ const TrialListDetail: FC<{
 }> = ({ trial, isBestTrial, directions, objectiveNames, formWidgets }) => {
   const theme = useTheme()
   const artifactEnabled = useRecoilValue<boolean>(artifactIsAvailable)
-  const formWidgetLoading = useTrialUpdatingValue(trial.trial_id)
   const startMs = trial.datetime_start?.getTime()
   const completeMs = trial.datetime_complete?.getTime()
 
@@ -275,27 +274,14 @@ const TrialListDetail: FC<{
         latestNote={trial.note}
         cardSx={{ marginBottom: theme.spacing(2) }}
       />
-      {trial.state === "Running" &&
-        !formWidgetLoading &&
-        directions.length > 0 &&
-        formWidgets !== undefined && (
-          <ObjectiveForm
-            trial={trial}
-            directions={directions}
-            names={objectiveNames}
-            formWidgets={formWidgets}
-          />
-        )}
-      {(trial.state === "Complete" || formWidgetLoading) &&
-        directions.length > 0 &&
-        formWidgets !== undefined && (
-          <ReadonlyObjectiveForm
-            trial={trial}
-            directions={directions}
-            names={objectiveNames}
-            formWidgets={formWidgets}
-          />
-        )}
+      {formWidgets !== undefined && (
+        <TrialFormWidgets
+          trial={trial}
+          directions={directions}
+          objectiveNames={objectiveNames}
+          formWidgets={formWidgets}
+        />
+      )}
       <Box
         sx={{
           marginBottom: theme.spacing(2),

--- a/optuna_dashboard/ts/state.ts
+++ b/optuna_dashboard/ts/state.ts
@@ -10,6 +10,13 @@ export const studyDetailsState = atom<StudyDetails>({
   default: {},
 })
 
+export const trialsUpdatingState = atom<{
+  [trialId: string]: boolean
+}>({
+  key: "trialsUpdating",
+  default: {},
+})
+
 export const paramImportanceState = atom<StudyParamImportance>({
   key: "paramImportance",
   default: {},
@@ -57,6 +64,11 @@ export const useStudyDetailValue = (studyId: number): StudyDetail | null => {
 export const useStudySummaryValue = (studyId: number): StudySummary | null => {
   const studySummaries = useRecoilValue<StudySummary[]>(studySummariesState)
   return studySummaries.find((s) => s.study_id == studyId) || null
+}
+
+export const useTrialUpdatingValue = (trialId: number): boolean => {
+  const updating = useRecoilValue(trialsUpdatingState)
+  return updating[trialId] || false
 }
 
 export const useParamImportanceValue = (

--- a/optuna_dashboard/ts/types/index.d.ts
+++ b/optuna_dashboard/ts/types/index.d.ts
@@ -151,6 +151,7 @@ type ObjectiveSliderWidget = {
 type ObjectiveTextInputWidget = {
   type: "text"
   description: string
+  optional: boolean
   user_attr_key?: string
 }
 

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -10,17 +10,6 @@ class SerializeAttrsTestCase(TestCase):
         serialized = serialize_attrs({"bytes": b"This is a bytes object."})
         self.assertEqual(serialized[0]["value"], "<binary object>")
 
-    def test_serialize_string(self) -> None:
-        for length in [1000, 1024, 1100]:
-            with self.subTest(f"length: {length}"):
-                value = "a" * length
-                serialized = serialize_attrs(
-                    {
-                        "key": value,
-                    }
-                )
-                self.assertLessEqual(len(serialized[0]["value"]), 1024)
-
     def test_serialize_dict(self) -> None:
         serialized = serialize_attrs(
             {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
* [x] Allow `TextInputWidget` to accept strings for user attribute forms.
* [x] Fix some bugs.
* [x] Rename `ObjectiveFormWidgets` and `ReadonlyObjectiveFormWidgets` to `TrialFormWidgets`
* [x] Add `nowUpdating` state to trials.
