### PR TITLE
Add constraints for pareto front

### DIFF
--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -8,8 +8,8 @@ from typing import Union
 import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
-from optuna.study import StudySummary
 from optuna.samplers._base import _CONSTRAINTS_KEY
+from optuna.study import StudySummary
 from optuna.trial import FrozenTrial
 
 from . import _note as note

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -9,6 +9,7 @@ import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.study import StudySummary
+from optuna.samplers._base import _CONSTRAINTS_KEY
 from optuna.trial import FrozenTrial
 
 from . import _note as note
@@ -187,6 +188,7 @@ def serialize_frozen_trial(
         ),
         "note": note.get_note_from_system_attrs(study_system_attrs, trial._trial_id),
         "artifacts": list_trial_artifacts(study_system_attrs, trial._trial_id),
+        "constraints": trial_system_attrs.get(_CONSTRAINTS_KEY, []),
     }
 
     serialized_intermediate_values: list[IntermediateValue] = []

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -29,7 +29,8 @@ interface TrialResponse {
   user_attrs: Attribute[]
   system_attrs: Attribute[]
   note: Note
-  artifacts: Artifact[]
+  artifacts: Artifact[],
+  constraints: number[]
 }
 
 const convertTrialResponse = (res: TrialResponse): Trial => {
@@ -52,6 +53,7 @@ const convertTrialResponse = (res: TrialResponse): Trial => {
     system_attrs: res.system_attrs,
     note: res.note,
     artifacts: res.artifacts,
+    constraints: res.constraints,
   }
 }
 

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -29,7 +29,7 @@ interface TrialResponse {
   user_attrs: Attribute[]
   system_attrs: Attribute[]
   note: Note
-  artifacts: Artifact[],
+  artifacts: Artifact[]
   constraints: number[]
 }
 

--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -192,8 +192,8 @@ const plotParetoFront = (
 
   const feasibleTrials: Trial[] = []
   const InfeasibleTrials: Trial[] = []
-  filteredTrials.forEach(t => {
-    if(t.constraints.every(c => c <= 0)){
+  filteredTrials.forEach((t) => {
+    if (t.constraints.every((c) => c <= 0)) {
       feasibleTrials.push(t)
     } else {
       InfeasibleTrials.push(t)
@@ -231,8 +231,8 @@ const plotParetoFront = (
       objectiveXId,
       objectiveYId,
       InfeasibleTrials.length === 0
-        ?"%{text}<extra>Trial</extra>"
-        :"%{text}<extra>Feasible Trial</extra>",
+        ? "%{text}<extra>Trial</extra>"
+        : "%{text}<extra>Feasible Trial</extra>",
       true,
       true
     ),

--- a/optuna_dashboard/ts/types/index.d.ts
+++ b/optuna_dashboard/ts/types/index.d.ts
@@ -112,6 +112,7 @@ type Trial = {
   }[]
   user_attrs: Attribute[]
   system_attrs: Attribute[]
+  constraints: number[]
   note: Note
   artifacts: Artifact[]
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Constraints have been supported for PareteFront in #316 

## What does this implement/fix? Explain your changes.

Since the constraint values are used in other plots, I use optuna's _CONSTRAINT_KEY to serialize the constraint values.

The results, reflecting the constraints, are shown below. A feasible trial has a gray line around the edge, while an infasible trial has a gray marker with no edge line.

<img width="400" alt="Screenshot 2023-07-21 at 16 17 55" src="https://github.com/optuna/optuna-dashboard/assets/23289252/3c72ebba-336a-49ad-a082-30fa95e49b06">

<img width="400" alt="Screenshot 2023-07-21 at 16 24 39" src="https://github.com/optuna/optuna-dashboard/assets/23289252/b080525a-4739-4b7f-a590-d19110004933">

