### PR TITLE
Fetch plot API when num_trials is updated

### DIFF
--- a/optuna_dashboard/ts/components/GraphContour.tsx
+++ b/optuna_dashboard/ts/components/GraphContour.tsx
@@ -34,6 +34,8 @@ const ContourBackend: FC<{
   study: StudyDetail | null
 }> = ({ study = null }) => {
   const studyId = study?.id
+  const numCompletedTrials =
+    study?.trials.filter((t) => t.state === "Complete").length || 0
   useEffect(() => {
     if (studyId === undefined) {
       return
@@ -45,7 +47,7 @@ const ContourBackend: FC<{
       .catch((err) => {
         console.error(err)
       })
-  }, [studyId])
+  }, [studyId, numCompletedTrials])
   return <Box id={plotDomId} sx={{ height: "450px" }} />
 }
 

--- a/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
+++ b/optuna_dashboard/ts/components/GraphParallelCoordinate.tsx
@@ -100,6 +100,8 @@ const GraphParallelCoordinateBackend: FC<{
   study: StudyDetail | null
 }> = ({ study = null }) => {
   const studyId = study?.id
+  const numCompletedTrials =
+    study?.trials.filter((t) => t.state === "Complete").length || 0
   useEffect(() => {
     if (studyId === undefined) {
       return
@@ -111,7 +113,7 @@ const GraphParallelCoordinateBackend: FC<{
       .catch((err) => {
         console.error(err)
       })
-  }, [studyId])
+  }, [studyId, numCompletedTrials])
   return <Box id={plotDomId} sx={{ height: "450px" }} />
 }
 

--- a/optuna_dashboard/ts/components/GraphRank.tsx
+++ b/optuna_dashboard/ts/components/GraphRank.tsx
@@ -45,6 +45,8 @@ const GraphRankBackend: FC<{
   study: StudyDetail | null
 }> = ({ study = null }) => {
   const studyId = study?.id
+  const numCompletedTrials =
+    study?.trials.filter((t) => t.state === "Complete").length || 0
   useEffect(() => {
     if (studyId === undefined) {
       return
@@ -56,7 +58,7 @@ const GraphRankBackend: FC<{
       .catch((err) => {
         console.error(err)
       })
-  }, [studyId])
+  }, [studyId, numCompletedTrials])
   return <Box id={plotDomId} sx={{ height: "450px" }} />
 }
 

--- a/optuna_dashboard/ts/components/GraphSlice.tsx
+++ b/optuna_dashboard/ts/components/GraphSlice.tsx
@@ -46,6 +46,8 @@ const GraphSliceBackend: FC<{
   study: StudyDetail | null
 }> = ({ study = null }) => {
   const studyId = study?.id
+  const numCompletedTrials =
+    study?.trials.filter((t) => t.state === "Complete").length || 0
   useEffect(() => {
     if (studyId === undefined) {
       return
@@ -57,7 +59,7 @@ const GraphSliceBackend: FC<{
       .catch((err) => {
         console.error(err)
       })
-  }, [studyId])
+  }, [studyId, numCompletedTrials])
   return <Box id={plotDomId} sx={{ height: "450px" }} />
 }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
Add `numCompletedTrials` to the second argument of `useEffect` so that graphs are automatically updated when trials are updated.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
