### PR TITLE
Replace the time heuristic for storage check with check by a new trial number

### DIFF
--- a/e2e_tests/utils.py
+++ b/e2e_tests/utils.py
@@ -1,9 +1,7 @@
 from optuna_dashboard._storage import trials_cache
 from optuna_dashboard._storage import trials_cache_lock
-from optuna_dashboard._storage import trials_last_fetched_at
 
 
 def clear_inmemory_cache() -> None:
     with trials_cache_lock:
         trials_cache.clear()
-        trials_last_fetched_at.clear()

--- a/optuna_dashboard/_storage.py
+++ b/optuna_dashboard/_storage.py
@@ -40,6 +40,8 @@ def _should_update_trials_cache(storage: BaseStorage, study_id: int) -> bool:
         pass
 
     for t in trials:
+        # It is very likely that the number of updatable trials (running or waiting) is bounded
+        # by n_jobs, and when n_trials is huge (e.g. 10K), n_jobs is often very small (< 10).
         if (
             not t.state.is_finished()
             and storage.get_trial(trial_id=t._trial_id).state.is_finished()

--- a/optuna_dashboard/_storage.py
+++ b/optuna_dashboard/_storage.py
@@ -42,7 +42,7 @@ def _should_update_trials_cache(storage: BaseStorage, study_id: int) -> bool:
     for t in trials:
         if (
             not t.state.is_finished()
-            and storage.get_trial(trial_id=first_updatable_id).is_finished()
+            and storage.get_trial(trial_id=t._trial_id).state.is_finished()
         ):
             return True
     else:

--- a/optuna_dashboard/_storage.py
+++ b/optuna_dashboard/_storage.py
@@ -41,7 +41,7 @@ def _should_update_trials_cache(storage: BaseStorage, study_id: int) -> bool:
 
     for t in trials:
         # It is very likely that the number of updatable trials (running or waiting) is bounded
-        # by n_jobs, and when n_trials is huge (e.g. 10K), n_jobs is often very small (< 10).
+        # by n_jobs, and n_jobs is often very small (< 10) for huge n_trials (e.g. 10K).
         if (
             not t.state.is_finished()
             and storage.get_trial(trial_id=t._trial_id).state.is_finished()

--- a/python_tests/wsgi_client.py
+++ b/python_tests/wsgi_client.py
@@ -8,7 +8,6 @@ from typing import Union
 from bottle import Bottle
 from optuna_dashboard._storage import trials_cache
 from optuna_dashboard._storage import trials_cache_lock
-from optuna_dashboard._storage import trials_last_fetched_at
 
 
 if typing.TYPE_CHECKING:
@@ -18,7 +17,6 @@ if typing.TYPE_CHECKING:
 def clear_inmemory_cache() -> None:
     with trials_cache_lock:
         trials_cache.clear()
-        trials_last_fetched_at.clear()
 
 
 def create_wsgi_env(


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Since we currently refer to the storage to get all trials for GET requests, the load for the GET requests is often heavy.
By design, it is surely efficient to fetch all the trials when we would like to get many trials at once while it is quicker to fetch a trial if we just would like to know the state or existence of a trial.

The unittests of this PR pass after merging [this PR](https://github.com/optuna/optuna-dashboard/pull/727).
The previous PR fixes bugs in unittests, which caused leaked cache from unrelated tests.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

I use the trick explained above to judge whether we should fetch all the trials.
Currently, we rely on the last timing when we check all the trials, but I replace this heuristic with the following:
1. Check the maximum trial number in cache (and define it as `max_trial_number`),
2. Check whether the storage has a trial with the number of `max_trial_number + 1` for the current `study_id` of interest,
3. If yes, fetch all the trials from the storage as it is necessary,
4. If not, check all the cached trials' states, and if any states are updatable and the corresponding trial in the storage is not updatable (`COMPLETE`, `PRUNED`, or `FAILED`), we fetch all the trials,
5. Otherwise, we do not check all the trials.

Note that we need the time complexity of `O(N)` where `N` is the number rows in the storage to fetch a trial and I assume that we do not have so many running or waiting trials in each study as it is very unlikely to have many of such trials if Optuna works as intended.