### PR TITLE
Fix the bug while renaming a study with maximize direction

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -144,7 +144,9 @@ def create_app(
             response.status = 500
             return {"reason": "Failed to load the study"}
         try:
-            dst_study = optuna.create_study(storage=storage, study_name=dst_study_name, directions=summary.directions)
+            dst_study = optuna.create_study(
+                storage=storage, study_name=dst_study_name, directions=summary.directions
+            )
             dst_study.add_trials(src_study.get_trials(deepcopy=False))
         except DuplicatedStudyError:
             response.status = 400  # Bad request

--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -139,13 +139,9 @@ def create_app(
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
 
-        summary = get_study_summary(storage, study_id)
-        if summary is None:
-            response.status = 500
-            return {"reason": "Failed to load the study"}
         try:
             dst_study = optuna.create_study(
-                storage=storage, study_name=dst_study_name, directions=summary.directions
+                storage=storage, study_name=dst_study_name, directions=src_study.directions
             )
             dst_study.add_trials(src_study.get_trials(deepcopy=False))
         except DuplicatedStudyError:

--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -139,8 +139,12 @@ def create_app(
             response.status = 404  # Not found
             return {"reason": f"study_id={study_id} is not found"}
 
+        summary = get_study_summary(storage, study_id)
+        if summary is None:
+            response.status = 500
+            return {"reason": "Failed to load the study"}
         try:
-            dst_study = optuna.create_study(storage=storage, study_name=dst_study_name)
+            dst_study = optuna.create_study(storage=storage, study_name=dst_study_name, directions=summary.directions)
             dst_study.add_trials(src_study.get_trials(deepcopy=False))
         except DuplicatedStudyError:
             response.status = 400  # Bad request


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
_none_

## What does this implement/fix? Explain your changes.

In version 0.12.0, if a study with the **maximize** direction is renamed, it results in a new study being created with the **minimize** direction. To address this, I've transferred the original study's directions to the newly created study.
