### PR TITLE
Add tests for save_trial_note

### DIFF
--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -302,21 +302,24 @@ class APITestCase(TestCase):
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 1}
         status, study = self._test_save_trial_note(request_body)
         self.assertEqual(status, 204)
-        assert study.system_attrs == {
+        expected_system_attrs = {
             note_ver_key(0): request_body["version"],
             f"{note_str_key_prefix(0)}{0}": request_body["body"],
         }
+        for k, v in expected_system_attrs.items():
+            assert k in study.system_attrs
+            assert study.system_attrs[k] == v
 
     def test_save_trial_note_with_wrong_version(self) -> None:
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 0}
         status, study = self._test_save_trial_note(request_body)
         self.assertEqual(status, 409)
-        assert study.system_attrs == {}
+        assert note_ver_key(0) not in study.system_attrs
 
     def test_save_trial_note_empty(self) -> None:
         status, study = self._test_save_trial_note(request_body={})
         self.assertEqual(status, 400)
-        assert study.system_attrs == {}
+        assert note_ver_key(0) not in study.system_attrs
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")
     def test_skip_trial(self) -> None:

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -294,7 +294,7 @@ class APITestCase(TestCase):
         # Check if the version 1 is deleted.
         assert study.system_attrs == {
             note_ver_key(0): request_body["version"],
-            f"{note_str_key_prefix(0)}{0}": request_body["body"], 
+            f"{note_str_key_prefix(0)}{0}": request_body["body"],
         }
 
     def test_save_trial_note(self) -> None:
@@ -303,7 +303,7 @@ class APITestCase(TestCase):
         self.assertEqual(status, 204)
         assert study.system_attrs == {
             note_ver_key(0): request_body["version"],
-            f"{note_str_key_prefix(0)}{0}": request_body["body"], 
+            f"{note_str_key_prefix(0)}{0}": request_body["body"],
         }
 
     def test_save_trial_note_with_wrong_version(self) -> None:

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -9,7 +9,8 @@ from optuna import get_all_study_summaries
 from optuna.study import StudyDirection
 from optuna_dashboard._app import create_app
 from optuna_dashboard._app import create_new_study
-from optuna_dashboard._note import note_str_key_prefix, note_ver_key
+from optuna_dashboard._note import note_str_key_prefix
+from optuna_dashboard._note import note_ver_key
 from optuna_dashboard._preference_setting import register_preference_feedback_component
 from optuna_dashboard._preferential_history import NewHistory
 from optuna_dashboard._preferential_history import remove_history

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -291,7 +291,7 @@ class APITestCase(TestCase):
                 content_type="application/json",
                 body=json.dumps(request_body),
             )
-        self.assertEqual(status, 204)
+        assert status == 204
         # Check if the version 1 is deleted.
         assert study.system_attrs == {
             note_ver_key(0): request_body["version"],
@@ -301,7 +301,7 @@ class APITestCase(TestCase):
     def test_save_trial_note(self) -> None:
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 1}
         status, study = self._save_trial_note(request_body)
-        self.assertEqual(status, 204)
+        assert status == 204
         expected_system_attrs = {
             note_ver_key(0): request_body["version"],
             f"{note_str_key_prefix(0)}{0}": request_body["body"],
@@ -313,12 +313,12 @@ class APITestCase(TestCase):
     def test_save_trial_note_with_wrong_version(self) -> None:
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 0}
         status, study = self._save_trial_note(request_body)
-        self.assertEqual(status, 409)
+        assert status == 409
         assert note_ver_key(0) not in study.system_attrs
 
     def test_save_trial_note_empty(self) -> None:
         status, study = self._save_trial_note(request_body={})
-        self.assertEqual(status, 400)
+        assert status == 400
         assert note_ver_key(0) not in study.system_attrs
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="BoTorch dropped Python3.7 support")

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -299,7 +299,7 @@ class APITestCase(TestCase):
         }
 
     def test_save_trial_note(self) -> None:
-        request_body = {"body": "Test note.", "version": 1}
+        request_body: dict[str, int | str] = {"body": "Test note.", "version": 1}
         status, study = self._test_save_trial_note(request_body)
         self.assertEqual(status, 204)
         assert study.system_attrs == {
@@ -308,7 +308,7 @@ class APITestCase(TestCase):
         }
 
     def test_save_trial_note_with_wrong_version(self) -> None:
-        request_body = {"body": "Test note.", "version": 0}
+        request_body: dict[str, int | str] = {"body": "Test note.", "version": 0}
         status, study = self._test_save_trial_note(request_body)
         self.assertEqual(status, 409)
         assert study.system_attrs == {}

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -263,9 +263,7 @@ class APITestCase(TestCase):
         self.assertEqual(status, 400)
         assert study.trials[0].user_attrs == {}
 
-    def _save_trial_note(
-        self, request_body: dict[str, int | str]
-    ) -> tuple[int, optuna.Study]:
+    def _save_trial_note(self, request_body: dict[str, int | str]) -> tuple[int, optuna.Study]:
         study = optuna.create_study()
         trial = study.ask()
         app = create_app(study._storage)

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -263,7 +263,7 @@ class APITestCase(TestCase):
         self.assertEqual(status, 400)
         assert study.trials[0].user_attrs == {}
 
-    def _test_save_trial_note(
+    def _save_trial_note(
         self, request_body: dict[str, int | str]
     ) -> tuple[int, optuna.Study]:
         study = optuna.create_study()
@@ -300,7 +300,7 @@ class APITestCase(TestCase):
 
     def test_save_trial_note(self) -> None:
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 1}
-        status, study = self._test_save_trial_note(request_body)
+        status, study = self._save_trial_note(request_body)
         self.assertEqual(status, 204)
         expected_system_attrs = {
             note_ver_key(0): request_body["version"],
@@ -312,12 +312,12 @@ class APITestCase(TestCase):
 
     def test_save_trial_note_with_wrong_version(self) -> None:
         request_body: dict[str, int | str] = {"body": "Test note.", "version": 0}
-        status, study = self._test_save_trial_note(request_body)
+        status, study = self._save_trial_note(request_body)
         self.assertEqual(status, 409)
         assert note_ver_key(0) not in study.system_attrs
 
     def test_save_trial_note_empty(self) -> None:
-        status, study = self._test_save_trial_note(request_body={})
+        status, study = self._save_trial_note(request_body={})
         self.assertEqual(status, 400)
         assert note_ver_key(0) not in study.system_attrs
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR adds tests for [save_trial_note](https://github.com/optuna/optuna-dashboard/blob/40698888abb97224fe20211f4f7398efe24edf4e/optuna_dashboard/_app.py#L428-L449).

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

The added tests check the following:
1. Whether the bad request (400) will be returned when a note is not given,
2. Whether the conflict request (409) will be returned when the note version is not incremented,
3. Whether we can successfully save the note and version, and
4. Whether we can overwrite the note and its version.
