### PR TITLE
Add unit tests for `save_trial_user_attrs`

### DIFF
--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -246,7 +246,6 @@ class APITestCase(TestCase):
         assert study.trials[0].user_attrs == request_body["user_attrs"]
         assert study.trials[1].user_attrs == {}
 
-
     def test_save_trial_user_attrs_empty(self) -> None:
         study = optuna.create_study()
         trial = study.ask()
@@ -261,7 +260,6 @@ class APITestCase(TestCase):
         )
         self.assertEqual(status, 400)
         assert study.trials[0].user_attrs == {}
-
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")
     def test_skip_trial(self) -> None:

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -220,6 +220,49 @@ class APITestCase(TestCase):
         assert study_detail["feedback_component_type"]["output_type"] == "artifact"
         assert study_detail["feedback_component_type"]["artifact_key"] == "image"
 
+    def test_save_trial_user_attrs(self) -> None:
+        study = optuna.create_study()
+        trials: list[optuna.Trial] = []
+        for _ in range(2):
+            trial = study.ask()
+            trials.append(trial)
+
+        request_body = {
+            "user_attrs": {
+                "number": 0,
+            },
+        }
+
+        app = create_app(study._storage)
+        status, _, _ = send_request(
+            app,
+            f"/api/trials/{trials[0]._trial_id}/user-attrs",
+            "POST",
+            content_type="application/json",
+            body=json.dumps(request_body),
+        )
+        self.assertEqual(status, 204)
+
+        assert study.trials[0].user_attrs == request_body["user_attrs"]
+        assert study.trials[1].user_attrs == {}
+
+
+    def test_save_trial_user_attrs_empty(self) -> None:
+        study = optuna.create_study()
+        trial = study.ask()
+
+        app = create_app(study._storage)
+        status, _, _ = send_request(
+            app,
+            f"/api/trials/{trial._trial_id}/user-attrs",
+            "POST",
+            content_type="application/json",
+            body=json.dumps({}),
+        )
+        self.assertEqual(status, 400)
+        assert study.trials[0].user_attrs == {}
+
+
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")
     def test_skip_trial(self) -> None:
         storage = optuna.storages.InMemoryStorage()


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

`save_trial_user_attrs` was introduced to `optuna/_app.py` in https://github.com/optuna/optuna-dashboard/pull/431. However, it lacks unit tests.

## What does this implement/fix? Explain your changes.

- Add test cases for `save_trial_user_attrs` to `python_tests/test_api.py`
  - Verify that `user_attrs` are saved correctly
  - Ensure it can handle an empty dictionary as invalid input