### PR TITLE
Fix a bug that `boto3.upload_fileobj` may close the file

### DIFF
--- a/python_tests/artifact/test_boto3.py
+++ b/python_tests/artifact/test_boto3.py
@@ -26,9 +26,10 @@ class Boto3BackendTestCase(TestCase):
     def test_upload_download(self) -> None:
         artifact_id = "dummy-uuid"
         dummy_content = b"Hello World"
+        buf = io.BytesIO(dummy_content)
 
         backend = Boto3Backend(self.bucket_name)
-        backend.write(artifact_id, io.BytesIO(dummy_content))
+        backend.write(artifact_id, buf)
         assert len(self.s3_client.list_objects(Bucket=self.bucket_name)["Contents"]) == 1
         obj = self.s3_client.get_object(Bucket=self.bucket_name, Key=artifact_id)
         assert obj["Body"].read() == dummy_content
@@ -36,6 +37,7 @@ class Boto3BackendTestCase(TestCase):
         with backend.open(artifact_id) as f:
             actual = f.read()
         self.assertEqual(actual, dummy_content)
+        self.assertFalse(buf.closed)
 
     def test_remove(self) -> None:
         artifact_id = "dummy-uuid"


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
See https://github.com/boto/boto3/issues/929