### PR TITLE
Support intermediate value plots for constrained optimization

### DIFF
--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -85,12 +85,13 @@ const plotIntermediateValue = (
       (iv) => iv.value !== "inf" && iv.value !== "-inf" && iv.value !== "nan"
     )
     const isFeasible = trial.constraints.every((c) => c <= 0)
-    let name = `trial #${trial.number}`
-    if (trial.state === "Running") {
-      name += ` (running)`
-    } else {
-      name += isFeasible ? `` : ` (infeasible)`
-    }
+    const name = `trial #${trial.number} ${
+      trial.state === "Running"
+        ? "(running)"
+        : !isFeasible
+        ? " (infeasible)"
+        : ""
+    }`
     return {
       x: values.map((iv) => iv.step),
       y: values.map((iv) => iv.value),

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -85,20 +85,19 @@ const plotIntermediateValue = (
       (iv) => iv.value !== "inf" && iv.value !== "-inf" && iv.value !== "nan"
     )
     const isFeasible = trial.constraints.every((c) => c <= 0)
-    const name = `trial #${trial.number} ${
-      trial.state === "Running"
-        ? "(running)"
-        : !isFeasible
-        ? " (infeasible)"
-        : ""
-    }`
     return {
       x: values.map((iv) => iv.step),
       y: values.map((iv) => iv.value),
       marker: { maxdisplayed: 10 },
       mode: "lines+markers",
       type: "scatter",
-      name,
+      name: `trial #${trial.number} ${
+        trial.state === "Running"
+          ? "(running)"
+          : !isFeasible
+          ? "(infeasible)"
+          : ""
+      }`,
       ...(!isFeasible && { line: { color: "#CCCCCC", dash: "dash" } }),
     }
   })

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -98,7 +98,7 @@ const plotIntermediateValue = (
       mode: "lines+markers",
       type: "scatter",
       name,
-      ...(isFeasible && { line: { color: "#CCCCCC" } }),
+      ...(isFeasible && { line: { color: "#CCCCCC",  dash: "dash" } }),
     }
   })
   plotly.react(plotDomId, plotData, layout)

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -98,7 +98,7 @@ const plotIntermediateValue = (
       mode: "lines+markers",
       type: "scatter",
       name,
-      ...(isFeasible && { line: { color: "#CCCCCC",  dash: "dash" } }),
+      ...(!isFeasible && { line: { color: "#CCCCCC", dash: "dash" } }),
     }
   })
   plotly.react(plotDomId, plotData, layout)

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -98,7 +98,7 @@ const plotIntermediateValue = (
           ? "(infeasible)"
           : ""
       }`,
-      ...(!isFeasible && { line: { color: "#CCCCCC", dash: "dash" } }),
+      ...(!isFeasible && { line: { color: "#CCCCCC" } }),
     }
   })
   plotly.react(plotDomId, plotData, layout)

--- a/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
+++ b/optuna_dashboard/ts/components/GraphIntermediateValues.tsx
@@ -84,16 +84,21 @@ const plotIntermediateValue = (
     const values = trial.intermediate_values.filter(
       (iv) => iv.value !== "inf" && iv.value !== "-inf" && iv.value !== "nan"
     )
+    const isFeasible = trial.constraints.every((c) => c <= 0)
+    let name = `trial #${trial.number}`
+    if (trial.state === "Running") {
+      name += ` (running)`
+    } else {
+      name += isFeasible ? `` : ` (infeasible)`
+    }
     return {
       x: values.map((iv) => iv.step),
       y: values.map((iv) => iv.value),
       marker: { maxdisplayed: 10 },
       mode: "lines+markers",
       type: "scatter",
-      name:
-        trial.state !== "Running"
-          ? `trial #${trial.number}`
-          : `trial #${trial.number} (running)`,
+      name,
+      ...(isFeasible && { line: { color: "#CCCCCC" } }),
     }
   })
   plotly.react(plotDomId, plotData, layout)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR intends to support [PR#4851](https://github.com/optuna/optuna/pull/4851) in Optuna.
PR#4851 supported the gray coloring for infeasible solutions in the intermediate value plot.
Hence, I introduced the same feature to OptunaDashBoard.

Here is an example. 

1. Run the following code:

```python
import optuna
import matplotlib.pyplot as plt
from optuna.trial import Trial, FrozenTrial
from optuna.study import create_study
from optuna.visualization import plot_intermediate_values
from typing import Sequence

def objective_with_constraints(trial: Trial) -> float:
        trial.set_user_attr("constraint", [trial.number % 2])

        trial.report(trial.number, step=0)
        trial.report(trial.number + 1, step=1)
        return 0.0

def constraints(trial: FrozenTrial) -> Sequence[float]:
    return trial.user_attrs["constraint"]

study = create_study(sampler=optuna.samplers.NSGAIIISampler(constraints_func=constraints), storage="sqlite:///test.db")
study.optimize(objective_with_constraints, n_trials=10)
```

2. Then check the visualization:

```shell
$ npm run build:dev
$ optuna-dashboard sqlite:///$HOME/test.db
```

3. The appearance of the dashboard:

![image](https://github.com/optuna/optuna-dashboard/assets/47781922/102b3ea3-06ac-449d-8278-69a7c3a02ef0)

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

1. Color the infeasible trials with `#CCCCCC`,
2. Make the infeasible lines dashed (for color blind), and
3. Add the label saying ` (infeasible)` if the trials are infeasible and complete.