### PR TITLE
Support `numpy` scalars in `Trial.user_attrs`

### DIFF
--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import numbers
 import threading
 from typing import Any
 from typing import List
@@ -9,7 +10,6 @@ from typing import Set
 from typing import Tuple
 from typing import TYPE_CHECKING
 
-import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -86,11 +86,11 @@ class _CachedExtraStudyProperty:
 
         self._cursor = next_cursor
 
-    def _is_sortable_value(self, v: Any) -> bool:
-        return not isinstance(v, bool) and isinstance(v, (int, float, np.integer, np.floating))
-
     def _update_user_attrs(self, trial: FrozenTrial) -> None:
-        current_user_attrs = {k: self._is_sortable_value(v) for k, v in trial.user_attrs.items()}
+        current_user_attrs = {
+            k: not isinstance(v, bool) and isinstance(v, numbers.Real)
+            for k, v in trial.user_attrs.items()
+        }
         for attr_name, current_is_sortable in current_user_attrs.items():
             is_sortable = self._union_user_attrs.get(attr_name)
             if is_sortable is None:

--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import copy
 import threading
+from typing import Any
 from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
 from typing import TYPE_CHECKING
 
+import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.trial import FrozenTrial
 from optuna.trial import TrialState
@@ -84,12 +86,11 @@ class _CachedExtraStudyProperty:
 
         self._cursor = next_cursor
 
+    def _is_sortable_value(self, v: Any) -> bool:
+        return not isinstance(v, bool) and isinstance(v, (int, float, np.integer, np.floating))
+
     def _update_user_attrs(self, trial: FrozenTrial) -> None:
-        # TODO(c-bata): Support numpy-specific number types.
-        current_user_attrs = {
-            k: not isinstance(v, bool) and isinstance(v, (int, float))
-            for k, v in trial.user_attrs.items()
-        }
+        current_user_attrs = {k: self._is_sortable_value(v) for k, v in trial.user_attrs.items()}
         for attr_name, current_is_sortable in current_user_attrs.items():
             is_sortable = self._union_user_attrs.get(attr_name)
             if is_sortable is None:

--- a/optuna_dashboard/_cached_extra_study_property.py
+++ b/optuna_dashboard/_cached_extra_study_property.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import copy
 import numbers
 import threading
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Set

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -105,7 +105,7 @@ def serialize_attrs(attrs: dict[str, Any]) -> list[Attribute]:
         elif isinstance(v, str):
             value = v
         elif isinstance(v, (np.floating, np.integer)):
-            value = v.item()
+            value = str(v.item())
         else:
             value = json.dumps(v)
             value = value[:MAX_ATTR_LENGTH] if len(value) > MAX_ATTR_LENGTH else value

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
+import numbers
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import Union
 
-import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.study import StudySummary
@@ -104,8 +104,8 @@ def serialize_attrs(attrs: dict[str, Any]) -> list[Attribute]:
             value = "<binary object>"
         elif isinstance(v, str):
             value = v
-        elif isinstance(v, (np.floating, np.integer)):
-            value = str(v.item())
+        elif isinstance(v, numbers.Real):
+            value = str(v)
         else:
             value = json.dumps(v)
             value = value[:MAX_ATTR_LENGTH] if len(value) > MAX_ATTR_LENGTH else value

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -104,6 +104,8 @@ def serialize_attrs(attrs: dict[str, Any]) -> list[Attribute]:
             value = "<binary object>"
         elif isinstance(v, str):
             value = v
+        elif isinstance(v, (np.floating, np.integer)):
+            value = v.item()
         else:
             value = json.dumps(v)
             value = value[:MAX_ATTR_LENGTH] if len(value) > MAX_ATTR_LENGTH else value

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -7,6 +7,7 @@ from typing import Any
 from typing import TYPE_CHECKING
 from typing import Union
 
+import numpy as np
 from optuna.distributions import BaseDistribution
 from optuna.distributions import CategoricalDistribution
 from optuna.study import StudySummary

--- a/python_tests/test_cached_extra_study_property.py
+++ b/python_tests/test_cached_extra_study_property.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest import TestCase
 import warnings
 
+import numpy as np
 import optuna
 from optuna import create_trial
 from optuna.distributions import BaseDistribution
@@ -254,11 +255,29 @@ class _CachedExtraStudyPropertyUserAttrs(TestCase):
 
     def test_infer_sortable(self) -> None:
         user_attrs_list: list[dict[str, Any]] = [
-            {"a": 1, "b": 1, "c": 1, "d": "a", "e": 1, "f": True},
+            {
+                "a": 1,
+                "b": 1,
+                "c": 1,
+                "d": "a",
+                "e": 1,
+                "f": True,
+                "g": np.float128(1.1),
+                "h": np.int64(2),
+            },
             {"a": 2, "b": "a", "c": "a", "d": "a"},
             {"a": 3, "b": None, "c": 3, "d": "a", "e": 3},
         ]
