### PR TITLE
Fix a minor bug that `upload_artifact` api does not return the latest artifacts.

### DIFF
--- a/optuna_dashboard/artifact/_backend.py
+++ b/optuna_dashboard/artifact/_backend.py
@@ -139,6 +139,7 @@ def register_artifact_route(
         storage.set_trial_system_attr(trial_id, attr_key, json.dumps(artifact))
         response.status = 201
 
+        trial = storage.get_trial(trial_id)  # Fetch trial.system_attrs again.
         return {
             "artifact_id": artifact_id,
             "artifacts": list_trial_artifacts(storage.get_study_system_attrs(study_id), trial),


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Fix a minor bug that upload_artifact api does not return the latest artifacts.