### PR TITLE
Add PED-ANOVA as the first option for importance evaluator

### DIFF
--- a/optuna_dashboard/_importance.py
+++ b/optuna_dashboard/_importance.py
@@ -26,6 +26,16 @@ except Exception as e:
     FastFanovaImportanceEvaluator = None  # type: ignore
 
 
+try:
+    from optuna.importance import PedAnovaImportanceEvaluator
+except ImportError:
+    _logger.warning(f"optuna>=3.6.0 is required for PedAnovaImportanceEvaluator.")
+    PedAnovaImportanceEvaluator = None  # type: ignore
+except Exception as e:
+    _logger.warning(f"Skipping to use PedAnovaImportanceEvaluator due to {e}.")
+    PedAnovaImportanceEvaluator = None  # type: ignore
+
+
 if TYPE_CHECKING:
     from typing import Callable
     from typing import Optional
@@ -64,6 +74,12 @@ def _get_param_importances(
     *,
     target: Optional[Callable[[FrozenTrial], float]] = None,
 ) -> dict[str, float]:
+    if PedAnovaImportanceEvaluator is not None:
+        # TODO(nabenabe0928): We might want to pass baseline_quantile as an argument in the future.
+        return get_param_importances(
+            study, target=target, evaluator=PedAnovaImportanceEvaluator()
+        )
+
     if FastFanovaImportanceEvaluator is not None:
         try:
             evaluator = FastFanovaImportanceEvaluator(completed_trials=completed_trials)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [ ] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This PR aims to add PED-ANOVA, a quick f-ANOVA calculation algorithm, to the first choice of the importance calculation of Optuna Dashboard to enhance UX.

For PED-ANOVA, please check the following PR:
- https://github.com/optuna/optuna/pull/5212

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This PR introduces PED-ANOVA to Optuna Dashboard if the Optuna version in the environment is 3.6 or later.
By using PED-ANOVA, the visualization becomes very quick, so users will not experience very lagged dashboard behavior anymore due to the importance evaluation.
