### PR TITLE
Improve accuracy of `_one_side_trunc_norm_sampling`

### DIFF
--- a/python_tests/preferential/samplers/test_gp.py
+++ b/python_tests/preferential/samplers/test_gp.py
@@ -1,0 +1,29 @@
+import sys
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+import torch
+
+
+if sys.version_info >= (3, 8):
+    from optuna_dashboard.preferential.samplers.gp import _one_side_trunc_norm_sampling
+else:
+    pytest.skip("BoTorch dropped Python3.7 support", allow_module_level=True)
+
+
+def test_one_side_trunc_norm_sampling() -> None:
+    for lower in np.linspace(-10, 10, 100):
+        assert _one_side_trunc_norm_sampling(torch.tensor([lower], dtype=torch.float64)) >= lower
+
+    with patch.object(torch, "rand", return_value=torch.tensor([0.4], dtype=torch.float64)):
+        sampled_value = _one_side_trunc_norm_sampling(torch.tensor([0.1], dtype=torch.float64))
+        assert np.allclose(sampled_value.numpy(), 0.899967154837563)
+
+    with patch.object(torch, "rand", return_value=torch.tensor([0.8], dtype=torch.float64)):
+        sampled_value = _one_side_trunc_norm_sampling(torch.tensor([-2.3], dtype=torch.float64))
+        assert np.allclose(sampled_value.numpy(), -0.8113606739551955)
+
+    with patch.object(torch, "rand", return_value=torch.tensor([0.1], dtype=torch.float64)):
+        sampled_value = _one_side_trunc_norm_sampling(torch.tensor([5], dtype=torch.float64))
+        assert np.allclose(sampled_value.numpy(), 5.426934003050024)

--- a/python_tests/preferential/samplers/test_gp.py
+++ b/python_tests/preferential/samplers/test_gp.py
@@ -3,11 +3,11 @@ from unittest.mock import patch
 
 import numpy as np
 import pytest
-import torch
 
 
 if sys.version_info >= (3, 8):
     from optuna_dashboard.preferential.samplers.gp import _one_side_trunc_norm_sampling
+    import torch
 else:
     pytest.skip("BoTorch dropped Python3.7 support", allow_module_level=True)
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
Improve the accuracy of `_one_side_trunc_norm_sampling` and add tests. The expected values were calculated using `scipy.stats.truncnorm`.