### PR TITLE
Implement log scale of parallel coordinate

### DIFF
--- a/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
@@ -175,12 +175,13 @@ const plotCoordinate = (
     })
     const minValue = Math.min(...logValues)
     const maxValue = Math.max(...logValues)
+    const range = [minValue, maxValue]
     const tickvals = Array.from(
       { length: Math.ceil(maxValue) - Math.floor(minValue) + 1 },
       (_, i) => i + Math.floor(minValue)
     )
     const ticktext = tickvals.map((x) => `${Math.pow(10, x).toPrecision(3)}`)
-    return { logValues, tickvals, ticktext }
+    return { logValues, range, tickvals, ticktext }
   }
 
   const dimensions = targets.map((target) => {
@@ -215,15 +216,14 @@ const plotCoordinate = (
         }
       } else if (s.distribution.log) {
         // numerical and log
-        const values = trials.map((t) => {
-          return target.getTargetValue(t) as number
-        })
-        const { logValues, tickvals, ticktext } = calculateLogScale(values)
+        const { logValues, range, tickvals, ticktext } =
+          calculateLogScale(values)
         return {
           label: breakLabelIfTooLong(s.name),
           values: logValues,
-          tickvals: tickvals,
-          ticktext: ticktext,
+          range,
+          tickvals,
+          ticktext,
         }
       } else {
         // numerical and non-log

--- a/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
@@ -175,7 +175,7 @@ const plotCoordinate = (
     })
     const minValue = Math.min(...logValues)
     const maxValue = Math.max(...logValues)
-    const range = [minValue, maxValue]
+    const range = [Math.floor(minValue), Math.ceil(maxValue)]
     const tickvals = Array.from(
       { length: Math.ceil(maxValue) - Math.floor(minValue) + 1 },
       (_, i) => i + Math.floor(minValue)
@@ -226,7 +226,7 @@ const plotCoordinate = (
           ticktext,
         }
       } else {
-        // numerical and non-log
+        // numerical and linear
         return {
           label: breakLabelIfTooLong(s.name),
           values: values,


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
NA

Log axis if distribution is log scale for parallel coordinate plot

## scripts
```
import logging

import optuna
from optuna_dashboard._app import create_app


host = "127.0.0.1"
port = 8080

optuna.logging.set_verbosity(logging.CRITICAL)


def create_optuna_storage() -> optuna.storages.InMemoryStorage:
    storage = optuna.storages.InMemoryStorage()

    # Single-objective study
    study = optuna.create_study(study_name="single-objective", storage=storage)

    def objective_single(trial: optuna.Trial) -> float:
        x1 = trial.suggest_float("x1", 0, 10)
        x2 = trial.suggest_float("x2", 0.1, 10, log=True)
        x3 = trial.suggest_categorical("x3", ["foo", "bar"])
        return (x1 - 2) ** 2 + (x2 - 5) ** 2

    study.optimize(objective_single, n_trials=100)

    return storage


def main() -> None:
    storage = create_optuna_storage()
    app = create_app(storage, debug=True)
    app.run(host=host, port=port, reloader=True)


if __name__ == "__main__":
    main()
```


