### PR TITLE
Fix check for single-objective study

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -187,7 +187,10 @@ def create_app(
 
         # TODO(c-bata): Cache best_trials
         if len(summary.directions) == 1:
-            best_trials = [storage.get_best_trial(study_id)]
+            if len([t for t in trials if t.state == TrialState.COMPLETE]) == 0:
+                best_trials = []
+            else:
+                best_trials = [storage.get_best_trial(study_id)]
         else:
             best_trials = get_pareto_front_trials(trials=trials, directions=summary.directions)
         (

--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -186,7 +186,7 @@ def create_app(
         trials = get_trials(storage, study_id)
 
         # TODO(c-bata): Cache best_trials
-        if summary.directions == 1:
+        if len(summary.directions) == 1:
             best_trials = [storage.get_best_trial(study_id)]
         else:
             best_trials = get_pareto_front_trials(trials=trials, directions=summary.directions)


### PR DESCRIPTION
In `get_study_detail`, the check for single-objective study is buggy, and it performs `get_pareto_front_trials` even for single-objective study. Since `get_pareto_front_trials` is currently implemented as an O(#trials^2) operation, it becomes a bottleneck for study with >1000 trials.

This PR removes the bug and speeds up response time for single-objective study.

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.