-        expected = {"a": True, "b": False, "c": False, "d": False, "e": True, "f": False}
+        expected = {
+            "a": True,
+            "b": False,
+            "c": False,
+            "d": False,
+            "e": True,
+            "f": False,
+            "g": True,
+            "h": True,
+        }
 
         trials = []
         for user_attrs in user_attrs_list:

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -36,7 +36,7 @@ def test_serialize_numpy_integer() -> None:
         }
     )
     assert len(serialized) == 4
-    assert all([v["value"] == 1 for v in serialized])
+    assert all([v["value"] == "1" for v in serialized])
 
 
 def test_serialize_numpy_floating() -> None:
@@ -49,7 +49,7 @@ def test_serialize_numpy_floating() -> None:
         }
     )
     assert len(serialized) == 4
-    assert all([v["value"] == 1.0 for v in serialized])
+    assert all([v["value"] == "1.0" for v in serialized])
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 
+import numpy as np
 import optuna
 from optuna_dashboard._serializer import serialize_attrs
 from optuna_dashboard._serializer import serialize_study_detail
@@ -23,6 +24,32 @@ def test_serialize_dict() -> None:
         }
     )
     assert len(serialized) <= 1
+
+
+def test_serialize_numpy_integer() -> None:
+    serialized = serialize_attrs(
+        {
+            "int8": np.int8(1),
+            "int16": np.int16(1),
+            "int32": np.int32(1),
+            "int64": np.int64(1),
+        }
+    )
+    assert len(serialized) == 4
+    assert all([v["value"] == 1 for v in serialized])
+
+
+def test_serialize_numpy_floating() -> None:
+    serialized = serialize_attrs(
+        {
+            "float16": np.float16(1.0),
+            "float32": np.float32(1.0),
+            "float64": np.float64(1.0),
+            "float128": np.float128(1.0),
+        }
+    )
+    assert len(serialized) == 4
+    assert all([v["value"] == 1.0 for v in serialized])
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

This PR addresses the following TODO comment:
https://github.com/optuna/optuna-dashboard/blob/cd2159ea463d8e48167fd07ef5e39dd99fda1d6d/optuna_dashboard/_cached_extra_study_property.py#L88

## What does this implement/fix? Explain your changes.

- This change enables the conversion of numpy scalars to Python's native numerical values during the serialization of `FrozenTrial`.
- It recognizes `np.integer` and `np.floating` as sortable values.
- The process of checking for sortable values has been extracted into a private method for better clarity.

## Discussion

`numpy` scalars can only stored in `InMemoryStorage` since they are not JSON-serializable.
I guess most of users use persistent storages such as `RDBStorage` and `JournalFileStorage` with the dashboard, so the change might benefit limited number of users.

## Additional Context

Below is the code provided to verify the behavior described.

<details>
<summary>numpy-scalars-in-user-attrs.py</summary>

```python
from __future__ import annotations

import logging
import os.path

import numpy as np
import optuna
from optuna.artifacts import FileSystemArtifactStore
from optuna_dashboard._app import create_app


host = "0.0.0.0"
port = 8080

optuna.logging.set_verbosity(logging.CRITICAL)


def create_optuna_storage() -> optuna.storages.InMemoryStorage:
    storage = optuna.storages.InMemoryStorage()

    # Single-objective study
    study = optuna.create_study(study_name="single-objective-user-attrs", storage=storage)

    def objective_single_user_attr(trial: optuna.Trial) -> float:
        x1 = trial.suggest_float("x1", 0, 10)
        x2 = trial.suggest_float("x2", 0, 10)
        if x1 < 5:
            trial.set_user_attr("X", "foo")
        else:
            trial.set_user_attr("X", "bar")
        trial.set_user_attr("Y", x1 + x2)
        trial.set_user_attr("np.float64", np.float64(x1 + x2))
        trial.set_user_attr("np.int32", np.int32(x1 + x2))
        trial.set_user_attr("int", int(x1 - x2))
        return (x1 - 2) ** 2 + (x2 - 5) ** 2

    study.optimize(objective_single_user_attr, n_trials=100)

    return storage


def main() -> None:
    storage = create_optuna_storage()
    base_path = os.path.join(os.path.dirname(__file__), "artifact")
    if not os.path.exists(base_path):
        os.mkdir(base_path)
    artifact_store = FileSystemArtifactStore(base_path=base_path)
    app = create_app(storage, artifact_store, debug=True)
    app.run(host=host, port=port, reloader=True)


if __name__ == "__main__":
    main()
```

</detalis>