### PR TITLE
Fix randint ValueError in windows

### DIFF
--- a/optuna_dashboard/preferential/samplers/gp.py
+++ b/optuna_dashboard/preferential/samplers/gp.py
@@ -317,7 +317,7 @@ class PreferentialGPSampler(optuna.samplers.BaseSampler):
 
         self._rng = np.random.RandomState(seed)
         self.independent_sampler = independent_sampler or optuna.samplers.RandomSampler(
-            seed=self._rng.randint(2**32)
+            seed=self._rng.randint(2**32, dtype=np.int64)
         )
 
         self._search_space = optuna.search_space.IntersectionSearchSpace()
@@ -355,7 +355,7 @@ class PreferentialGPSampler(optuna.samplers.BaseSampler):
         )
         pref_ids = torch.tensor([[ids[b], ids[w]] for b, w in preferences], dtype=torch.int32)
         with torch.random.fork_rng():
-            torch.manual_seed(self._rng.randint(2**32))
+            torch.manual_seed(self._rng.randint(2**32, dtype=np.int64))
 
             self._gp = self._gp or _PreferentialGP(
                 kernel=self.kernel


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

When I run PreferentialOptimization in a windows environment, I get the following error in the randint function.

```
Traceback (most recent call last):
  File "c:\Users\hrntsm\Desktop\potest\main.py", line 60, in <module>
    main()
  File "c:\Users\hrntsm\Desktop\potest\main.py", line 27, in main
    sampler=PreferentialGPSampler(),
  File "C:\Users\hrntsm\Desktop\potest\.venv\lib\site-packages\optuna_dashboard\preferential\samplers\gp.py", line 320, in __init__
    seed=self._rng.randint(2**32)
  File "numpy\\random\\mtrand.pyx", line 779, in numpy.random.mtrand.RandomState.randint
  File "numpy\\random\\_bounded_integers.pyx", line 2881, in numpy.random._bounded_integers._rand_int32
ValueError: high is out of bounds for int32
```

Fix this error by specifying the dtype explicitly.

### env

- windows11
- python3.9
- optuna3.3.0
- optuna-dashboard0.13.0
