### PR TITLE
Add flake8 ignore options

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,7 @@
 [flake8]
+ignore =
+    E203
+    W503
 max-line-length = 99
 statistics = True
 exclude = venv,build


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #719 and #802.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Add flake8's ignore option to align with Optuna's one. Without this option, flake8 conflicts with black formatter sometimes.
https://github.com/optuna/optuna/blob/11dca397313eca84dd183e57351c33f33b05e4f6/setup.cfg#L2-L5