### PR TITLE
[PreferentialGPSampler] Do exhaustive evaluation of acquisition function when the search space is small enough

### DIFF
--- a/optuna_dashboard/preferential/samplers/gp.py
+++ b/optuna_dashboard/preferential/samplers/gp.py
@@ -4,7 +4,6 @@ import itertools
 import math
 from typing import Any
 from typing import Callable
-from typing import cast
 import warnings
 
 import botorch.acquisition.analytic

--- a/optuna_dashboard/preferential/samplers/gp.py
+++ b/optuna_dashboard/preferential/samplers/gp.py
@@ -363,7 +363,7 @@ class PreferentialGPSampler(optuna.samplers.BaseSampler):
             # TODO: Make it possible to apply it on mixed search space
             def get_all_possible_params(dist: optuna.distributions.BaseDistribution) -> list[Any]:
                 if isinstance(dist, CategoricalDistribution):
-                    return dist.choices
+                    return list(dist.choices)
                 elif isinstance(dist, (IntDistribution, FloatDistribution)):
                     return list(np.arange(dist.low, dist.high, dist.step))
                 else:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

This is a direct extention of #618, allowing users to optimize acquisition function exactly when the search space is small enough.
Also add some warnings when it falls back to continuous relaxation.