### PR TITLE
Fix best trials in analytics when preference feedback mode

### DIFF
--- a/optuna_dashboard/ts/components/BestTrialsCard.tsx
+++ b/optuna_dashboard/ts/components/BestTrialsCard.tsx
@@ -32,22 +32,23 @@ export const BestTrialsCard: FC<{
     header = `Best Trial (number=${bestTrial.number})`
     content = (
       <>
-        {bestTrial.values === undefined || bestTrial.values.length === 1 ? (
-          <Typography
-            variant="h3"
-            sx={{
-              fontWeight: theme.typography.fontWeightBold,
-              marginBottom: theme.spacing(2),
-            }}
-            color="secondary"
-          >
-            {bestTrial.values}
-          </Typography>
-        ) : (
-          <Typography>
-            Objective Values = [{bestTrial.values?.join(", ")}]
-          </Typography>
-        )}
+        {!studyDetail?.is_preferential &&
+          (bestTrial.values === undefined || bestTrial.values.length === 1 ? (
+            <Typography
+              variant="h3"
+              sx={{
+                fontWeight: theme.typography.fontWeightBold,
+                marginBottom: theme.spacing(2),
+              }}
+              color="secondary"
+            >
+              {bestTrial.values}
+            </Typography>
+          ) : (
+            <Typography>
+              Objective Values = [{bestTrial.values?.join(", ")}]
+            </Typography>
+          ))}
         <Typography>
           Params = [
           {bestTrial.params


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
When a study is in preference mode, I hid the objective value from best trials in analysis.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
