### PR TITLE
Add constraints for history plot

### DIFF
--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -431,7 +431,7 @@ const plotHistory = (
     name: "Infeasible Trial",
     marker: {
       size: markerSize,
-      color: "#cccccc",
+      color: mode === "dark" ? "#666666" : "#cccccc",
     },
     mode: "markers",
     type: "scatter",
@@ -570,14 +570,13 @@ const plotHistoryMultiStudies = (
       name: `Infeasible Trial of ${h.study_name}`,
       marker: {
         size: markerSize,
-        color: "#cccccc",
+        color: mode === "dark" ? "#666666" : "#cccccc",
       },
       mode: "markers",
       type: "scatter",
       showlegend: false,
     })
   })
-
   plotData.push(...infeasiblePlotData)
   plotly.react(plotDomId, plotData, layout)
 }

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -486,7 +486,7 @@ const plotHistoryMultiStudies = (
   }
 
   const plotData: Partial<plotly.PlotData>[] = []
-  const InfeasiblePlotData: Partial<plotly.PlotData>[] = []
+  const infeasiblePlotData: Partial<plotly.PlotData>[] = []
   historyPlotInfos.forEach((h) => {
     const feasibleTrials: Trial[] = []
     const infeasibleTrials: Trial[] = []
@@ -562,7 +562,7 @@ const plotHistoryMultiStudies = (
         type: "scatter",
       })
     }
-    InfeasiblePlotData.push({
+    infeasiblePlotData.push({
       x: infeasibleTrials.map(getAxisX),
       y: infeasibleTrials.map(
         (t: Trial): number => target.getTargetValue(t) as number
@@ -578,6 +578,6 @@ const plotHistoryMultiStudies = (
     })
   })
 
-  plotData.push(...InfeasiblePlotData)
+  plotData.push(...infeasiblePlotData)
   plotly.react(plotDomId, plotData, layout)
 }

--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -191,12 +191,12 @@ const plotParetoFront = (
   }
 
   const feasibleTrials: Trial[] = []
-  const InfeasibleTrials: Trial[] = []
+  const infeasibleTrials: Trial[] = []
   filteredTrials.forEach((t) => {
     if (t.constraints.every((c) => c <= 0)) {
       feasibleTrials.push(t)
     } else {
-      InfeasibleTrials.push(t)
+      infeasibleTrials.push(t)
     }
   })
 
@@ -230,7 +230,7 @@ const plotParetoFront = (
       feasibleTrials.filter((t, i) => dominatedTrials[i]),
       objectiveXId,
       objectiveYId,
-      InfeasibleTrials.length === 0
+      infeasibleTrials.length === 0
         ? "%{text}<extra>Trial</extra>"
         : "%{text}<extra>Feasible Trial</extra>",
       true,
@@ -245,7 +245,7 @@ const plotParetoFront = (
       true
     ),
     makeScatterObject(
-      InfeasibleTrials,
+      infeasibleTrials,
       objectiveXId,
       objectiveYId,
       "%{text}<extra>Infeasible Trial</extra>",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Support constraint in optimization history plot like #525 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Both plots for the study alone and comparison plots were made to take into account the constraints.

<img width="400" alt="Screenshot 2023-07-27 at 21 04 04" src="https://github.com/optuna/optuna-dashboard/assets/23289252/6b09372d-7f1c-4e7c-8ad1-deee73db0bb9">

<img width="400" alt="Screenshot 2023-07-27 at 21 04 47" src="https://github.com/optuna/optuna-dashboard/assets/23289252/8c41fb4b-af9d-460b-8e45-0e9214016e71">

