### PR TITLE
Revert SupportsRead and use BinaryIO again

### DIFF
--- a/optuna_dashboard/artifact/boto3.py
+++ b/optuna_dashboard/artifact/boto3.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import io
-import shutil
 from typing import TYPE_CHECKING
 
 import boto3
@@ -11,11 +9,8 @@ from optuna_dashboard.artifact.exceptions import ArtifactNotFound
 
 if TYPE_CHECKING:
     from typing import BinaryIO
-    from typing import IO
     from typing import Optional
-    from typing import TypeGuard
 
-    from _typeshed import SupportsRead
     from mypy_boto3_s3 import S3Client
 
 
@@ -53,16 +48,8 @@ class Boto3Backend:
         assert body is not None
         return body  # type: ignore
 
-    def write(self, artifact_id: str, content_body: SupportsRead[bytes]) -> None:
-        if _is_file_like_obj(content_body):
-            self.client.upload_fileobj(content_body, self.bucket, artifact_id)
-            return
-
-        # Convert SupportsRead[bytes] to file-like object
-        buf = io.BytesIO()
-        shutil.copyfileobj(content_body, buf)
-        buf.seek(0)
-        self.client.upload_fileobj(buf, self.bucket, artifact_id)
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
+        self.client.upload_fileobj(content_body, self.bucket, artifact_id)
 
     def remove(self, artifact_id: str) -> None:
         try:
@@ -77,15 +64,6 @@ def _is_not_found_error(e: ClientError) -> bool:
     error_code = e.response.get("Error", {}).get("Code")
     http_status_code = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
     return error_code == "NoSuchKey" or http_status_code == 404
-
-
-def _is_file_like_obj(obj: SupportsRead[bytes]) -> TypeGuard[IO[bytes]]:
-    return (
-        isinstance(obj, io.TextIOBase)
-        or isinstance(obj, io.BufferedIOBase)
-        or isinstance(obj, io.RawIOBase)
-        or isinstance(obj, io.IOBase)
-    )
 
 
 if TYPE_CHECKING:

--- a/optuna_dashboard/artifact/file_system.py
+++ b/optuna_dashboard/artifact/file_system.py
@@ -10,8 +10,6 @@ from optuna_dashboard.artifact.exceptions import ArtifactNotFound
 if TYPE_CHECKING:
     from typing import BinaryIO
 
-    from _typeshed import SupportsRead
-
 
 class FileSystemBackend:
     """An artifact backend for file systems.
@@ -43,7 +41,7 @@ class FileSystemBackend:
             raise ArtifactNotFound("not found") from e
         return f
 
-    def write(self, artifact_id: str, content_body: SupportsRead[bytes]) -> None:
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
         filepath = os.path.join(self._base_path, artifact_id)
         with open(filepath, "wb") as f:
             shutil.copyfileobj(content_body, f)

--- a/optuna_dashboard/artifact/protocol.py
+++ b/optuna_dashboard/artifact/protocol.py
@@ -12,8 +12,6 @@ except ImportError:
 if TYPE_CHECKING:
     from typing import BinaryIO
 
-    from _typeshed import SupportsRead
-
 
 class ArtifactBackend(Protocol):
     """A protocol defining the interface for an artifact backend.
@@ -39,7 +37,7 @@ class ArtifactBackend(Protocol):
         """
         ...
 
-    def write(self, artifact_id: str, content_body: SupportsRead[bytes]) -> None:
+    def write(self, artifact_id: str, content_body: BinaryIO) -> None:
         """Save the content to the backend.
 
         Args:

--- a/python_tests/test_boto3_artifact.py
+++ b/python_tests/test_boto3_artifact.py
@@ -1,7 +1,5 @@
 import io
 from unittest import TestCase
-from unittest.mock import MagicMock
-from unittest.mock import patch
 
 import boto3
 from moto import mock_s3
@@ -35,21 +33,6 @@ class Boto3BackendTestCase(TestCase):
         obj = self.s3_client.get_object(Bucket=self.bucket_name, Key=artifact_id)
         assert obj["Body"].read() == dummy_content
 
-        with backend.open(artifact_id) as f:
-            actual = f.read()
-        self.assertEqual(actual, dummy_content)
-
-    @patch("optuna_dashboard.artifact.boto3._is_file_like_obj")
-    def test_upload_download_non_file_like(self, mock_is_file_like_obj: MagicMock) -> None:
-        mock_is_file_like_obj.side_effect = lambda o: False
-
-        artifact_id = "dummy-uuid"
-        dummy_content = b"Hello World"
-        backend = Boto3Backend(self.bucket_name)
-        backend.write(artifact_id, io.BytesIO(dummy_content))
-        assert len(self.s3_client.list_objects(Bucket=self.bucket_name)["Contents"]) == 1
-        obj = self.s3_client.get_object(Bucket=self.bucket_name, Key=artifact_id)
-        assert obj["Body"].read() == dummy_content
         with backend.open(artifact_id) as f:
             actual = f.read()
         self.assertEqual(actual, dummy_content)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #481

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
In Optuna Dashboard v0.10.1b1 release, I changed the ArtifactBackend interface. But I found some performance concerns, so this PR reverts it.