### PR TITLE
Fix bug where the include pruned trials label has inverted behaviour to expected

### DIFF
--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -43,7 +43,7 @@ export const GraphHistory: FC<{
   const [markerSize, setMarkerSize] = useState<number>(5)
 
   const [targets, selected, setTarget] = useObjectiveAndUserAttrTargets(study)
-  const trials = useFilteredTrials(study, [selected], includePruned)
+  const trials = useFilteredTrials(study, [selected], !includePruned)
 
   useEffect(() => {
     if (study !== null) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #501 

## What does this implement/fix? Explain your changes.

Code on main makes use of the `useFilteredTrials` function, whose `filterPruned` parameter should be set to true if we do wish to filter out pruned trials. We should thus be passing `!includePruned` to this function, i.e. if we do wish to includePruned, we should _not_ filterPruned and vice versa.

Behaviour after this PR:
<img width="1728" alt="Screenshot 2023-07-19 at 21 47 12" src="https://github.com/optuna/optuna-dashboard/assets/52001888/fc8bd3de-9d53-4ae0-a810-c520688530c4">

<img width="1728" alt="Screenshot 2023-07-19 at 21 47 56" src="https://github.com/optuna/optuna-dashboard/assets/52001888/0c4ff21d-6e29-4659-80d5-c26ead6e2e3d">

