### PR TITLE
Add `is_preferential` property to the study detail api response

### DIFF
--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -15,6 +15,7 @@ from . import _note as note
 from ._form_widget import get_form_widgets_json
 from ._named_objectives import get_objective_names
 from .artifact._backend import list_trial_artifacts
+from .preferential._study import _SYSTEM_ATTR_PREFERENTIAL_STUDY
 
 
 if TYPE_CHECKING:
@@ -143,6 +144,7 @@ def serialize_study_detail(
     serialized["union_user_attrs"] = [{"key": a[0], "sortable": a[1]} for a in union_user_attrs]
     serialized["has_intermediate_values"] = has_intermediate_values
     serialized["note"] = note.get_note_from_system_attrs(system_attrs, None)
+    serialized["is_preferential"] = system_attrs.get(_SYSTEM_ATTR_PREFERENTIAL_STUDY, False)
     objective_names = get_objective_names(system_attrs)
     if objective_names:
         serialized["objective_names"] = objective_names

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
-from unittest import TestCase
-
+import optuna
 from optuna_dashboard._serializer import serialize_attrs
+from optuna_dashboard._serializer import serialize_study_detail
+from optuna_dashboard.preferential import create_study
+
+from optuna_dashboard._storage import get_study_summaries
 
 
 def test_serialize_bytes() -> None:
@@ -17,3 +20,25 @@ def test_serialize_dict() -> None:
         }
     )
     assert len(serialized) <= 1
+
+
+def test_get_study_detail_is_preferential() -> None:
+    storage = optuna.storages.InMemoryStorage()
+    study = create_study(storage=storage)
+    study_summaries = get_study_summaries(storage)
+    assert len(study_summaries) == 1
+
+    study_summary = study_summaries[0]
+    study_detail = serialize_study_detail(study_summary, [], study.trials, [], [], [], False)
+    assert study_detail["is_preferential"]
+
+
+def test_get_study_detail_is_not_preferential() -> None:
+    storage = optuna.storages.InMemoryStorage()
+    study = optuna.create_study(storage=storage)
+    study_summaries = get_study_summaries(storage)
+    assert len(study_summaries) == 1
+
+    study_summary = study_summaries[0]
+    study_detail = serialize_study_detail(study_summary, [], study.trials, [], [], [], False)
+    assert not study_detail["is_preferential"]

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 import optuna
 from optuna_dashboard._serializer import serialize_attrs
 from optuna_dashboard._serializer import serialize_study_detail
-from optuna_dashboard.preferential import create_study
-
 from optuna_dashboard._storage import get_study_summaries
+from optuna_dashboard.preferential import create_study
 
 
 def test_serialize_bytes() -> None:

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -5,15 +5,15 @@ from unittest import TestCase
 from optuna_dashboard._serializer import serialize_attrs
 
 
-class SerializeAttrsTestCase(TestCase):
-    def test_serialize_bytes(self) -> None:
-        serialized = serialize_attrs({"bytes": b"This is a bytes object."})
-        self.assertEqual(serialized[0]["value"], "<binary object>")
+def test_serialize_bytes() -> None:
+    serialized = serialize_attrs({"bytes": b"This is a bytes object."})
+    assert serialized[0]["value"] == "<binary object>"
 
-    def test_serialize_dict(self) -> None:
-        serialized = serialize_attrs(
-            {
-                "key": {"foo": "bar"},
-            }
-        )
-        self.assertLessEqual(len(serialized), 1)
+
+def test_serialize_dict() -> None:
+    serialized = serialize_attrs(
+        {
+            "key": {"foo": "bar"},
+        }
+    )
+    assert len(serialized) <= 1


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Add `is_preferential` property to the study detail api response