### PR TITLE
Use WaveSurfer instead of `audio` tag.

### DIFF
--- a/optuna_dashboard/ts/components/ArtifactCardMedia.tsx
+++ b/optuna_dashboard/ts/components/ArtifactCardMedia.tsx
@@ -3,6 +3,7 @@ import {
   ThreejsArtifactViewer,
   isThreejsArtifact,
 } from "./ThreejsArtifactViewer"
+import { WaveSurferArtifactViewer } from "./WaveSurferArtifactViewer"
 import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile"
 import { CardMedia, Box } from "@mui/material"
 
@@ -43,9 +44,12 @@ export const ArtifactCardMedia: FC<{
           alignItems: "center",
         }}
       >
-        <audio controls style={{ width: "100%" }}>
-          <source src={urlPath} type={artifact.mimetype} />
-        </audio>
+        <WaveSurferArtifactViewer
+          height={100}
+          waveColor="rgb(200, 0, 200)"
+          progressColor="rgb(100, 0, 100)"
+          url={urlPath}
+        />
       </Box>
     )
   } else if (artifact.mimetype.startsWith("image")) {

--- a/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
@@ -9,15 +9,12 @@ interface WaveSurferArtifactViewerProps {
   url: string
 }
 
-// WaveSurfer hook
 const useWavesurfer = (
   containerRef: React.MutableRefObject<HTMLDivElement>,
   options: WaveSurferArtifactViewerProps
 ) => {
   const [wavesurfer, setWavesurfer] = useState<WaveSurfer | null>(null)
 
-  // Initialize wavesurfer when the container mounts
-  // or any of the props change
   useEffect(() => {
     if (!containerRef.current) return
 
@@ -36,8 +33,7 @@ const useWavesurfer = (
   return wavesurfer
 }
 
-// Create a React component that will render wavesurfer.
-// Props are wavesurfer options.
+// Create a React component of wavesurfer.
 export const WaveSurferArtifactViewer: React.FC<
   WaveSurferArtifactViewerProps
 > = (props) => {
@@ -45,14 +41,11 @@ export const WaveSurferArtifactViewer: React.FC<
   const [isPlaying, setIsPlaying] = useState(false)
   const wavesurfer = useWavesurfer(containerRef, props)
 
-  // On play button click
   const onPlayClick = useCallback(() => {
     if (!wavesurfer) return
     wavesurfer.isPlaying() ? wavesurfer.pause() : wavesurfer.play()
   }, [wavesurfer])
 
-  // Initialize wavesurfer when the container mounts
-  // or any of the props change
   useEffect(() => {
     if (!wavesurfer) return
 

--- a/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
@@ -28,7 +28,7 @@ const useWavesurfer = (
     return () => {
       ws.destroy()
     }
-  }, [options, containerRef])
+  }, [containerRef])
 
   return wavesurfer
 }

--- a/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/WaveSurferArtifactViewer.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useEffect, useState, useRef } from "react"
+import WaveSurfer from "wavesurfer.js"
+import { Box } from "@mui/material"
+
+interface WaveSurferArtifactViewerProps {
+  height: number
+  waveColor: string
+  progressColor: string
+  url: string
+}
+
+// WaveSurfer hook
+const useWavesurfer = (
+  containerRef: React.MutableRefObject<HTMLDivElement>,
+  options: WaveSurferArtifactViewerProps
+) => {
+  const [wavesurfer, setWavesurfer] = useState<WaveSurfer | null>(null)
+
+  // Initialize wavesurfer when the container mounts
+  // or any of the props change
+  useEffect(() => {
+    if (!containerRef.current) return
+
+    const ws = WaveSurfer.create({
+      ...options,
+      container: containerRef.current,
+    })
+
+    setWavesurfer(ws)
+
+    return () => {
+      ws.destroy()
+    }
+  }, [options, containerRef])
+
+  return wavesurfer
+}
+
+// Create a React component that will render wavesurfer.
+// Props are wavesurfer options.
+export const WaveSurferArtifactViewer: React.FC<
+  WaveSurferArtifactViewerProps
+> = (props) => {
+  const containerRef = useRef<HTMLDivElement>(null!)
+  const [isPlaying, setIsPlaying] = useState(false)
+  const wavesurfer = useWavesurfer(containerRef, props)
+
+  // On play button click
+  const onPlayClick = useCallback(() => {
+    if (!wavesurfer) return
+    wavesurfer.isPlaying() ? wavesurfer.pause() : wavesurfer.play()
+  }, [wavesurfer])
+
+  // Initialize wavesurfer when the container mounts
+  // or any of the props change
+  useEffect(() => {
+    if (!wavesurfer) return
+
+    setIsPlaying(false)
+
+    const subscriptions = [
+      wavesurfer.on("play", () => setIsPlaying(true)),
+      wavesurfer.on("pause", () => setIsPlaying(false)),
+    ]
+
+    return () => {
+      subscriptions.forEach((unsub) => unsub())
+    }
+  }, [wavesurfer])
+
+  return (
+    <Box style={{ width: "100%", display: "flex", flexDirection: "column" }}>
+      <div ref={containerRef} style={{ minHeight: "120px", width: "100%" }} />
+      <button onClick={onPlayClick} style={{ marginTop: "1em" }}>
+        {isPlaying ? "Pause" : "Play"}
+      </button>
+    </Box>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,8 @@
         "rehype-raw": "^6.1.1",
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
-        "three": "^0.155.0"
+        "three": "^0.155.0",
+        "wavesurfer.js": "^7.4.12"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -14824,6 +14825,11 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/wavesurfer.js": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.4.12.tgz",
+      "integrity": "sha512-KzH4LkcOp8LECs9cOVIPBl6vsSoICKuZz+v5kh/zvxilpaVszU+QKC+4s2KEAqcCxBCecg3cNSg4RqAx278F8g=="
+    },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
@@ -25937,6 +25943,11 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
+    },
+    "wavesurfer.js": {
+      "version": "7.4.12",
+      "resolved": "https://registry.npmjs.org/wavesurfer.js/-/wavesurfer.js-7.4.12.tgz",
+      "integrity": "sha512-KzH4LkcOp8LECs9cOVIPBl6vsSoICKuZz+v5kh/zvxilpaVszU+QKC+4s2KEAqcCxBCecg3cNSg4RqAx278F8g=="
     },
     "web-namespaces": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "rehype-raw": "^6.1.1",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
-    "three": "^0.155.0"
+    "three": "^0.155.0",
+    "wavesurfer.js": "^7.4.12"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

A possible follow-up for https://github.com/optuna/optuna-dashboard/issues/629.

## What does this implement/fix? Explain your changes.

* Install [WaveSurfer](https://wavesurfer.xyz/) to play audio artifacts.
* Add `WaveSurferArtifactViewer` based on the [official example](https://wavesurfer.xyz/examples/?react.js)
* Use the `WaveSurferArtifactViewer` instead of `audio` tag in the ArtifactCardMedia.tsx