### PR TITLE
Fix bug of slider widget

### DIFF
--- a/optuna_dashboard/ts/components/TrialFormWidgets.tsx
+++ b/optuna_dashboard/ts/components/TrialFormWidgets.tsx
@@ -277,6 +277,7 @@ export const useSliderWidget = (
 ): WidgetState => {
   const theme = useTheme()
   const [value, setValue] = useState<number>(widget.min)
+  const defaultStep = 0.01
   const render = () => (
     <FormControl key={key} sx={{ margin: theme.spacing(1, 2) }}>
       <FormLabel>
@@ -291,12 +292,8 @@ export const useSliderWidget = (
           defaultValue={widget.min}
           min={widget.min}
           max={widget.max}
-          step={widget.step}
-          marks={
-            widget.labels === null || widget.labels.length == 0
-              ? true
-              : widget.labels
-          }
+          step={widget.step || defaultStep}
+          marks={widget.labels === null ? undefined : widget.labels}
           valueLabelDisplay="auto"
         />
       </Box>

--- a/optuna_dashboard/ts/types/index.d.ts
+++ b/optuna_dashboard/ts/types/index.d.ts
@@ -139,7 +139,7 @@ type ObjectiveSliderWidget = {
   user_attr_key?: string
   min: number
   max: number
-  step: number
+  step: number | null
   labels:
     | {
         value: number


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Fix panic in the following example:

```python
import logging
import optuna
from optuna_dashboard import register_objective_form_widgets
from optuna_dashboard import SliderWidget
from optuna_dashboard._app import create_app


host = "127.0.0.1"
port = 8080

optuna.logging.set_verbosity(logging.CRITICAL)


def create_optuna_storage() -> optuna.storages.InMemoryStorage:
    storage = optuna.storages.InMemoryStorage()
    study = optuna.create_study(study_name="multi-objective-running", storage=storage, direction="minimize")
    register_objective_form_widgets(study, [
        SliderWidget(min=0, max=10)
    ])
    trial = study.ask()

    return storage


def main() -> None:
    storage = create_optuna_storage()
    app = create_app(storage, debug=True)
    app.run(host=host, port=port, reloader=True)


if __name__ == "__main__":
    main()
```