### PR TITLE
Add tests for `proxy_study_artifact`

### DIFF
--- a/python_tests/artifact/test_backend.py
+++ b/python_tests/artifact/test_backend.py
@@ -125,10 +125,11 @@ class TestProxyStudyArtifact(TestCase):
                 f.flush()
                 artifact_id = upload_artifact(self.study, f.name, artifact_store=artifact_store)
             app = create_app(self.storage, artifact_store)
-            status, _, _ = send_request(
+            status, _, body = send_request(
                 app,
                 f"/artifacts/{self.study._study_id}/{artifact_id}",
                 "GET",
                 content_type="application/json",
             )
             self.assertEqual(status, 200)
+            self.assertEqual(body, b"dummy_content")

--- a/python_tests/artifact/test_backend.py
+++ b/python_tests/artifact/test_backend.py
@@ -104,7 +104,6 @@ class TestProxyStudyArtifact(TestCase):
             content_type="application/json",
         )
         self.assertEqual(status, 400)
-        self.assertEqual(body, b"Cannot access to the artifacts.")
 
     def test_artifact_not_found(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/python_tests/artifact/test_backend.py
+++ b/python_tests/artifact/test_backend.py
@@ -116,7 +116,6 @@ class TestProxyStudyArtifact(TestCase):
                 content_type="application/json",
             )
             self.assertEqual(status, 404)
-            self.assertEqual(body, b"Not Found")
 
     def test_successful_artifact_retrieval(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR adds tests for [proxy_study_artifact](https://github.com/optuna/optuna-dashboard/blob/40698888abb97224fe20211f4f7398efe24edf4e/optuna_dashboard/artifact/_backend.py#L68-L83).

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

The added tests check the following:

1. Whether the bad request (400) will be returned when an artifact_store is not given,
2. Whether the not found (404) will be returned when an artifact_store exists but requested artifact_id is not found,
3. Whether we can successfully obtain data when an artifact_store exists and requested artifact_id is valid.