### PR TITLE
Ordering trial by value should always de-prioritise undefined values

### DIFF
--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -28,7 +28,7 @@ interface DataGridColumn<T> {
   field: keyof T
   label: string
   sortable?: boolean
-  less?: (a: T, b: T) => number
+  less?: (a: T, b: T, ascending: boolean) => number
   filterable?: boolean
   toCellValue?: (rowIndex: number) => string | React.ReactNode
   padding?: "normal" | "checkbox" | "none"
@@ -358,7 +358,8 @@ function stableSort<T>(
   const stabilizedThis = array.map((el, index) => [el, index] as [T, number])
   stabilizedThis.sort((a, b) => {
     if (less) {
-      const result = order == "asc" ? -less(a[0], b[0]) : less(a[0], b[0])
+      const ascending = order == "asc"
+      const result = ascending ? -less(a[0], b[0], ascending) : less(a[0], b[0], ascending)
       if (result !== 0) return result
     } else {
       const result = comparator(a[0], b[0])

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -359,7 +359,9 @@ function stableSort<T>(
   stabilizedThis.sort((a, b) => {
     if (less) {
       const ascending = order == "asc"
-      const result = ascending ? -less(a[0], b[0], ascending) : less(a[0], b[0], ascending)
+      const result = ascending
+        ? -less(a[0], b[0], ascending)
+        : less(a[0], b[0], ascending)
       if (result !== 0) return result
     } else {
       const result = comparator(a[0], b[0])

--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -28,7 +28,7 @@ export const TrialTable: FC<{
       field: "values",
       label: "Value",
       sortable: true,
-      less: (firstEl, secondEl): number => {
+      less: (firstEl, secondEl, ascending): number => {
         const firstVal = firstEl.values?.[0]
         const secondVal = secondEl.values?.[0]
 
@@ -36,9 +36,9 @@ export const TrialTable: FC<{
           return 0
         }
         if (firstVal === undefined) {
-          return -1
+          return ascending ? -1 : 1
         } else if (secondVal === undefined) {
-          return 1
+          return ascending ? 1 : -1
         }
         if (firstVal === "-inf" || secondVal === "inf") {
           return 1
@@ -63,7 +63,7 @@ export const TrialTable: FC<{
             ? objectiveNames[objectiveId]
             : `Objective ${objectiveId}`,
         sortable: true,
-        less: (firstEl, secondEl): number => {
+        less: (firstEl, secondEl, ascending): number => {
           const firstVal = firstEl.values?.[objectiveId]
           const secondVal = secondEl.values?.[objectiveId]
 
@@ -71,9 +71,9 @@ export const TrialTable: FC<{
             return 0
           }
           if (firstVal === undefined) {
-            return -1
+            return ascending ? -1 : 1
           } else if (secondVal === undefined) {
-            return 1
+            return ascending ? 1 : -1
           }
           if (firstVal === "-inf" || secondVal === "inf") {
             return 1
@@ -106,7 +106,7 @@ export const TrialTable: FC<{
             ?.param_external_value || null,
         sortable: sortable,
         filterable: filterable,
-        less: (firstEl, secondEl): number => {
+        less: (firstEl, secondEl, _): number => {
           const firstVal = firstEl.params.find(
             (p) => p.name === s.name
           )?.param_internal_value
@@ -146,7 +146,7 @@ export const TrialTable: FC<{
           ?.value || null,
       sortable: attr_spec.sortable,
       filterable: !attr_spec.sortable,
-      less: (firstEl, secondEl): number => {
+      less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.user_attrs.find(
           (attr) => attr.key === attr_spec.key
         )?.value

--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -106,6 +106,7 @@ export const TrialTable: FC<{
             ?.param_external_value || null,
         sortable: sortable,
         filterable: filterable,
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         less: (firstEl, secondEl, _): number => {
           const firstVal = firstEl.params.find(
             (p) => p.name === s.name
@@ -146,6 +147,7 @@ export const TrialTable: FC<{
           ?.value || null,
       sortable: attr_spec.sortable,
       filterable: !attr_spec.sortable,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.user_attrs.find(
           (attr) => attr.key === attr_spec.key

--- a/standalone_app/src/components/DataGrid.tsx
+++ b/standalone_app/src/components/DataGrid.tsx
@@ -28,7 +28,7 @@ interface DataGridColumn<T> {
   field: keyof T
   label: string
   sortable?: boolean
-  less?: (a: T, b: T) => number
+  less?: (a: T, b: T, ascending: boolean) => number
   filterable?: boolean
   toCellValue?: (rowIndex: number) => string | React.ReactNode
   padding?: "normal" | "checkbox" | "none"
@@ -358,7 +358,8 @@ function stableSort<T>(
   const stabilizedThis = array.map((el, index) => [el, index] as [T, number])
   stabilizedThis.sort((a, b) => {
     if (less) {
-      const result = order == "asc" ? -less(a[0], b[0]) : less(a[0], b[0])
+      const ascending = order == "asc"
+      const result = ascending ? -less(a[0], b[0], ascending) : less(a[0], b[0], ascending)
       if (result !== 0) return result
     } else {
       const result = comparator(a[0], b[0])

--- a/standalone_app/src/components/DataGrid.tsx
+++ b/standalone_app/src/components/DataGrid.tsx
@@ -359,7 +359,9 @@ function stableSort<T>(
   stabilizedThis.sort((a, b) => {
     if (less) {
       const ascending = order == "asc"
-      const result = ascending ? -less(a[0], b[0], ascending) : less(a[0], b[0], ascending)
+      const result = ascending
+        ? -less(a[0], b[0], ascending)
+        : less(a[0], b[0], ascending)
       if (result !== 0) return result
     } else {
       const result = comparator(a[0], b[0])

--- a/standalone_app/src/components/TrialTable.tsx
+++ b/standalone_app/src/components/TrialTable.tsx
@@ -25,7 +25,7 @@ export const TrialTable: FC<{
       field: "values",
       label: "Value",
       sortable: true,
-      less: (firstEl, secondEl): number => {
+      less: (firstEl, secondEl, ascending): number => {
         const firstVal = firstEl.values?.[0]
         const secondVal = secondEl.values?.[0]
 
@@ -33,9 +33,9 @@ export const TrialTable: FC<{
           return 0
         }
         if (firstVal === undefined) {
-          return -1
+          return ascending ? -1 : 1
         } else if (secondVal === undefined) {
-          return 1
+          return ascending ? 1 : -1
         }
         if (firstVal === "-inf" || secondVal === "inf") {
           return 1
@@ -57,7 +57,7 @@ export const TrialTable: FC<{
         field: "values",
         label: `Objective ${objectiveId}`,
         sortable: true,
-        less: (firstEl, secondEl): number => {
+        less: (firstEl, secondEl, ascending): number => {
           const firstVal = firstEl.values?.[objectiveId]
           const secondVal = secondEl.values?.[objectiveId]
 
@@ -65,9 +65,9 @@ export const TrialTable: FC<{
             return 0
           }
           if (firstVal === undefined) {
-            return -1
+            return ascending ? -1 : 1 
           } else if (secondVal === undefined) {
-            return 1
+            return ascending ? 1 : -1
           }
           if (firstVal === "-inf" || secondVal === "inf") {
             return 1
@@ -96,7 +96,7 @@ export const TrialTable: FC<{
         null,
       sortable: true,
       filterable: false,
-      less: (firstEl, secondEl): number => {
+      less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.params.find(
           (p) => p.name === s.name
         )?.param_internal_value
@@ -126,7 +126,7 @@ export const TrialTable: FC<{
           ?.value || null,
       sortable: attr_spec.sortable,
       filterable: false,
-      less: (firstEl, secondEl): number => {
+      less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.user_attrs.find(
           (attr) => attr.key === attr_spec.key
         )?.value

--- a/standalone_app/src/components/TrialTable.tsx
+++ b/standalone_app/src/components/TrialTable.tsx
@@ -65,7 +65,7 @@ export const TrialTable: FC<{
             return 0
           }
           if (firstVal === undefined) {
-            return ascending ? -1 : 1 
+            return ascending ? -1 : 1
           } else if (secondVal === undefined) {
             return ascending ? 1 : -1
           }

--- a/standalone_app/src/components/TrialTable.tsx
+++ b/standalone_app/src/components/TrialTable.tsx
@@ -96,6 +96,7 @@ export const TrialTable: FC<{
         null,
       sortable: true,
       filterable: false,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.params.find(
           (p) => p.name === s.name
@@ -126,6 +127,7 @@ export const TrialTable: FC<{
           ?.value || null,
       sortable: attr_spec.sortable,
       filterable: false,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.user_attrs.find(
           (attr) => attr.key === attr_spec.key


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #264 

## What does this implement/fix? Explain your changes.
As we aren't considering the ascending/descending nature of sort, we end up having trials with no value appearing above trials with values in certain cases (see referenced issue). This fix takes this into account.

<img width="960" alt="chrome_kHA0xB5rbc" src="https://github.com/optuna/optuna-dashboard/assets/52001888/03bbe828-14dc-4c2d-a98c-75a6595b7c5a">
<img width="960" alt="chrome_xT0n2Qf8bw" src="https://github.com/optuna/optuna-dashboard/assets/52001888/103122ae-3909-4a62-a60c-a989a2602778">

