### PR TITLE
improve ux when trying to open sqlite without protocol

### DIFF
--- a/optuna_dashboard/_storage_url.py
+++ b/optuna_dashboard/_storage_url.py
@@ -61,7 +61,9 @@ def get_storage(
 
 def _has_sqlite_header(storage_url: str) -> bool:
     storage_path = Path(storage_url)
-    SQLITE_HEADER = b"SQLite format 3\x00" # see https://github.com/optuna/optuna-dashboard/pull/800
+    SQLITE_HEADER = (
+        b"SQLite format 3\x00"  # see https://github.com/optuna/optuna-dashboard/pull/800
+    )
     with storage_path.open(mode="rb") as f:
         header = f.read(len(SQLITE_HEADER))
     return header == SQLITE_HEADER


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes/Improves UX for #799 

## What does this implement/fix? Explain your changes.

- Improves UX by guessing file using file header to open a sqlite db without protocol, e.g.:
```bash
$ optuna-dashboard example.db
```
- flake8 and mypy are happy with my changes
- i tried to add tests, but was not able because `pytest python_test/` fails on main with import errors

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
