### PR TITLE
_cli.py: apply expandvars() to `storage` argument

### DIFF
--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import os.path
 from socketserver import ThreadingMixIn
 import sys
 from typing import TYPE_CHECKING
@@ -116,7 +117,7 @@ def main() -> None:
     args = parser.parse_args()
 
     storage: BaseStorage
-    storage = get_storage(args.storage, storage_class=args.storage_class)
+    storage = get_storage(os.path.expandvars(args.storage), storage_class=args.storage_class)
 
     artifact_store: ArtifactStore | None
     if args.artifact_dir is None:


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## What does this implement/fix? Explain your changes.

so that I can pass a database password as an environment variable, like:

```
$ export PG_PASS=53cr37  # or k8s secret or whatever
$ optuna-dashboard.py 'postgresql://optuna:$PG_PASS@db/optuna'
```

Note we must not let Bash interpret the `$` notation as that'll expose the secret to other users on the machine through commands like `ps`, `top`

Apologies, but I haven’t had the opportunity to test it myself...