### PR TITLE
Remove deprecation warning messages

### DIFF
--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -246,7 +246,7 @@ def serialize_frozen_trial(
         ],
         "user_attrs": serialize_attrs(trial.user_attrs),
         "note": note.get_note_from_system_attrs(study_system_attrs, trial._trial_id),
-        "artifacts": list_trial_artifacts(study_system_attrs, trial),
+        "artifacts": list_trial_artifacts(study_system_attrs, trial_system_attrs, trial),
         "constraints": trial_system_attrs.get(CONSTRAINTS_KEY, []),
     }
 

--- a/python_tests/artifact/test_backend.py
+++ b/python_tests/artifact/test_backend.py
@@ -84,9 +84,12 @@ def test_delete_all_artifacts(init_storage_with_artifact_meta: MagicMock) -> Non
 
 def test_list_trial_artifacts(init_storage_with_artifact_meta: MagicMock) -> None:
     storage = init_storage_with_artifact_meta
-    trial = MagicMock(_trial_id=0, system_attrs=storage.get_trial_system_attrs(0))
+    trial_system_attrs = storage.get_trial_system_attrs(0)
+    trial = MagicMock(_trial_id=0, system_attrs={})
 
-    actual = _backend.list_trial_artifacts(storage.get_study_system_attrs(0), trial)
+    actual = _backend.list_trial_artifacts(
+        storage.get_study_system_attrs(0), trial_system_attrs, trial
+    )
     assert actual == [
         {"artifact_id": "id0", "filename": "foo.txt"},
         {"artifact_id": "id1", "filename": "bar.txt"},

--- a/python_tests/artifact/test_optuna_compatibility.py
+++ b/python_tests/artifact/test_optuna_compatibility.py
@@ -36,8 +36,11 @@ def test_list_optuna_trial_artifacts() -> None:
         study.tell(trial, 0.0)
 
         study_system_attrs = storage.get_study_system_attrs(study._study_id)
+        trial_system_attrs = storage.get_trial_system_attrs(trial._trial_id)
         frozen_trial = storage.get_trial(trial._trial_id)
-        artifact_meta_list = list_trial_artifacts(study_system_attrs, frozen_trial)
+        artifact_meta_list = list_trial_artifacts(
+            study_system_attrs, trial_system_attrs, frozen_trial
+        )
         assert len(artifact_meta_list) == 1
 
         artifact_id = artifact_meta_list[0]["artifact_id"]


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
### Before

```
$ optuna-dashboard sqlite:///db.sqlite3 --host 0.0.0.0
[2024-01-24 09:53:13 +0900] [3088821] [INFO] Starting gunicorn 21.2.0
[2024-01-24 09:53:13 +0900] [3088821] [INFO] Listening at: http://0.0.0.0:8080 (3088821)
[2024-01-24 09:53:13 +0900] [3088821] [INFO] Using worker: gthread
[2024-01-24 09:53:13 +0900] [3088853] [INFO] Booting worker with pid: 3088853
/home/cbata/go/src/github.com/optuna/optuna-dashboard/venv/lib/python3.11/site-packages/optuna/study/_study_summary.py:115: FutureWarning: `system_attrs` has been deprecated in v3.1.0. The removal of this feature is currently scheduled for v5.0.0, but this schedule is subject to change. See https://github.com/optuna/optuna/releases/tag/v3.1.0.
  warnings.warn(
/home/cbata/go/src/github.com/optuna/optuna-dashboard/venv/lib/python3.11/site-packages/optuna/study/_study_summary.py:115: FutureWarning: `system_attrs` has been deprecated in v3.1.0. The removal of this feature is currently scheduled for v5.0.0, but this schedule is subject to change. See https://github.com/optuna/optuna/releases/tag/v3.1.0.
  warnings.warn(
/home/cbata/go/src/github.com/optuna/optuna-dashboard/venv/lib/python3.11/site-packages/optuna/study/_study_summary.py:115: FutureWarning: `system_attrs` has been deprecated in v3.1.0. The removal of this feature is currently scheduled for v5.0.0, but this schedule is subject to change. See https://github.com/optuna/optuna/releases/tag/v3.1.0.
  warnings.warn(
```

### After
```
$ optuna-dashboard sqlite:///db.sqlite3 --host 0.0.0.0
[2024-01-24 10:06:20 +0900] [3096288] [INFO] Starting gunicorn 21.2.0
[2024-01-24 10:06:20 +0900] [3096288] [INFO] Listening at: http://0.0.0.0:8080 (3096288)
[2024-01-24 10:06:20 +0900] [3096288] [INFO] Using worker: gthread
[2024-01-24 10:06:20 +0900] [3096320] [INFO] Booting worker with pid: 3096320
[2024-01-24 10:06:52 +0900] [3096288] [INFO] Handling signal: winch
```