### PR TITLE
Prevent layout shift with intermediate values plot

### DIFF
--- a/optuna_dashboard/ts/components/StudyHistory.tsx
+++ b/optuna_dashboard/ts/components/StudyHistory.tsx
@@ -108,17 +108,6 @@ export const StudyHistory: FC<{ studyId: number }> = ({ studyId }) => {
         </CardContent>
       </Card>
       <Grid2 container spacing={2} sx={{ padding: theme.spacing(0, 2) }}>
-        {studyDetail !== null &&
-        studyDetail.directions.length === 1 &&
-        studyDetail.has_intermediate_values ? (
-          <Grid2 xs={6}>
-            <GraphIntermediateValues
-              trials={trials}
-              includePruned={includePruned}
-              logScale={logScale}
-            />
-          </Grid2>
-        ) : null}
         <Grid2 xs={6}>
           <GraphHyperparameterImportance
             studyId={studyId}
@@ -170,6 +159,17 @@ export const StudyHistory: FC<{ studyId: number }> = ({ studyId }) => {
             </CardContent>
           </Card>
         </Grid2>
+        {studyDetail !== null &&
+        studyDetail.directions.length === 1 &&
+        studyDetail.has_intermediate_values ? (
+          <Grid2 xs={6}>
+            <GraphIntermediateValues
+              trials={trials}
+              includePruned={includePruned}
+              logScale={logScale}
+            />
+          </Grid2>
+        ) : null}
       </Grid2>
 
       {artifactEnabled && studyDetail !== null && (


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
The layout shift is occurring because the decision to display the plot of intermediate values is made during loading. This PR prevents the shift by replacing the plot last.
