### PR TITLE
Fix python-tests CI with Python 3.7

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/workflows/python-tests.yml'
       - '**.py'
+      - 'pyproject.toml'
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ test = [
 optional = [
     "streamlit",
     "boto3",
-    "botorch>=0.8.1",
+    "botorch>=0.8.1; python_version>='3.8'",
 ]
 
 preferential = [


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This issue introduced by #652.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Due to #652, CI now installs `botorch>=0.8.1`, but this does not work on Python 3.7. This PR fixes it.