### PR TITLE
Enhance delete artifacts APIs and add tests for them

### DIFF
--- a/optuna_dashboard/artifact/_backend.py
+++ b/optuna_dashboard/artifact/_backend.py
@@ -14,7 +14,6 @@ from bottle import HTTPResponse
 from bottle import request
 from bottle import response
 import optuna
-from optuna.artifacts.exceptions import ArtifactNotFound
 from optuna.trial import FrozenTrial
 
 from .._bottle_util import json_api_view
@@ -182,6 +181,8 @@ def register_artifact_route(
     @app.delete("/api/artifacts/<study_id:int>/<trial_id:int>/<artifact_id:re:[0-9a-fA-F-]+>")
     @json_api_view
     def delete_trial_artifact(study_id: int, trial_id: int, artifact_id: str) -> dict[str, Any]:
+        from optuna.artifacts.exceptions import ArtifactNotFound
+
         if artifact_store is None:
             response.status = 400  # Bad Request
             return {"reason": "Cannot access to the artifacts."}
@@ -205,6 +206,8 @@ def register_artifact_route(
     @app.delete("/api/artifacts/<study_id:int>/<artifact_id:re:[0-9a-fA-F-]+>")
     @json_api_view
     def delete_study_artifact(study_id: int, artifact_id: str) -> dict[str, Any]:
+        from optuna.artifacts.exceptions import ArtifactNotFound
+
         if artifact_store is None:
             response.status = 400  # Bad Request
             return {"reason": "Cannot access to the artifacts."}

--- a/optuna_dashboard/artifact/_backend.py
+++ b/optuna_dashboard/artifact/_backend.py
@@ -14,6 +14,7 @@ from bottle import HTTPResponse
 from bottle import request
 from bottle import response
 import optuna
+from optuna.artifacts.exceptions import ArtifactNotFound
 from optuna.trial import FrozenTrial
 
 from .._bottle_util import json_api_view
@@ -184,7 +185,11 @@ def register_artifact_route(
         if artifact_store is None:
             response.status = 400  # Bad Request
             return {"reason": "Cannot access to the artifacts."}
-        artifact_store.remove(artifact_id)
+        try:
+            artifact_store.remove(artifact_id)
+        except ArtifactNotFound as e:
+            response.status = 404
+            return {"reason": str(e)}
 
         # The artifact's metadata is stored in one of the following two locations:
         storage.set_study_system_attr(
@@ -203,7 +208,11 @@ def register_artifact_route(
         if artifact_store is None:
             response.status = 400  # Bad Request
             return {"reason": "Cannot access to the artifacts."}
-        artifact_store.remove(artifact_id)
+        try:
+            artifact_store.remove(artifact_id)
+        except ArtifactNotFound as e:
+            response.status = 404
+            return {"reason": str(e)}
 
         storage.set_study_system_attr(
             study_id, ARTIFACTS_ATTR_PREFIX + artifact_id, json.dumps(None)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
None

## What does this implement/fix? Explain your changes.
* Add tests for delete study/trial artifacts APIs
* Make delete study/trial artifacts APIs to be able to properly handle the ArtifactNotFound exception, i.e., returning 404 rather than causing internal server error

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
