### PR TITLE
Change render double side in ThreejsArtifactViewer

### DIFF
--- a/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/ThreejsArtifactViewer.tsx
@@ -115,7 +115,7 @@ export const ThreejsArtifactViewer: React.FC<ThreejsArtifactViewerProps> = (
       {geometry.length > 0 &&
         geometry.map((geo, index) => (
           <mesh key={index} geometry={geo}>
-            <meshNormalMaterial />
+            <meshNormalMaterial side={THREE.DoubleSide} />
           </mesh>
         ))}
     </Canvas>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

ThreejsArtifactViewer has so far only one side to render.
Since this is inconvenient for a surface with not thickness, both sides are now the target of rendering.

previous (render only top side)

| top side | bottom side(no rendering)|
|---|---|
| ![Screenshot 2024-01-30 at 13 52 05](https://github.com/optuna/optuna-dashboard/assets/23289252/825e9fc1-49cc-4408-800e-14db4b45a167) | ![Screenshot 2024-01-30 at 13 52 10](https://github.com/optuna/optuna-dashboard/assets/23289252/0116cd17-3eb1-4499-99d5-ba71ae016174) |

this pr

| top side | bottom side(render also this side))|
|---|---|
| ![Screenshot 2024-01-30 at 13 52 05](https://github.com/optuna/optuna-dashboard/assets/23289252/825e9fc1-49cc-4408-800e-14db4b45a167) | ![Screenshot 2024-01-30 at 13 52 22](https://github.com/optuna/optuna-dashboard/assets/23289252/af3be777-f83a-42d2-8cc5-3df6247249f6) |
