### PR TITLE
Update infeasible dark mode color to improve visibility

### DIFF
--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -109,9 +109,10 @@ const makeScatterObject = (
   objectiveYId: number,
   hovertemplate: string,
   dominated: boolean,
-  feasible: boolean
+  feasible: boolean,
+  mode: string
 ): Partial<plotly.PlotData> => {
-  const marker = makeMarker(trials, dominated, feasible)
+  const marker = makeMarker(trials, dominated, feasible, mode)
   return {
     x: trials.map((t) => t.values![objectiveXId] as number),
     y: trials.map((t) => t.values![objectiveYId] as number),
@@ -126,7 +127,8 @@ const makeScatterObject = (
 const makeMarker = (
   trials: Trial[],
   dominated: boolean,
-  feasible: boolean
+  feasible: boolean,
+  mode: string
 ): Partial<plotly.PlotData> => {
   if (feasible && dominated) {
     return {
@@ -154,7 +156,7 @@ const makeMarker = (
   } else {
     return {
       // @ts-ignore
-      color: "#cccccc",
+      color: mode === "dark" ? "#666666" : "#cccccc",
     }
   }
 }
@@ -234,7 +236,8 @@ const plotParetoFront = (
         ? "%{text}<extra>Trial</extra>"
         : "%{text}<extra>Feasible Trial</extra>",
       true,
-      true
+      true,
+      mode
     ),
     makeScatterObject(
       feasibleTrials.filter((t, i) => !dominatedTrials[i]),
@@ -242,7 +245,8 @@ const plotParetoFront = (
       objectiveYId,
       "%{text}<extra>Best Trial</extra>",
       false,
-      true
+      true,
+      mode
     ),
     makeScatterObject(
       infeasibleTrials,
@@ -250,7 +254,8 @@ const plotParetoFront = (
       objectiveYId,
       "%{text}<extra>Infeasible Trial</extra>",
       false,
-      false
+      false,
+      mode
     ),
   ]
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Follow-up #529 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Changed the color of the marker from `#cccccc` to `#666666` when infeasible in dark mode on the pareto front.
