### PR TITLE
Add type ignore comment for JSONSerializable

### DIFF
--- a/optuna_dashboard/_form_widget.py
+++ b/optuna_dashboard/_form_widget.py
@@ -362,7 +362,12 @@ def register_objective_form_widgets(
         "output_type": "objective",
         "widgets": [w.to_dict() for w in widgets],
     }
-    study._storage.set_study_system_attr(study._study_id, FORM_WIDGETS_KEY, form_widgets)
+    study._storage.set_study_system_attr(
+        study._study_id,
+        FORM_WIDGETS_KEY,
+        # TODO(c-bata): Remove type: ignore comment
+        form_widgets,  # type: ignore
+    )
 
 
 def register_user_attr_form_widgets(
@@ -435,7 +440,12 @@ def register_user_attr_form_widgets(
         "output_type": "user_attr",
         "widgets": widget_dicts,
     }
-    study._storage.set_study_system_attr(study._study_id, FORM_WIDGETS_KEY, form_widgets)
+    study._storage.set_study_system_attr(
+        study._study_id,
+        FORM_WIDGETS_KEY,
+        # TODO(c-bata): Remove type: ignore comment
+        form_widgets,  # type: ignore
+    )
 
 
 def get_form_widgets_json(study_system_attr: dict[str, Any]) -> Optional[FormWidgetJSON]:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Optuna 3.2 introduces `JSONSerializable` type and it causes mypy error on Optuna Dashboard.