### PR TITLE
Split DataGrid component into two components

### DIFF
--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -119,7 +119,7 @@ function DataGrid<T>(props: {
   })
 
   // Sorting
-  const createSortHandler = (columnId: number) => () => {
+  const createSortHandler = (columnId: number) => {
     const isAsc = orderBy === columnId && order === "asc"
     setOrder(isAsc ? "desc" : "asc")
     setOrderBy(columnId)
@@ -135,20 +135,6 @@ function DataGrid<T>(props: {
   const RootDiv = styled("div")({
     width: "100%",
   })
-  const HiddenSpan = styled("span")({
-    border: 0,
-    clip: "rect(0 0 0 0)",
-    height: 1,
-    margin: -1,
-    overflow: "hidden",
-    padding: 0,
-    position: "absolute",
-    top: 20,
-    width: 1,
-  })
-  const TableHeaderCellSpan = styled("span")({
-    display: "inline-flex",
-  })
   return (
     <RootDiv>
       <TableContainer>
@@ -161,48 +147,16 @@ function DataGrid<T>(props: {
             <TableRow>
               {collapseBody ? <TableCell /> : null}
               {columns.map((column, columnIdx) => (
-                <TableCell
-                  key={columnIdx}
-                  padding={column.padding || "normal"}
-                  sortDirection={orderBy === column.field ? order : false}
-                >
-                  <TableHeaderCellSpan>
-                    {column.sortable ? (
-                      <TableSortLabel
-                        active={orderBy === columnIdx}
-                        direction={orderBy === columnIdx ? order : "asc"}
-                        onClick={createSortHandler(columnIdx)}
-                      >
-                        {column.label}
-                        {orderBy === column.field ? (
-                          <HiddenSpan>
-                            {order === "desc"
-                              ? "sorted descending"
-                              : "sorted ascending"}
-                          </HiddenSpan>
-                        ) : null}
-                      </TableSortLabel>
-                    ) : (
-                      column.label
-                    )}
-                    {column.filterable ? (
-                      <IconButton
-                        size={dense ? "small" : "medium"}
-                        style={
-                          fieldAlreadyFiltered(columnIdx)
-                            ? {}
-                            : { visibility: "hidden" }
-                        }
-                        color="inherit"
-                        onClick={() => {
-                          clearFilter(columnIdx)
-                        }}
-                      >
-                        <Clear />
-                      </IconButton>
-                    ) : null}
-                  </TableHeaderCellSpan>
-                </TableCell>
+                <DataGridHeaderColumn<T>
+                  key={column.label}
+                  createSortHandler={createSortHandler}
+                  column={column}
+                  columnIdx={columnIdx}
+                  orderBy={orderBy}
+                  order={order}
+                  clearFilter={clearFilter}
+                  filtered={fieldAlreadyFiltered(columnIdx)}
+                />
               ))}
             </TableRow>
           </TableHead>
@@ -236,6 +190,82 @@ function DataGrid<T>(props: {
         onRowsPerPageChange={handleChangeRowsPerPage}
       />
     </RootDiv>
+  )
+}
+
+function DataGridHeaderColumn<T>(props: {
+  column: DataGridColumn<T>
+  columnIdx: number
+  orderBy: number
+  order: Order
+  dense?: boolean
+  createSortHandler: (columnIdx: number) => void
+  clearFilter: (columnIdx: number) => void
+  filtered: boolean
+}) {
+  const {
+    column,
+    columnIdx,
+    dense,
+    orderBy,
+    order,
+    createSortHandler,
+    clearFilter,
+    filtered,
+  } = props
+
+  const HiddenSpan = styled("span")({
+    border: 0,
+    clip: "rect(0 0 0 0)",
+    height: 1,
+    margin: -1,
+    overflow: "hidden",
+    padding: 0,
+    position: "absolute",
+    top: 20,
+    width: 1,
+  })
+  const TableHeaderCellSpan = styled("span")({
+    display: "inline-flex",
+  })
+  return (
+    <TableCell
+      padding={column.padding || "normal"}
+      sortDirection={orderBy === column.field ? order : false}
+    >
+      <TableHeaderCellSpan>
+        {column.sortable ? (
+          <TableSortLabel
+            active={orderBy === columnIdx}
+            direction={orderBy === columnIdx ? order : "asc"}
+            onClick={() => {
+              createSortHandler(columnIdx)
+            }}
+          >
+            {column.label}
+            {orderBy === column.field ? (
+              <HiddenSpan>
+                {order === "desc" ? "sorted descending" : "sorted ascending"}
+              </HiddenSpan>
+            ) : null}
+          </TableSortLabel>
+        ) : (
+          column.label
+        )}
+        {column.filterable ? (
+          <IconButton
+            size={dense ? "small" : "medium"}
+            style={filtered ? {} : { visibility: "hidden" }}
+            color="inherit"
+            onClick={() => {
+              clearFilter(columnIdx)
+            }}
+          >
+            <Clear />
+          </IconButton>
+        ) : null}
+      </TableHeaderCellSpan>
+    </TableCell>
   )
 }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #696 

## What does this implement/fix? Explain your changes.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
This PR splits `DataGrid` component into two components, DataGrid and DataGridHeaderColumn, making it easier to introduce #696.