### PR TITLE
Fix the vscode extension's entry point for code-server execution

### DIFF
--- a/vscode/package-lock.json
+++ b/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optuna-dashboard",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "optuna-dashboard",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.1",

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -27,7 +27,7 @@
     "optuna-dashboard"
   ],
   "activationEvents": [],
-  "browser": "./dist/web/extension.js",
+  "main": "./dist/web/extension.js",
   "contributes": {
     "commands": [
       {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Motivations

The current VS Code extension does not support code-server. This PR aims to fix it.

## Details of the change

According to the [documentation](https://code.visualstudio.com/api/advanced-topics/remote-extensions#workarounds-for-using-localhost-from-a-webview), the VS Code extension for the code-server must not be the web extension. The current entry point is defined by `browser` property, which is for the web extension. I changed the property name from the `browser` to the `main`, which is for the standard extension.

## How to confirm the change

1. Create the VSIX file by running `make vscode-extension`.
2. Upload the VSIX file to the remote environment running the code-server.
3. Install the extension from the VSIX file. Right click the file, and press the `Install Extension VSIX`.
4. Open some sqlite file by right clicking and press the `Open in Optuna Dashboard`.