### PR TITLE
Use self.assertEqual in tests 

### DIFF
--- a/python_tests/artifact/test_boto3.py
+++ b/python_tests/artifact/test_boto3.py
@@ -30,9 +30,9 @@ class Boto3BackendTestCase(TestCase):
 
         backend = Boto3Backend(self.bucket_name)
         backend.write(artifact_id, buf)
-        assert len(self.s3_client.list_objects(Bucket=self.bucket_name)["Contents"]) == 1
+        self.assertEqual(len(self.s3_client.list_objects(Bucket=self.bucket_name)["Contents"]), 1)
         obj = self.s3_client.get_object(Bucket=self.bucket_name, Key=artifact_id)
-        assert obj["Body"].read() == dummy_content
+        self.assertEqual(obj["Body"].read(), dummy_content)
 
         with backend.open(artifact_id) as f:
             actual = f.read()
@@ -44,11 +44,11 @@ class Boto3BackendTestCase(TestCase):
         backend = Boto3Backend(self.bucket_name)
         backend.write(artifact_id, io.BytesIO(b"Hello"))
         objects = self.s3_client.list_objects(Bucket=self.bucket_name)["Contents"]
-        assert len([obj for obj in objects if obj["Key"] == artifact_id]) == 1
+        self.assertEqual(len([obj for obj in objects if obj["Key"] == artifact_id]), 1)
 
         backend.remove(artifact_id)
         objects = self.s3_client.list_objects(Bucket=self.bucket_name).get("Contents", [])
-        assert len([obj for obj in objects if obj["Key"] == artifact_id]) == 0
+        self.assertEqual(len([obj for obj in objects if obj["Key"] == artifact_id]), 0)
 
     def test_file_not_found_exception(self) -> None:
         backend = Boto3Backend(self.bucket_name)

--- a/python_tests/test_cached_extra_study_property.py
+++ b/python_tests/test_cached_extra_study_property.py
@@ -278,4 +278,4 @@ class _CachedExtraStudyPropertyUserAttrs(TestCase):
         cached_extra_study_property = _CachedExtraStudyProperty()
         cached_extra_study_property.update(trials)
         actual = {k: v for k, v in cached_extra_study_property.union_user_attrs}
-        assert actual == expected
+        self.assertEqual(actual, expected)

--- a/python_tests/test_form_widget.py
+++ b/python_tests/test_form_widget.py
@@ -41,4 +41,4 @@ class FormWidgetsTestCase(TestCase):
             with self.subTest(f"{widget.__class__}-{i}"):
                 d = cast(Dict[str, Any], widget.to_dict())
                 restored = dict_to_form_widget(d)
-                assert widget == restored
+                self.assertEqual(widget, restored)

--- a/python_tests/test_metric_names.py
+++ b/python_tests/test_metric_names.py
@@ -21,4 +21,4 @@ class MetricNamesTestCase(unittest.TestCase):
         study_system_attrs = study._storage.get_study_system_attrs(study._study_id)
         metric_names = get_objective_names(study_system_attrs)
 
-        assert metric_names == ["val_loss", "flops"]
+        self.assertEqual(metric_names, ["val_loss", "flops"])

--- a/python_tests/test_note.py
+++ b/python_tests/test_note.py
@@ -19,9 +19,9 @@ class NoteTestCase(TestCase):
         ]:
             with self.subTest(f"with_{dummy_body_str}_{attr_len}"):
                 attrs = note.split_body(dummy_body_str, None)
-                assert len(attrs) == attr_len
+                self.assertEqual(len(attrs), attr_len)
                 actual = note.concat_body(attrs, None)
-                assert dummy_body_str == actual
+                self.assertEqual(actual, dummy_body_str)
 
     def test_save_and_get_study_note(self) -> None:
         study = optuna.create_study()
@@ -32,11 +32,11 @@ class NoteTestCase(TestCase):
                 system_attrs = study._storage.get_study_system_attrs(study._study_id)
 
                 actual = get_note(study)
-                assert actual == body
+                self.assertEqual(actual, body)
 
                 note_dict = note.get_note_from_system_attrs(system_attrs, None)
-                assert note_dict["body"] == body
-                assert note_dict["version"] == expected_ver
+                self.assertEqual(note_dict["body"], body)
+                self.assertEqual(note_dict["version"], expected_ver)
 
     def test_save_and_get_trial_note(self) -> None:
         study = optuna.create_study()
@@ -48,8 +48,8 @@ class NoteTestCase(TestCase):
                 system_attrs = study._storage.get_study_system_attrs(study._study_id)
 
                 actual = get_note(trial)
-                assert actual == body
+                self.assertEqual(actual, body)
 
                 note_dict = note.get_note_from_system_attrs(system_attrs, trial._trial_id)
-                assert note_dict["body"] == body
-                assert note_dict["version"] == expected_ver
+                self.assertEqual(note_dict["body"], body)
+                self.assertEqual(note_dict["version"], expected_ver)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
Use `self.assertEqual` instead of `assert A == B`.