### PR TITLE
Fix 3dm axis handling

### DIFF
--- a/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
@@ -75,10 +75,8 @@ export const ThreejsArtifactViewer: React.FC<ThreejsArtifactViewerProps> = (
       loader.load(props.src, (object: THREE.Object3D) => {
         const meshes = object.children as THREE.Mesh[]
         const rhinoGeometries = meshes.map((mesh) => mesh.geometry)
+        THREE.Object3D.DEFAULT_UP.set(0, 0, 1)
         if (rhinoGeometries.length > 0) {
-          rhinoGeometries.forEach((rhinoGeometry) => {
-            rhinoGeometry.rotateX(-Math.PI / 4)
-          })
           handleLoadedGeometries(rhinoGeometries)
         }
       })


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Follow-up #552 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

The 3dm file has a Z-up coordinate system, but Threejs has a Y-up coordinate system.
So far, the model was rotated after the 3dm file was loaded. However, this may cause the orientation of the model to be incorrect, so the coordinate system itself was changed.
