### PR TITLE
Make running trials in timeline plot visible

### DIFF
--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -70,7 +70,7 @@ const plotTimeline = (trials: Trial[], mode: string) => {
     ...trials.map((t) => {
       return t.datetime_start === undefined || t.datetime_complete === undefined
         ? -Infinity
-        : t.datetime_start.getTime() - t.datetime_complete.getTime()
+        : t.datetime_complete.getTime() - t.datetime_start.getTime()
     })
   )
   const hasRunning =

--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -123,12 +123,11 @@ const plotTimeline = (trials: Trial[], mode: string) => {
     const starts = bars.map((b) => b.datetime_start ?? new Date())
     const runDurations = bars.map((b, i) => {
       const startTime = starts[i].getTime()
-      const completeTime = b.datetime_complete?.getTime() ?? startTime
+      const completeTime = isRunning
+        ? maxDatetime.getTime()
+        : b.datetime_complete?.getTime() ?? startTime
       // By using 1 as the min value, we can recognize these bars at least when zooming in.
-      return Math.max(
-        1,
-        !isRunning ? completeTime - startTime : maxDatetime.getTime() - startTime
-      )
+      return Math.max(1, completeTime - startTime)
     })
     const trace: Partial<plotly.PlotData> = {
       type: "bar",

--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -80,8 +80,8 @@ const plotTimeline = (trials: Trial[], mode: string) => {
       if (t.state !== runningKey) {
         return false
       }
-      const start = t.datetime_start?.getTime() ?? new Date().getTime()
       const now = new Date().getTime()
+      const start = t.datetime_start?.getTime() ?? now
       // This is an ad-hoc handling to check if the trial is running.
       // We do not check via `trialState` because some trials may have state=RUNNING,
       // even if they are not running because of unexpected job kills.
@@ -120,7 +120,8 @@ const plotTimeline = (trials: Trial[], mode: string) => {
 
   const makeTrace = (bars: Trial[], state: string, color: string) => {
     const isRunning = state === runningKey
-    const starts = bars.map((b) => b.datetime_start ?? new Date())
+    // Waiting trials should not squash other trials, so use `maxDatetime` instead of `new Date()`.
+    const starts = bars.map((b) => b.datetime_start ?? maxDatetime)
     const runDurations = bars.map((b, i) => {
       const startTime = starts[i].getTime()
       const completeTime = isRunning

--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -68,13 +68,14 @@ const plotTimeline = (trials: Trial[], mode: string) => {
   )
   const maxRunDuration = Math.max(
     ...trials.map((t) => {
-      const start = t.datetime_start?.getTime() ?? new Date().getTime()
-      const complete = t.datetime_complete?.getTime() ?? start
-      return t.state === runningKey ? -Infinity : complete - start
+      return t.datetime_start === undefined || t.datetime_complete === undefined
+        ? -Infinity
+        : t.datetime_start.getTime() - t.datetime_complete.getTime()
     })
   )
   const hasRunning =
-    maxRunDuration === -Infinity ||
+    (maxRunDuration === -Infinity &&
+      trials.some((t) => t.state === runningKey)) ||
     trials.some((t) => {
       if (t.state !== runningKey) {
         return false
@@ -120,7 +121,10 @@ const plotTimeline = (trials: Trial[], mode: string) => {
       const start = b.datetime_start?.getTime() ?? new Date().getTime()
       const complete = b.datetime_complete?.getTime() ?? start
       // By using 1 as the min value, we can recognize these bars at least when zooming in.
-      return Math.max(1, !isRunning ? complete - start : maxDatetime.getTime() - start)
+      return Math.max(
+        1,
+        !isRunning ? complete - start : maxDatetime.getTime() - start
+      )
     })
     const trace: Partial<plotly.PlotData> = {
       type: "bar",

--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -66,32 +66,33 @@ const plotTimeline = (trials: Trial[], mode: string) => {
     )
   )
   const maxRunDuration = Math.max(
-    ...lastTrials.map(
-      (t) => {
-        const start = t.datetime_start?.getTime() ?? new Date().getTime()
-        const complete = t.datetime_complete?.getTime() ?? start
-        return complete - start
-      }
-    )
+    ...lastTrials.map((t) => {
+      const start = t.datetime_start?.getTime() ?? new Date().getTime()
+      const complete = t.datetime_complete?.getTime() ?? start
+      return complete - start
+    })
   )
-  const hasRunning = maxRunDuration === 0 || lastTrials.some((t) => {
+  const hasRunning =
+    maxRunDuration === 0 ||
+    lastTrials.some((t) => {
       const isRunning = t.state === "Running"
-      if (!isRunning){
+      if (!isRunning) {
         return false
       }
       const start = t.datetime_start?.getTime() ?? new Date().getTime()
       const now = new Date().getTime()
       // This is an ad-hoc handling to check if the trial is running.
       return now - start < maxRunDuration * 5
-    }
-  )
-  const maxDatetime = hasRunning ? new Date() : new Date(
-    Math.max(
-      ...lastTrials.map(
-        (t) => t.datetime_complete?.getTime() ?? minDatetime.getTime()
+    })
+  const maxDatetime = hasRunning
+    ? new Date()
+    : new Date(
+        Math.max(
+          ...lastTrials.map(
+            (t) => t.datetime_complete?.getTime() ?? minDatetime.getTime()
+          )
+        )
       )
-    )
-  )
   const layout: Partial<plotly.Layout> = {
     margin: {
       l: 50,


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR makes the running trials in the timeline plot visible.
Currently, running trials are handled as a run duration of zero.
For this reason, we cannot see running trials in the timeline plot although it actually exists.
In this PR, I aim to make them appear in the timeline plot.
Plus, I revised the code so that trials, which were killed before they completed, will handle the max time in the plot as the max completed/pruned/failed timing.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This PR makes the following changes:
1. Running trials will appear on the timeline plot, and
2. The maximum of the x-axis is handled as either the current date time (if the current running durations are not too long) or the maximum completed time.
