### PR TITLE
Support for older versions of the schema

### DIFF
--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -63,14 +63,18 @@ const getSchemaVersion = (db: SQLite3DB): string => {
 }
 
 const isSupportedSchema = (schemaVersion: string): boolean => {
-  let lowestVersion = "v2.6.0.a"  // OK: "v3.2.0.a", "v3.0.0.d", "v2.6.0.a"
+  let lowestVersion = "v2.6.0.a" // supported: "v3.2.0.a", "v3.0.0.{a,b,c,d}", "v2.6.0.a"
   if (schemaVersion == lowestVersion) return true
-  return isGreaterSchemaVersion(schemaVersion,lowestVersion)
+  return isGreaterSchemaVersion(schemaVersion, lowestVersion)
 }
 
-const isGreaterSchemaVersion = (leftVersion: string, rightVersion: string): boolean => { // return leftVersion > rightVersion
-  leftVersion = leftVersion.replace(/\D/g,'')
-  rightVersion = rightVersion.replace(/\D/g,'')
+const isGreaterSchemaVersion = (
+  leftVersion: string,
+  rightVersion: string
+): boolean => {
+  // return leftVersion > rightVersion
+  leftVersion = leftVersion.replace(/\D/g, "")
+  rightVersion = rightVersion.replace(/\D/g, "")
   return Number(leftVersion) > Number(rightVersion)
 }
 
@@ -147,7 +151,11 @@ const getStudies = (db: SQLite3DB, schemaVersion: string): Study[] => {
   return studies
 }
 
-const getTrials = (db: SQLite3DB, studyId: number, schemaVersion: string): Trial[] => {
+const getTrials = (
+  db: SQLite3DB,
+  studyId: number,
+  schemaVersion: string
+): Trial[] => {
   const trials: Trial[] = []
   db.exec({
     sql:
@@ -172,7 +180,11 @@ const getTrials = (db: SQLite3DB, studyId: number, schemaVersion: string): Trial
         study_id: studyId,
         state: state,
         values: getTrialValues(db, trialId, schemaVersion),
-        intermediate_values: getTrialIntermediateValues(db, trialId, schemaVersion),
+        intermediate_values: getTrialIntermediateValues(
+          db,
+          trialId,
+          schemaVersion
+        ),
         params: [], // Set this column later
         user_attrs: [], // Set this column later
         datetime_start: vals[3],
@@ -184,9 +196,13 @@ const getTrials = (db: SQLite3DB, studyId: number, schemaVersion: string): Trial
   return trials
 }
 
-const getTrialValues = (db: SQLite3DB, trialId: number, schemaVersion: string): TrialValueNumber[] => {
+const getTrialValues = (
+  db: SQLite3DB,
+  trialId: number,
+  schemaVersion: string
+): TrialValueNumber[] => {
   const values: TrialValueNumber[] = []
-  if (isGreaterSchemaVersion(schemaVersion,"v2.6.0.a")) {
+  if (isGreaterSchemaVersion(schemaVersion, "v2.6.0.a")) {
     db.exec({
       sql:
         "SELECT value, value_type" +
@@ -257,8 +273,17 @@ const paramInternalValueToExternalValue = (
 
 const parseDistributionJSON = (t: string): Distribution => {
   const parsed = JSON.parse(t)
-  const floatDistributionList = ["FloatDistribution", "UniformDistribution", "LogUniformDistribution", "DiscreteUniformDistribution"]
-  const intDistributionList = ["IntDistribution", "IntUniformDistribution", "IntLogUniformDistribution"]
+  const floatDistributionList = [
+    "FloatDistribution",
+    "UniformDistribution",
+    "LogUniformDistribution",
+    "DiscreteUniformDistribution",
+  ]
+  const intDistributionList = [
+    "IntDistribution",
+    "IntUniformDistribution",
+    "IntLogUniformDistribution",
+  ]
   if (floatDistributionList.includes(parsed.name)) {
     return {
       type: "FloatDistribution",
@@ -317,7 +342,7 @@ const getTrialIntermediateValues = (
   schemaVersion: string
 ): TrialIntermediateValue[] => {
   const values: TrialIntermediateValue[] = []
-  if (isGreaterSchemaVersion(schemaVersion,"v2.6.0.a")) {
+  if (isGreaterSchemaVersion(schemaVersion, "v2.6.0.a")) {
     db.exec({
       sql:
         "SELECT step, intermediate_value, intermediate_value_type" +
@@ -334,7 +359,7 @@ const getTrialIntermediateValues = (
               ? "+inf"
               : vals[2] === "NAN"
               ? "nan"
-              : vals[1]
+              : vals[1],
         })
       },
     })

--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -51,13 +51,12 @@ export const loadStorage = (
 
 const isSupportedSchema = (db: SQLite3DB): boolean => {
   let supported = true
+  let supportedVersions = ["v3.2.0.a"]
   db.exec({
-    sql: "SELECT schema_version FROM version_info LIMIT 1",
+    sql: "SELECT version_num FROM alembic_version LIMIT 1",
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     callback: (vals: any[]) => {
-      if (vals[0] != 12) {
-        supported = false
-      }
+      supported = supportedVersions.includes(vals[0])
     },
   })
   return supported

--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -279,18 +279,7 @@ const paramInternalValueToExternalValue = (
 
 const parseDistributionJSON = (t: string): Distribution => {
   const parsed = JSON.parse(t)
-  const floatDistributionList = [
-    "FloatDistribution",
-    "UniformDistribution",
-    "LogUniformDistribution",
-    "DiscreteUniformDistribution",
-  ]
-  const intDistributionList = [
-    "IntDistribution",
-    "IntUniformDistribution",
-    "IntLogUniformDistribution",
-  ]
-  if (floatDistributionList.includes(parsed.name)) {
+  if (parsed.name === "FloatDistribution") {
     return {
       type: "FloatDistribution",
       low: parsed.attributes.low as number,
@@ -298,13 +287,53 @@ const parseDistributionJSON = (t: string): Distribution => {
       step: parsed.attributes.step as number,
       log: parsed.attributes.log as boolean,
     }
-  } else if (intDistributionList.includes(parsed.name)) {
+  } else if (parsed.name === "UniformDistribution") {
+    return {
+      type: "FloatDistribution",
+      low: parsed.attributes.low as number,
+      high: parsed.attributes.high as number,
+      step: null,
+      log: false,
+    }
+  } else if (parsed.name === "LogUniformDistribution") {
+    return {
+      type: "FloatDistribution",
+      low: parsed.attributes.low as number,
+      high: parsed.attributes.high as number,
+      step: null,
+      log: true,
+    }
+  } else if (parsed.name === "DiscreteUniformDistribution") {
+    return {
+      type: "FloatDistribution",
+      low: parsed.attributes.low as number,
+      high: parsed.attributes.high as number,
+      step: parsed.attributes.q,
+      log: false,
+    }
+  } else if (parsed.name === "IntDistribution") {
     return {
       type: "IntDistribution",
       low: parsed.attributes.low as number,
       high: parsed.attributes.high as number,
       step: parsed.attributes.step as number,
       log: parsed.attributes.log as boolean,
+    }
+  } else if (parsed.name === "IntUniformDistribution") {
+    return {
+      type: "IntDistribution",
+      low: parsed.attributes.low as number,
+      high: parsed.attributes.high as number,
+      step: parsed.attributes.step as number,
+      log: false,
+    }
+  } else if (parsed.name === "IntLogUniformDistribution") {
+    return {
+      type: "IntDistribution",
+      low: parsed.attributes.low as number,
+      high: parsed.attributes.high as number,
+      step: parsed.attributes.step as number,
+      log: true,
     }
   } else {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -332,7 +332,9 @@ const getTrialIntermediateValues = (
               ? "-inf"
               : vals[2] === "INF_POS"
               ? "+inf"
-              : vals[1], // TODO: NANの対応
+              : vals[2] === "NAN"
+              ? "nan"
+              : vals[1]
         })
       },
     })

--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -63,7 +63,7 @@ const getSchemaVersion = (db: SQLite3DB): string => {
 }
 
 const isSupportedSchema = (schemaVersion: string): boolean => {
-  let lowestVersion = "v2.6.0.a" // supported: "v3.2.0.a", "v3.0.0.{a,b,c,d}", "v2.6.0.a"
+  const lowestVersion = "v2.6.0.a" // supported: "v3.2.0.a", "v3.0.0.{a,b,c,d}", "v2.6.0.a"
   if (schemaVersion == lowestVersion) return true
   return isGreaterSchemaVersion(schemaVersion, lowestVersion)
 }

--- a/standalone_app/src/sqlite3.ts
+++ b/standalone_app/src/sqlite3.ts
@@ -73,9 +73,15 @@ const isGreaterSchemaVersion = (
   rightVersion: string
 ): boolean => {
   // return leftVersion > rightVersion
+  const leftSuffix = leftVersion.split(".").reverse()[0]
+  const rightSuffix = rightVersion.split(".").reverse()[0]
   leftVersion = leftVersion.replace(/\D/g, "")
   rightVersion = rightVersion.replace(/\D/g, "")
-  return Number(leftVersion) > Number(rightVersion)
+
+  const left = Number(leftVersion)
+  const right = Number(rightVersion)
+  if (left == right) return leftSuffix > rightSuffix
+  return left > right
 }
 
 const getStudies = (db: SQLite3DB, schemaVersion: string): Study[] => {
@@ -202,7 +208,7 @@ const getTrialValues = (
   schemaVersion: string
 ): TrialValueNumber[] => {
   const values: TrialValueNumber[] = []
-  if (isGreaterSchemaVersion(schemaVersion, "v2.6.0.a")) {
+  if (isGreaterSchemaVersion(schemaVersion, "v3.0.0.c")) {
     db.exec({
       sql:
         "SELECT value, value_type" +
@@ -342,7 +348,7 @@ const getTrialIntermediateValues = (
   schemaVersion: string
 ): TrialIntermediateValue[] => {
   const values: TrialIntermediateValue[] = []
-  if (isGreaterSchemaVersion(schemaVersion, "v2.6.0.a")) {
+  if (isGreaterSchemaVersion(schemaVersion, "v3.0.0.c")) {
     db.exec({
       sql:
         "SELECT step, intermediate_value, intermediate_value_type" +

--- a/standalone_app/src/types/index.d.ts
+++ b/standalone_app/src/types/index.d.ts
@@ -10,7 +10,7 @@ type FloatDistribution = {
   type: "FloatDistribution"
   low: number
   high: number
-  step: number
+  step: number | null
   log: boolean
 }
 
@@ -18,7 +18,7 @@ type IntDistribution = {
   type: "IntDistribution"
   low: number
   high: number
-  step: number
+  step: number | null
   log: boolean
 }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
null

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
- Adds support for older versions of the schema. 
   - Especially, supported for  "v3.2.0.x", "v3.0.0.x" and "v2.6.0.x"
- Fixes bug regarding `intermediate_value_type`.