### PR TITLE
Add filtering with multiple values to TrialTable

### DIFF
--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -102,8 +102,8 @@ function DataGrid<T>(props: {
       return
     }
     const newFilters = filters.filter((f) => f.columnIdx !== columnIdx)
-    for (const [choiceIdx, filtered] of filteredMenus[columnIdx].entries()) {
-      if (filtered) {
+    for (const choiceIdx in filteredMenus[columnIdx]) {
+      if (filteredMenus[columnIdx][choiceIdx]) {
         newFilters.push({ columnIdx: columnIdx, value: choices[choiceIdx] })
       }
     }
@@ -124,6 +124,21 @@ function DataGrid<T>(props: {
       updateFilter(columnIdx, newFilteredMenus)
     }
     setFilteredMenus(newFilteredMenus)
+  }
+
+  const handleClickFilterMenu = (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    columnIdx: number
+  ): void => {
+    const newFilterMenuAnchorEls = Array(...filterMenuAnchorEls)
+    newFilterMenuAnchorEls[columnIdx] = e.currentTarget
+    setFilterMenuAnchorEls(newFilterMenuAnchorEls)
+  }
+
+  const handleCloseFilterMenu = (columnIdx: number): void => {
+    const newFilterMenuAnchorEls = Array(...filterMenuAnchorEls)
+    newFilterMenuAnchorEls[columnIdx] = null
+    setFilterMenuAnchorEls(newFilterMenuAnchorEls)
   }
 
   const filteredRows = rows.filter((row, rowIdx) => {
@@ -228,11 +243,7 @@ function DataGrid<T>(props: {
                             filterMenuAnchorEls[columnIdx] ? "true" : undefined
                           }
                           onClick={(e) => {
-                            const newFilterMenuAnchorEls = Array(
-                              ...filterMenuAnchorEls
-                            )
-                            newFilterMenuAnchorEls[columnIdx] = e.currentTarget
-                            setFilterMenuAnchorEls(newFilterMenuAnchorEls)
+                            handleClickFilterMenu(e, columnIdx)
                           }}
                         >
                           <FilterListIcon fontSize="small" />
@@ -242,11 +253,7 @@ function DataGrid<T>(props: {
                           id={`filter-${column.label}`}
                           open={Boolean(filterMenuAnchorEls[columnIdx])}
                           onClose={() => {
-                            const newFilterMenuAnchorEls = Array(
-                              ...filterMenuAnchorEls
-                            )
-                            newFilterMenuAnchorEls[columnIdx] = null
-                            setFilterMenuAnchorEls(newFilterMenuAnchorEls)
+                            handleCloseFilterMenu(columnIdx)
                           }}
                         >
                           {column.filterChoices.map((choice, i) => (

--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -19,6 +19,7 @@ export const TrialTable: FC<{
       label: "State",
       sortable: true,
       filterable: true,
+      filterChoices: ["Complete", "Pruned", "Fail", "Running", "Waiting"],
       padding: "none",
       toCellValue: (i) => trials[i].state.toString(),
     },

--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -18,7 +18,6 @@ export const TrialTable: FC<{
       field: "state",
       label: "State",
       sortable: true,
-      filterable: true,
       filterChoices: ["Complete", "Pruned", "Fail", "Running", "Waiting"],
       padding: "none",
       toCellValue: (i) => trials[i].state.toString(),
@@ -98,7 +97,6 @@ export const TrialTable: FC<{
   ) {
     studyDetail?.intersection_search_space.forEach((s) => {
       const sortable = s.distribution.type !== "CategoricalDistribution"
-      const filterable = s.distribution.type === "CategoricalDistribution"
       columns.push({
         field: "params",
         label: `Param ${s.name}`,
@@ -106,7 +104,10 @@ export const TrialTable: FC<{
           trials[i].params.find((p) => p.name === s.name)
             ?.param_external_value || null,
         sortable: sortable,
-        filterable: filterable,
+        filterChoices:
+          "choices" in s.distribution
+            ? s.distribution.choices.map((c) => c.value)
+            : undefined,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         less: (firstEl, secondEl, _): number => {
           const firstVal = firstEl.params.find(
@@ -147,7 +148,6 @@ export const TrialTable: FC<{
         trials[i].user_attrs.find((attr) => attr.key === attr_spec.key)
           ?.value || null,
       sortable: attr_spec.sortable,
-      filterable: !attr_spec.sortable,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       less: (firstEl, secondEl, _): number => {
         const firstVal = firstEl.user_attrs.find(

--- a/typescript_tests/DataGrid.test.tsx
+++ b/typescript_tests/DataGrid.test.tsx
@@ -23,7 +23,7 @@ it("Filter rows of DataGrid", () => {
     { id: 5, key: "foo", value: 3 },
   ]
   const columns: DataGridColumn<DummyAttribute>[] = [
-    { field: "key", label: "Key", filterable: true },
+    { field: "key", label: "Key", filterChoices: ["foo", "bar"] },
     {
       field: "value",
       label: "Value",
@@ -60,7 +60,7 @@ it("Filter rows after sorted", () => {
     { id: 5, key: "foo", value: 5000 },
   ]
   const columns: DataGridColumn<DummyAttribute>[] = [
-    { field: "key", label: "Key", filterable: true },
+    { field: "key", label: "Key", filterChoices: ["foo", "bar"] },
     {
       field: "value",
       label: "Value",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR solves [issue#238](https://github.com/optuna/optuna-dashboard/issues/238), which mentions that the trial table should be able to filter trials with multiple values.

Although the issue mentions the limitation of `DataGrid`, this PR will not directly extend `DataGrid` so that it will accommodate the filtering feature for an arbitrary input.
Rather, I focus on how to filter the trial with multiple values. 

## What does this implement/fix? Explain your changes.

In this PR, I will add the following changes:
1. Add filtering for trial state to trial table,
2. Add the sync with filterable (the check boxes track the changes in filterable as well).

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
