### PR TITLE
Reduce the number of memory allocation on artifact backend.

### DIFF
--- a/optuna_dashboard/artifact/file_system.py
+++ b/optuna_dashboard/artifact/file_system.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 import os
+import shutil
 from typing import BinaryIO
 from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsRead
 
 
 class FileSystemBackend:
@@ -31,10 +36,10 @@ class FileSystemBackend:
         filepath = os.path.join(self._base_path, artifact_id)
         return open(filepath, "rb")
 
-    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+    def write(self, artifact_id: str, content_body: SupportsRead[bytes]) -> None:
         filepath = os.path.join(self._base_path, artifact_id)
         with open(filepath, "wb") as f:
-            f.write(content_body.read())
+            shutil.copyfileobj(content_body, f)
 
     def remove(self, artifact_id: str) -> None:
         filepath = os.path.join(self._base_path, artifact_id)

--- a/optuna_dashboard/artifact/protocol.py
+++ b/optuna_dashboard/artifact/protocol.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 from typing import BinaryIO
 from typing import Protocol
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from _typeshed import SupportsRead
 
 
 class ArtifactBackend(Protocol):
     def open(self, artifact_id: str) -> BinaryIO:
         ...
 
-    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+    def write(self, artifact_id: str, content_body: SupportsRead[bytes]) -> None:
         ...
 
     def remove(self, artifact_id: str) -> None:

--- a/python_tests/test_boto3_artifact.py
+++ b/python_tests/test_boto3_artifact.py
@@ -9,23 +9,28 @@ from optuna_dashboard.artifact.boto3 import Boto3Backend
 @mock_s3
 class Boto3BackendTestCase(TestCase):
     def setUp(self) -> None:
-        self.s3_client = boto3.resource("s3")
-        self.bucket = self.s3_client.create_bucket(Bucket="moto-bucket")
+        self.s3_client = boto3.client("s3")
+        self.bucket_name = "moto-bucket"
+        self.s3_client.create_bucket(Bucket=self.bucket_name)
 
     def tearDown(self) -> None:
-        self.bucket.objects.all().delete()
-        self.bucket.delete()
+        objects = self.s3_client.list_objects(Bucket=self.bucket_name).get("Contents", [])
+        if objects:
+            self.s3_client.delete_objects(Bucket=self.bucket_name, Delete={
+                "Objects": [{"Key": obj["Key"] for obj in objects}],
+                "Quiet": True
+            })
+        self.s3_client.delete_bucket(Bucket=self.bucket_name)
 
     def test_upload_download(self) -> None:
         artifact_id = "dummy-uuid"
         dummy_content = b"Hello World"
 
-        backend = Boto3Backend(self.bucket.name)
+        backend = Boto3Backend(self.bucket_name)
         backend.write(artifact_id, io.BytesIO(dummy_content))
-
-        objects = [obj for obj in self.bucket.objects.all() if obj.key == artifact_id]
-        assert len(objects) == 1
-        assert objects[0].get()["Body"].read() == dummy_content
+        assert len(self.s3_client.list_objects(Bucket=self.bucket_name)['Contents']) == 1
+        obj = self.s3_client.get_object(Bucket=self.bucket_name, Key=artifact_id)
+        assert obj["Body"].read() == dummy_content
 
         with backend.open(artifact_id) as f:
             actual = f.read()
@@ -33,9 +38,11 @@ class Boto3BackendTestCase(TestCase):
 
     def test_remove(self) -> None:
         artifact_id = "dummy-uuid"
-        backend = Boto3Backend(self.bucket.name)
+        backend = Boto3Backend(self.bucket_name)
         backend.write(artifact_id, io.BytesIO(b"Hello"))
-        assert len([obj for obj in self.bucket.objects.all() if obj.key == artifact_id]) == 1
+        objects = self.s3_client.list_objects(Bucket=self.bucket_name)['Contents']
+        assert len([obj for obj in objects if obj["Key"] == artifact_id]) == 1
 
         backend.remove(artifact_id)
-        assert len([obj for obj in self.bucket.objects.all() if obj.key == artifact_id]) == 0
+        objects = self.s3_client.list_objects(Bucket=self.bucket_name).get('Contents', [])
+        assert len([obj for obj in objects if obj["Key"] == artifact_id]) == 0


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
* Relax type of `ArtifactBackend.write(...)` from `BinaryIO` to `SupportsRead[bytes]`
* Avoid to load an entire file content on memory.