### PR TITLE
[preferential] Separate best_trials and active_trials

### DIFF
--- a/examples/preferential-optimization/generator.py
+++ b/examples/preferential-optimization/generator.py
@@ -35,7 +35,7 @@ def main() -> NoReturn:
         while True:
             # If n_comparison "best" trials (that are not reported bad) exists,
             # the generator waits for human evaluation.
-            if len(study.best_trials) >= n_comparison:
+            if study.should_generate():
                 time.sleep(0.1)  # Avoid busy-loop
                 continue
 

--- a/examples/preferential-optimization/generator.py
+++ b/examples/preferential-optimization/generator.py
@@ -20,8 +20,6 @@ artifact_path = os.path.join(os.path.dirname(__file__), "artifact")
 artifact_backend = FileSystemBackend(base_path=artifact_path)
 os.makedirs(artifact_path, exist_ok=True)
 
-n_comparison = 5
-
 
 def main() -> NoReturn:
     study = create_study(
@@ -35,7 +33,7 @@ def main() -> NoReturn:
         while True:
             # If n_comparison "best" trials (that are not reported bad) exists,
             # the generator waits for human evaluation.
-            if study.should_generate():
+            if not study.should_generate():
                 time.sleep(0.1)  # Avoid busy-loop
                 continue
 

--- a/optuna_dashboard/preferential/_study.py
+++ b/optuna_dashboard/preferential/_study.py
@@ -12,9 +12,11 @@ from optuna.samplers import BaseSampler
 from optuna.samplers import RandomSampler
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
+from optuna_dashboard.preferential._system_attrs import get_n_generate
 from optuna_dashboard.preferential._system_attrs import get_preferences
 from optuna_dashboard.preferential._system_attrs import is_skipped_trial
-from optuna_dashboard.preferential._system_attrs import report_preferences, get_n_generate, set_n_generate
+from optuna_dashboard.preferential._system_attrs import report_preferences
+from optuna_dashboard.preferential._system_attrs import set_n_generate
 
 
 _logger = logging.get_logger(__name__)
@@ -256,26 +258,26 @@ class PreferentialStudy:
     @property
     def n_generate(self) -> int:
         """Return the number of trials that should be generated and shown to user.
-        
+
         :func:`~optuna_dashboard.preferential.PreferentialStudy.should_generate` returns
         :obj:`True` if the number of trials not reported bad and not skipped are less than
         :attr:`~optuna_dashboard.preferential.PreferentialStudy.n_generate`.
         """
         system_attrs = self._study._storage.get_study_system_attrs(self._study._study_id)
         return get_n_generate(system_attrs)
-    
+
     def set_n_generate(self, n_generate: int) -> None:
         """Set the number of trials that should be generated and shown to user.
-        
+
         :func:`~optuna_dashboard.preferential.PreferentialStudy.should_generate` returns
         :obj:`True` if the number of trials not reported bad and not skipped are less than
         :attr:`~optuna_dashboard.preferential.PreferentialStudy.n_generate`.
         """
         return set_n_generate(self._study._study_id, self._study._storage, n_generate)
-    
+
     def should_generate(self) -> bool:
         """Return whether the generator should generate a new trial now.
-        
+
         Returns :obj:`True` if the number of trials not reported bad and not skipped are less than
         :attr:`~optuna_dashboard.preferential.PreferentialStudy.n_generate`. Users are recommended
         to generate a new trial if this method returns :obj:`True`, and to wait for human evaluation

--- a/optuna_dashboard/preferential/_study.py
+++ b/optuna_dashboard/preferential/_study.py
@@ -280,8 +280,8 @@ class PreferentialStudy:
 
         Returns :obj:`True` if the number of trials not reported bad and not skipped are less than
         :attr:`~optuna_dashboard.preferential.PreferentialStudy.n_generate`. Users are recommended
-        to generate a new trial if this method returns :obj:`True`, and to wait for human evaluation
-        if this method returns :obj:`False`.
+        to generate a new trial if this method returns :obj:`True`, and to wait for human
+        evaluation if this method returns :obj:`False`.
         """
         return len(self.best_trials) < self.n_generate
 
@@ -360,9 +360,7 @@ def create_study(
         study._storage.set_study_system_attr(
             study._study_id, _SYSTEM_ATTR_PREFERENTIAL_STUDY, True
         )
-        study._storage.set_study_system_attr(
-            study._study_id, _SYSTEM_ATTR_N_GENERATE, 4  # Default n_generate is 4
-        )
+        set_n_generate(study._study_id, study._storage, 4)  # Default n_generate
         return PreferentialStudy(study)
 
     except optuna.exceptions.DuplicatedStudyError:

--- a/optuna_dashboard/preferential/_system_attrs.py
+++ b/optuna_dashboard/preferential/_system_attrs.py
@@ -66,10 +66,10 @@ def is_skipped_trial(trial_id: int, study_system_attrs: dict[str, Any]) -> bool:
 def get_n_generate(study_system_attrs: dict[str, Any]) -> int:
     return study_system_attrs[_SYSTEM_ATTR_N_GENERATE]
 
+
 def set_n_generate(study_id: int, n_generate: int, storage: BaseStorage) -> None:
     storage.set_study_system_attr(
         study_id=study_id,
         key=_SYSTEM_ATTR_N_GENERATE,
         value=n_generate,
     )
-

--- a/optuna_dashboard/preferential/_system_attrs.py
+++ b/optuna_dashboard/preferential/_system_attrs.py
@@ -67,7 +67,7 @@ def get_n_generate(study_system_attrs: dict[str, Any]) -> int:
     return study_system_attrs[_SYSTEM_ATTR_N_GENERATE]
 
 
-def set_n_generate(study_id: int, n_generate: int, storage: BaseStorage) -> None:
+def set_n_generate(study_id: int, storage: BaseStorage, n_generate: int) -> None:
     storage.set_study_system_attr(
         study_id=study_id,
         key=_SYSTEM_ATTR_N_GENERATE,

--- a/optuna_dashboard/preferential/_system_attrs.py
+++ b/optuna_dashboard/preferential/_system_attrs.py
@@ -9,6 +9,7 @@ from optuna.trial import TrialState
 
 _SYSTEM_ATTR_PREFIX_PREFERENCE = "preference:values"
 _SYSTEM_ATTR_PREFIX_SKIP_TRIAL = "preference:skip_trial:"
+_SYSTEM_ATTR_N_GENERATE = "preference:n_generate"
 
 
 def report_preferences(
@@ -60,3 +61,15 @@ def report_skip(
 def is_skipped_trial(trial_id: int, study_system_attrs: dict[str, Any]) -> bool:
     key = _SYSTEM_ATTR_PREFIX_SKIP_TRIAL + str(trial_id)
     return key in study_system_attrs
+
+
+def get_n_generate(study_system_attrs: dict[str, Any]) -> int:
+    return study_system_attrs[_SYSTEM_ATTR_N_GENERATE]
+
+def set_n_generate(study_id: int, n_generate: int, storage: BaseStorage) -> None:
+    storage.set_study_system_attr(
+        study_id=study_id,
+        key=_SYSTEM_ATTR_N_GENERATE,
+        value=n_generate,
+    )
+


### PR DESCRIPTION

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## What does this implement/fix? Explain your changes.
Change the behavior of `best_trials` to "reported good at least once, not reported bad and not skipped". 

Add `active_trials` that are "not reported bad and not skipped" to show in UI.