### PR TITLE
Pin Python version to 3.11 as a hotfix

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           architecture: x64
       - name: Install dependencies
         run: |


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Addresses #685

## What does this implement/fix? Explain your changes.

- The CI configuration is updated to explicitly use Python 3.11 instead of the latest version. This is intended to be a temporary measure until the underlying issue with botorch installation and Python 3.12 is resolved.