### PR TITLE
Enable users to jump arbitrary page numbers from text field

### DIFF
--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -22,7 +22,6 @@ import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank"
 import CheckBoxIcon from "@mui/icons-material/CheckBox"
 import FilterListIcon from "@mui/icons-material/FilterList"
 import ListItemIcon from "@mui/material/ListItemIcon"
-import { Margin } from "@mui/icons-material"
 
 type Order = "asc" | "desc"
 
@@ -217,7 +216,7 @@ function DataGrid<T>(props: {
       </TableContainer>
       {filteredRows.length > 0 ? (
         <>
-          {/* tslint:disable-next-line: 2590 */}
+          {/* @ts-ignore */}
           <Box display="flex" alignItems="center">
             <TablePagination
               rowsPerPageOptions={rowsPerPageOption}
@@ -225,7 +224,9 @@ function DataGrid<T>(props: {
               count={filteredRows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              labelDisplayedRows={({ page }) => `${page+1} of ${maxPageNumber}`}
+              labelDisplayedRows={({ page }) =>
+                `${page + 1} of ${maxPageNumber}`
+              }
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}
             />

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -45,40 +45,6 @@ interface RowFilter {
   values: Value[]
 }
 
-function PaginationTextFieldComponent(props: {
-  onPageNumberSubmit: (value: number) => void
-  maxPageNumber: number
-}): React.ReactElement {
-  // This component is separated from DataGrid to prevent `DataGrid` from re-rendering the page,
-  // every time any letters are input.
-  const { onPageNumberSubmit, maxPageNumber } = props
-  const [specifiedPageText, setSpecifiedPageText] = React.useState("")
-
-  const handleSubmitPageNumber = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const newPage = parseInt(specifiedPageText, 10)
-    setSpecifiedPageText("") // reset the input field
-    if (Number.isNaN(newPage)) {
-      return
-    }
-    const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
-    // Page is 0-indexed in `TablePagination`.
-    onPageNumberSubmit(newPageNumber - 1)
-  }
-
-  return (
-    <form onSubmit={handleSubmitPageNumber}>
-      <TextField
-        label="Go to Page"
-        value={specifiedPageText}
-        onChange={(e) => {
-          setSpecifiedPageText(e.target.value)
-        }}
-      />
-    </form>
-  )
-}
-
 function DataGrid<T>(props: {
   columns: DataGridColumn<T>[]
   rows: T[]
@@ -118,6 +84,41 @@ function DataGrid<T>(props: {
   ) => {
     setRowsPerPage(parseInt(event.target.value, 10))
     setPage(0)
+  }
+
+  const PaginationTextFieldComponent: React.FC<{
+    onPageNumberSubmit: (value: number) => void
+    maxPageNumber: number
+  }> = ({ onPageNumberSubmit, maxPageNumber }) => {
+    // This component is separated from DataGrid to prevent `DataGrid` from re-rendering the page,
+    // every time any letters are input.
+    const [specifiedPageText, setSpecifiedPageText] = React.useState("")
+
+    const handleSubmitPageNumber = (
+      event: React.FormEvent<HTMLFormElement>
+    ) => {
+      event.preventDefault()
+      const newPage = parseInt(specifiedPageText, 10)
+      setSpecifiedPageText("") // reset the input field
+      if (Number.isNaN(newPage)) {
+        return
+      }
+      const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
+      // Page is 0-indexed in `TablePagination`.
+      onPageNumberSubmit(newPageNumber - 1)
+    }
+
+    return (
+      <form onSubmit={handleSubmitPageNumber}>
+        <TextField
+          label="Go to Page"
+          value={specifiedPageText}
+          onChange={(e) => {
+            setSpecifiedPageText(e.target.value)
+          }}
+        />
+      </form>
+    )
   }
 
   // Filtering

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -8,10 +8,13 @@ import {
   TablePagination,
   TableRow,
   TableSortLabel,
+  TextField,
   Collapse,
   IconButton,
   Menu,
   MenuItem,
+  Button,
+  Box,
 } from "@mui/material"
 import { styled } from "@mui/system"
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
@@ -41,6 +44,40 @@ interface DataGridColumn<T> {
 interface RowFilter {
   columnIdx: number
   values: Value[]
+}
+
+function PaginationTextFieldComponent<T>(props: {
+  onInputChange: (value: number) => void
+  maxPageNumber: number
+}): React.ReactElement {
+  // This component is separated from DataGrid to prevent it from updating,
+  // every time any letters are input.
+  const { onInputChange, maxPageNumber } = props
+  const [navigationPage, setNavigationPage] = React.useState("")
+
+  const handleSubmitPageNumber = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const newPage = parseInt(navigationPage, 10)
+    setNavigationPage("") // reset the input field
+    if (Number.isNaN(newPage)) {
+      return
+    }
+    const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
+    // 0-indexed.
+    onInputChange(newPageNumber - 1)
+  }
+
+  return (
+    <form onSubmit={handleSubmitPageNumber}>
+      <TextField
+        label="Go to Page"
+        value={navigationPage}
+        onChange={(e) => {
+          setNavigationPage(e.target.value)
+        }}
+      />
+    </form>
+  )
 }
 
 function DataGrid<T>(props: {
@@ -119,6 +156,7 @@ function DataGrid<T>(props: {
   const RootDiv = styled("div")({
     width: "100%",
   })
+  const maxPageNumber = Math.ceil(filteredRows.length / rowsPerPage)
   return (
     <RootDiv>
       <TableContainer>
@@ -177,15 +215,25 @@ function DataGrid<T>(props: {
           </TableBody>
         </Table>
       </TableContainer>
-      <TablePagination
-        rowsPerPageOptions={rowsPerPageOption}
-        component="div"
-        count={filteredRows.length}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onPageChange={handleChangePage}
-        onRowsPerPageChange={handleChangeRowsPerPage}
-      />
+      {filteredRows.length > 0 ? (
+        <Box display="flex" alignItems="center">
+          <TablePagination
+            rowsPerPageOptions={rowsPerPageOption}
+            component="div"
+            count={filteredRows.length}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={handleChangePage}
+            onRowsPerPageChange={handleChangeRowsPerPage}
+          />
+          {maxPageNumber > 4 ? (
+            <PaginationTextFieldComponent
+              onInputChange={(page) => setPage(page)}
+              maxPageNumber={Math.ceil(filteredRows.length / rowsPerPage)}
+            />
+          ) : null}
+        </Box>
+      ) : null}
     </RootDiv>
   )
 }

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -49,7 +49,7 @@ function PaginationTextFieldComponent(props: {
   onInputChange: (value: number) => void
   maxPageNumber: number
 }): React.ReactElement {
-  // This component is separated from DataGrid to prevent it from updating,
+  // This component is separated from DataGrid to prevent `DataGrid` from re-rendering the page,
   // every time any letters are input.
   const { onInputChange, maxPageNumber } = props
   const [navigationPage, setNavigationPage] = React.useState("")
@@ -62,7 +62,7 @@ function PaginationTextFieldComponent(props: {
       return
     }
     const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
-    // 0-indexed.
+    // Page is 0-indexed in `TablePagination`.
     onInputChange(newPageNumber - 1)
   }
 
@@ -215,6 +215,7 @@ function DataGrid<T>(props: {
         </Table>
       </TableContainer>
       {filteredRows.length > 0 ? (
+        // tslint:disable-next-line: 2590
         <Box display="flex" alignItems="center">
           <TablePagination
             rowsPerPageOptions={rowsPerPageOption}

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -107,6 +107,7 @@ function DataGrid<T>(props: {
     return (
       <form onSubmit={handleSubmitPageNumber}>
         <TextField
+          size="small"
           label={`Go to Page: n / ${maxPageNumber}`}
           value={specifiedPageText}
           type="number"
@@ -224,9 +225,6 @@ function DataGrid<T>(props: {
               count={filteredRows.length}
               rowsPerPage={rowsPerPage}
               page={page}
-              labelDisplayedRows={({ page }) =>
-                `${page + 1} of ${maxPageNumber}`
-              }
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}
             />

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -228,7 +228,7 @@ function DataGrid<T>(props: {
               onPageChange={handleChangePage}
               onRowsPerPageChange={handleChangeRowsPerPage}
             />
-            {maxPageNumber > 4 ? (
+            {maxPageNumber > 2 ? (
               <PaginationForm
                 onPageNumberSubmit={(page) => setPage(page)}
                 maxPageNumber={maxPageNumber}

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -46,33 +46,33 @@ interface RowFilter {
 }
 
 function PaginationTextFieldComponent(props: {
-  onInputChange: (value: number) => void
+  onPageNumberSubmit: (value: number) => void
   maxPageNumber: number
 }): React.ReactElement {
   // This component is separated from DataGrid to prevent `DataGrid` from re-rendering the page,
   // every time any letters are input.
-  const { onInputChange, maxPageNumber } = props
-  const [navigationPage, setNavigationPage] = React.useState("")
+  const { onPageNumberSubmit, maxPageNumber } = props
+  const [specifiedPageText, setSpecifiedPageText] = React.useState("")
 
   const handleSubmitPageNumber = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const newPage = parseInt(navigationPage, 10)
-    setNavigationPage("") // reset the input field
+    const newPage = parseInt(specifiedPageText, 10)
+    setSpecifiedPageText("") // reset the input field
     if (Number.isNaN(newPage)) {
       return
     }
     const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
     // Page is 0-indexed in `TablePagination`.
-    onInputChange(newPageNumber - 1)
+    onPageNumberSubmit(newPageNumber - 1)
   }
 
   return (
     <form onSubmit={handleSubmitPageNumber}>
       <TextField
         label="Go to Page"
-        value={navigationPage}
+        value={specifiedPageText}
         onChange={(e) => {
-          setNavigationPage(e.target.value)
+          setSpecifiedPageText(e.target.value)
         }}
       />
     </form>
@@ -232,7 +232,7 @@ function DataGrid<T>(props: {
             />
             {maxPageNumber > 4 ? (
               <PaginationTextFieldComponent
-                onInputChange={(page) => setPage(page)}
+                onPageNumberSubmit={(page) => setPage(page)}
                 maxPageNumber={maxPageNumber}
               />
             ) : null}

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -13,7 +13,6 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Button,
   Box,
 } from "@mui/material"
 import { styled } from "@mui/system"
@@ -46,7 +45,7 @@ interface RowFilter {
   values: Value[]
 }
 
-function PaginationTextFieldComponent<T>(props: {
+function PaginationTextFieldComponent(props: {
   onInputChange: (value: number) => void
   maxPageNumber: number
 }): React.ReactElement {

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -86,7 +86,7 @@ function DataGrid<T>(props: {
     setPage(0)
   }
 
-  const PaginationTextFieldComponent: React.FC<{
+  const PaginationForm: React.FC<{
     onPageNumberSubmit: (value: number) => void
     maxPageNumber: number
   }> = ({ onPageNumberSubmit, maxPageNumber }) => {
@@ -98,21 +98,20 @@ function DataGrid<T>(props: {
       event: React.FormEvent<HTMLFormElement>
     ) => {
       event.preventDefault()
-      const newPage = parseInt(specifiedPageText, 10)
-      setSpecifiedPageText("") // reset the input field
-      if (Number.isNaN(newPage)) {
-        return
-      }
-      const newPageNumber = newPage <= 0 ? 1 : Math.min(newPage, maxPageNumber)
+      const newPageNumber = parseInt(specifiedPageText, 10)
       // Page is 0-indexed in `TablePagination`.
       onPageNumberSubmit(newPageNumber - 1)
+      setSpecifiedPageText("") // reset the input field
     }
 
     return (
       <form onSubmit={handleSubmitPageNumber}>
         <TextField
-          label="Go to Page"
+          label={`Go to Page: n / ${maxPageNumber}`}
           value={specifiedPageText}
+          type="number"
+          style={{ width: 200 }}
+          inputProps={{ min: 1, max: maxPageNumber }}
           onChange={(e) => {
             setSpecifiedPageText(e.target.value)
           }}
@@ -232,7 +231,7 @@ function DataGrid<T>(props: {
               onRowsPerPageChange={handleChangeRowsPerPage}
             />
             {maxPageNumber > 4 ? (
-              <PaginationTextFieldComponent
+              <PaginationForm
                 onPageNumberSubmit={(page) => setPage(page)}
                 maxPageNumber={maxPageNumber}
               />

--- a/optuna_dashboard/ts/components/DataGrid.tsx
+++ b/optuna_dashboard/ts/components/DataGrid.tsx
@@ -22,6 +22,7 @@ import CheckBoxOutlineBlankIcon from "@mui/icons-material/CheckBoxOutlineBlank"
 import CheckBoxIcon from "@mui/icons-material/CheckBox"
 import FilterListIcon from "@mui/icons-material/FilterList"
 import ListItemIcon from "@mui/material/ListItemIcon"
+import { Margin } from "@mui/icons-material"
 
 type Order = "asc" | "desc"
 
@@ -215,24 +216,27 @@ function DataGrid<T>(props: {
         </Table>
       </TableContainer>
       {filteredRows.length > 0 ? (
-        // tslint:disable-next-line: 2590
-        <Box display="flex" alignItems="center">
-          <TablePagination
-            rowsPerPageOptions={rowsPerPageOption}
-            component="div"
-            count={filteredRows.length}
-            rowsPerPage={rowsPerPage}
-            page={page}
-            onPageChange={handleChangePage}
-            onRowsPerPageChange={handleChangeRowsPerPage}
-          />
-          {maxPageNumber > 4 ? (
-            <PaginationTextFieldComponent
-              onInputChange={(page) => setPage(page)}
-              maxPageNumber={Math.ceil(filteredRows.length / rowsPerPage)}
+        <>
+          {/* tslint:disable-next-line: 2590 */}
+          <Box display="flex" alignItems="center">
+            <TablePagination
+              rowsPerPageOptions={rowsPerPageOption}
+              component="div"
+              count={filteredRows.length}
+              rowsPerPage={rowsPerPage}
+              page={page}
+              labelDisplayedRows={({ page }) => `${page+1} of ${maxPageNumber}`}
+              onPageChange={handleChangePage}
+              onRowsPerPageChange={handleChangeRowsPerPage}
             />
-          ) : null}
-        </Box>
+            {maxPageNumber > 4 ? (
+              <PaginationTextFieldComponent
+                onInputChange={(page) => setPage(page)}
+                maxPageNumber={maxPageNumber}
+              />
+            ) : null}
+          </Box>
+        </>
       ) : null}
     </RootDiv>
   )


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR solves [issue#504](https://github.com/optuna/optuna-dashboard/issues/504).

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This PR adds the following features:
1. a text field to specify which page number to jump in DataGrid
2. the pagination for DataGrid will appear only if we have data,
3. the pagination text field for DataGrid will appear only if we have more than 4 pages, and
4. the pagination information is slightly modified to tell the page number.

## After the Modification

1. Too many rows to click next many times.
![image](https://github.com/optuna/optuna-dashboard/assets/47781922/c2f93207-2d4f-4c7d-ae2a-f3e9993c917b)

2. We can specify the page number to jump.
![image](https://github.com/optuna/optuna-dashboard/assets/47781922/d1f42800-9d57-4fb0-81ec-7ccb33f767ef)

3. The page number was successfully jumped to the specified page after hitting the enter key.

![image](https://github.com/optuna/optuna-dashboard/assets/47781922/e20555a0-0c47-43fd-b9e2-add3ef96b655)