### PR TITLE
Clear cache before going to another tests in unit tests

### DIFF
--- a/e2e_tests/test_dashboard/test_usecases/test_preferential_optimization.py
+++ b/e2e_tests/test_dashboard/test_usecases/test_preferential_optimization.py
@@ -9,6 +9,7 @@ from playwright.sync_api import Page
 import pytest
 
 from ...test_server import make_test_server
+from ...utils import clear_inmemory_cache
 
 
 def make_test_storage() -> optuna.storages.InMemoryStorage:
@@ -43,6 +44,7 @@ def make_test_storage() -> optuna.storages.InMemoryStorage:
 
 @pytest.fixture
 def storage() -> optuna.storages.InMemoryStorage:
+    clear_inmemory_cache()
     storage = make_test_storage()
     return storage
 

--- a/e2e_tests/test_dashboard/test_usecases/test_study_history.py
+++ b/e2e_tests/test_dashboard/test_usecases/test_study_history.py
@@ -3,6 +3,7 @@ from playwright.sync_api import Page
 import pytest
 
 from ...test_server import make_test_server
+from ...utils import clear_inmemory_cache
 
 
 def make_test_storage() -> optuna.storages.InMemoryStorage:
@@ -23,6 +24,7 @@ def make_test_storage() -> optuna.storages.InMemoryStorage:
 
 @pytest.fixture
 def storage() -> optuna.storages.InMemoryStorage:
+    clear_inmemory_cache()
     storage = make_test_storage()
     return storage
 

--- a/e2e_tests/test_dashboard/visual_regression_test.py
+++ b/e2e_tests/test_dashboard/visual_regression_test.py
@@ -1,19 +1,11 @@
 from typing import Callable
 
 import optuna
-from optuna_dashboard._storage import trials_cache
-from optuna_dashboard._storage import trials_cache_lock
-from optuna_dashboard._storage import trials_last_fetched_at
 from playwright.sync_api import Page
 import pytest
 
 from ..test_server import make_test_server
-
-
-def clear_inmemory_cache() -> None:
-    with trials_cache_lock:
-        trials_cache.clear()
-        trials_last_fetched_at.clear()
+from ..utils import clear_inmemory_cache
 
 
 @pytest.fixture

--- a/e2e_tests/test_dashboard/visual_regression_test.py
+++ b/e2e_tests/test_dashboard/visual_regression_test.py
@@ -1,12 +1,11 @@
 from typing import Callable
 
 import optuna
-from playwright.sync_api import Page
-import pytest
-
 from optuna_dashboard._storage import trials_cache
 from optuna_dashboard._storage import trials_cache_lock
 from optuna_dashboard._storage import trials_last_fetched_at
+from playwright.sync_api import Page
+import pytest
 
 from ..test_server import make_test_server
 

--- a/e2e_tests/test_dashboard/visual_regression_test.py
+++ b/e2e_tests/test_dashboard/visual_regression_test.py
@@ -4,11 +4,22 @@ import optuna
 from playwright.sync_api import Page
 import pytest
 
+from optuna_dashboard._storage import trials_cache
+from optuna_dashboard._storage import trials_cache_lock
+from optuna_dashboard._storage import trials_last_fetched_at
+
 from ..test_server import make_test_server
+
+
+def clear_inmemory_cache() -> None:
+    with trials_cache_lock:
+        trials_cache.clear()
+        trials_last_fetched_at.clear()
 
 
 @pytest.fixture
 def storage() -> optuna.storages.InMemoryStorage:
+    clear_inmemory_cache()
     storage = optuna.storages.InMemoryStorage()
     return storage
 

--- a/e2e_tests/utils.py
+++ b/e2e_tests/utils.py
@@ -1,0 +1,9 @@
+from optuna_dashboard._storage import trials_cache
+from optuna_dashboard._storage import trials_cache_lock
+from optuna_dashboard._storage import trials_last_fetched_at
+
+
+def clear_inmemory_cache() -> None:
+    with trials_cache_lock:
+        trials_cache.clear()
+        trials_last_fetched_at.clear()


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

As the unit tests take over the cache from previous tests, I added a clearing function for such cache.
By adding this to the current set of the unit tests, we can test our code more safely.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

I added a function for cleaning up the cache.
