### PR TITLE
Replace StudySummary to FrozenStudy in serializing

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -101,9 +101,10 @@ def create_app(
 
     @app.get("/api/studies")
     @json_api_view
-    def list_study_summaries() -> dict[str, Any]:
+    def list_studies() -> dict[str, Any]:
         studies = get_studies(storage)
         serialized = [serialize_frozen_study(s) for s in studies]
+        # TODO(umezawa): Rename `study_summaries` to `studies`.
         return {
             "study_summaries": serialized,
         }

--- a/optuna_dashboard/_serializer.py
+++ b/optuna_dashboard/_serializer.py
@@ -122,9 +122,7 @@ def serialize_frozen_study(study: FrozenStudy) -> dict[str, Any]:
         "study_name": study.study_name,
         "directions": [d.name.lower() for d in study.directions],
         "user_attrs": serialize_attrs(study.user_attrs),
-        "is_preferential": getattr(study, "_system_attrs", {}).get(
-            _SYSTEM_ATTR_PREFERENTIAL_STUDY, False
-        ),
+        "is_preferential": study.system_attrs.get(_SYSTEM_ATTR_PREFERENTIAL_STUDY, False),
     }
 
     return serialized
@@ -146,7 +144,7 @@ def serialize_study_detail(
         "directions": [d.name.lower() for d in study.directions],
         "user_attrs": serialize_attrs(study.user_attrs),
     }
-    system_attrs = getattr(study, "system_attrs", {})
+    system_attrs = study.system_attrs
     serialized["artifacts"] = list_study_artifacts(system_attrs)
 
     serialized["trials"] = [

--- a/optuna_dashboard/_storage.py
+++ b/optuna_dashboard/_storage.py
@@ -51,7 +51,7 @@ def get_studies(storage: BaseStorage) -> list[FrozenStudy]:
     return frozen_studies
 
 
-def get_study(storage: BaseStorage, study_id: int) -> FrozenStudy:
+def get_study(storage: BaseStorage, study_id: int) -> FrozenStudy | None:
     studies = get_studies(storage)
     for s in studies:
         if s._study_id != study_id:

--- a/python_tests/test_serializers.py
+++ b/python_tests/test_serializers.py
@@ -5,9 +5,9 @@ import sys
 import numpy as np
 import optuna
 from optuna_dashboard._serializer import serialize_attrs
+from optuna_dashboard._serializer import serialize_frozen_study
 from optuna_dashboard._serializer import serialize_study_detail
-from optuna_dashboard._serializer import serialize_study_summary
-from optuna_dashboard._storage import get_study_summaries
+from optuna_dashboard._storage import get_studies
 from optuna_dashboard.preferential import create_study
 from packaging import version
 import pytest
@@ -60,26 +60,20 @@ def test_serialize_numpy_floating() -> None:
 def test_get_study_detail_is_preferential() -> None:
     storage = optuna.storages.InMemoryStorage()
     study = create_study(n_generate=4, storage=storage)
-    study_summaries = get_study_summaries(storage)
-    assert len(study_summaries) == 1
+    studies = get_studies(storage)
+    assert len(studies) == 1
 
-    study_summary = study_summaries[0]
-    study_detail = serialize_study_detail(
-        study_summary, [], study.trials, [], [], [], False, {}, []
-    )
+    study_detail = serialize_study_detail(studies[0], [], study.trials, [], [], [], False, {}, [])
     assert study_detail["is_preferential"]
 
 
 def test_get_study_detail_is_not_preferential() -> None:
     storage = optuna.storages.InMemoryStorage()
     study = optuna.create_study(storage=storage)
-    study_summaries = get_study_summaries(storage)
-    assert len(study_summaries) == 1
+    studies = get_studies(storage)
+    assert len(studies) == 1
 
-    study_summary = study_summaries[0]
-    study_detail = serialize_study_detail(
-        study_summary, [], study.trials, [], [], [], False, {}, []
-    )
+    study_detail = serialize_study_detail(studies[0], [], study.trials, [], [], [], False, {}, [])
     assert not study_detail["is_preferential"]
 
 
@@ -87,20 +81,20 @@ def test_get_study_detail_is_not_preferential() -> None:
 @pytest.mark.skipif(
     version.parse(optuna.__version__) < version.parse("3.2.0"), reason="Needs optuna.search_space"
 )
-def test_get_study_summary_is_preferential() -> None:
+def test_get_study_is_preferential() -> None:
     storage = optuna.storages.InMemoryStorage()
     create_study(n_generate=4, storage=storage)
-    study_summaries = get_study_summaries(storage)
-    assert len(study_summaries) == 1
+    studies = get_studies(storage)
+    assert len(studies) == 1
 
-    study_summary = serialize_study_summary(study_summaries[0])
-    assert study_summary["is_preferential"]
+    serialized = serialize_frozen_study(studies[0])
+    assert serialized["is_preferential"]
 
 
-def test_get_study_summary_is_not_preferential() -> None:
+def test_get_study_is_not_preferential() -> None:
     storage = optuna.storages.InMemoryStorage()
     optuna.create_study(storage=storage)
-    study_summaries = get_study_summaries(storage)
-    assert len(study_summaries) == 1
-    study_summary = serialize_study_summary(study_summaries[0])
-    assert not study_summary["is_preferential"]
+    studies = get_studies(storage)
+    assert len(studies) == 1
+    serialized = serialize_frozen_study(studies[0])
+    assert not serialized["is_preferential"]


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
To make a follow-up PR for https://github.com/optuna/optuna-dashboard/pull/783

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
In optuna v3, to get attribute of a study, FrozenStudy was introduced and it is performance efficient.
As we deprecated optuna v2, we can use it now instead of StudySummary. 
