### PR TITLE
Add 3js artifact viewer to obj loader

### DIFF
--- a/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
@@ -197,9 +197,9 @@ function loadRhino3dm(
   props: ThreejsArtifactViewerProps,
   handleLoadedGeometries: (geometries: THREE.BufferGeometry[]) => THREE.Box3
 ) {
-  const loader = new Rhino3dmLoader()
-  loader.setLibraryPath("https://cdn.jsdelivr.net/npm/rhino3dm@7.15.0/")
-  loader.load(props.src, (object: THREE.Object3D) => {
+  const rhino3dmLoader = new Rhino3dmLoader()
+  rhino3dmLoader.setLibraryPath("https://cdn.jsdelivr.net/npm/rhino3dm@7.15.0/")
+  rhino3dmLoader.load(props.src, (object: THREE.Object3D) => {
     const meshes = object.children as THREE.Mesh[]
     const rhinoGeometries = meshes.map((mesh) => mesh.geometry)
     THREE.Object3D.DEFAULT_UP.set(0, 0, 1)

--- a/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
@@ -103,6 +103,7 @@ export const ThreejsArtifactViewer: React.FC<ThreejsArtifactViewerProps> = (
 
   return (
     <Canvas
+      frameloop="demand"
       camera={cameraSettings}
       style={{ width: props.width, height: props.height }}
     >


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

followup #552 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Support for displaying OBJ format files

![Screenshot 2023-10-23 at 18 17 22](https://github.com/optuna/optuna-dashboard/assets/23289252/bb830a83-fa93-4164-8c24-ba2ba259f9a8)
