### PR TITLE
Use boolean state to stop API requests being issued multiple times

### DIFF
--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -51,9 +51,9 @@ export const actionCreator = () => {
   const setStudySummariesLoading = useSetRecoilState<boolean>(
     studySummariesLoadingState
   )
-  const setStudyDetailLoading = useSetRecoilState<boolean>(
-    studyDetailLoadingState
-  )
+  const [studyDetailLoading, setStudyDetailLoading] = useRecoilState<
+    Record<number, boolean>
+  >(studyDetailLoadingState)
 
   const setStudyDetailState = (studyId: number, study: StudyDetail) => {
     setStudyDetails((prevVal) => {
@@ -235,7 +235,7 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
-    setStudyDetailLoading(true)
+    setStudyDetailLoading({ ...studyDetailLoading, [studyId]: true })
     let nLocalFixedTrials = 0
     if (studyId in studyDetails) {
       const currentTrials = studyDetails[studyId].trials
@@ -247,7 +247,7 @@ export const actionCreator = () => {
     }
     getStudyDetailAPI(studyId, nLocalFixedTrials)
       .then((study) => {
-        setStudyDetailLoading(false)
+        setStudyDetailLoading({ ...studyDetailLoading, [studyId]: false })
         const currentFixedTrials =
           studyId in studyDetails
             ? studyDetails[studyId].trials.slice(0, nLocalFixedTrials)
@@ -256,7 +256,7 @@ export const actionCreator = () => {
         setStudyDetailState(studyId, study)
       })
       .catch((err) => {
-        setStudyDetailLoading(false)
+        setStudyDetailLoading({ ...studyDetailLoading, [studyId]: false })
         const reason = err.response?.data.reason
         if (reason !== undefined) {
           enqueueSnackbar(`Failed to fetch study (reason=${reason})`, {

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -27,6 +27,7 @@ import {
   isFileUploading,
   artifactIsAvailable,
   plotlypyIsAvailableState,
+  reloadingState,
   reloadIntervalState,
   trialsUpdatingState,
   studySummariesLoadingState,
@@ -40,6 +41,7 @@ export const actionCreator = () => {
     useRecoilState<StudySummary[]>(studySummariesState)
   const [studyDetails, setStudyDetails] =
     useRecoilState<StudyDetails>(studyDetailsState)
+  const setReloading = useSetRecoilState<boolean>(reloadingState)
   const setReloadInterval = useSetRecoilState<number>(reloadIntervalState)
   const setUploading = useSetRecoilState<boolean>(isFileUploading)
   const setTrialsUpdating = useSetRecoilState(trialsUpdatingState)
@@ -231,6 +233,7 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
+    setReloading(true)
     let nLocalFixedTrials = 0
     if (studyId in studyDetails) {
       const currentTrials = studyDetails[studyId].trials
@@ -242,6 +245,7 @@ export const actionCreator = () => {
     }
     getStudyDetailAPI(studyId, nLocalFixedTrials)
       .then((study) => {
+        setReloading(false)
         const currentFixedTrials =
           studyId in studyDetails
             ? studyDetails[studyId].trials.slice(0, nLocalFixedTrials)
@@ -250,6 +254,7 @@ export const actionCreator = () => {
         setStudyDetailState(studyId, study)
       })
       .catch((err) => {
+        setReloading(false)
         const reason = err.response?.data.reason
         if (reason !== undefined) {
           enqueueSnackbar(`Failed to fetch study (reason=${reason})`, {

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -27,7 +27,7 @@ import {
   isFileUploading,
   artifactIsAvailable,
   plotlypyIsAvailableState,
-  reloadingState,
+  studyDetailLoadingState,
   reloadIntervalState,
   trialsUpdatingState,
   studySummariesLoadingState,
@@ -41,7 +41,6 @@ export const actionCreator = () => {
     useRecoilState<StudySummary[]>(studySummariesState)
   const [studyDetails, setStudyDetails] =
     useRecoilState<StudyDetails>(studyDetailsState)
-  const setReloading = useSetRecoilState<boolean>(reloadingState)
   const setReloadInterval = useSetRecoilState<number>(reloadIntervalState)
   const setUploading = useSetRecoilState<boolean>(isFileUploading)
   const setTrialsUpdating = useSetRecoilState(trialsUpdatingState)
@@ -51,6 +50,9 @@ export const actionCreator = () => {
   )
   const setStudySummariesLoading = useSetRecoilState<boolean>(
     studySummariesLoadingState
+  )
+  const setStudyDetailLoading = useSetRecoilState<boolean>(
+    studyDetailLoadingState
   )
 
   const setStudyDetailState = (studyId: number, study: StudyDetail) => {
@@ -233,7 +235,7 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
-    setReloading(true)
+    setStudyDetailLoading(true)
     let nLocalFixedTrials = 0
     if (studyId in studyDetails) {
       const currentTrials = studyDetails[studyId].trials
@@ -245,7 +247,7 @@ export const actionCreator = () => {
     }
     getStudyDetailAPI(studyId, nLocalFixedTrials)
       .then((study) => {
-        setReloading(false)
+        setStudyDetailLoading(false)
         const currentFixedTrials =
           studyId in studyDetails
             ? studyDetails[studyId].trials.slice(0, nLocalFixedTrials)
@@ -254,7 +256,7 @@ export const actionCreator = () => {
         setStudyDetailState(studyId, study)
       })
       .catch((err) => {
-        setReloading(false)
+        setStudyDetailLoading(false)
         const reason = err.response?.data.reason
         if (reason !== undefined) {
           enqueueSnackbar(`Failed to fetch study (reason=${reason})`, {

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -235,6 +235,9 @@ export const actionCreator = () => {
   }
 
   const updateStudyDetail = (studyId: number) => {
+    if (studyDetailLoading[studyId]) {
+      return
+    }
     setStudyDetailLoading({ ...studyDetailLoading, [studyId]: true })
     let nLocalFixedTrials = 0
     if (studyId in studyDetails) {

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -16,6 +16,7 @@ import HomeIcon from "@mui/icons-material/Home"
 import { StudyNote } from "./Note"
 import { actionCreator } from "../action"
 import {
+  reloadingState,
   reloadIntervalState,
   useStudyDetailValue,
   useStudyIsPreferential,
@@ -53,6 +54,7 @@ export const StudyDetail: FC<{
   const action = actionCreator()
   const studyId = useURLVars()
   const studyDetail = useStudyDetailValue(studyId)
+  const isLoading = useRecoilValue<boolean>(reloadingState)
   const reloadInterval = useRecoilValue<number>(reloadIntervalState)
   const studyName = useStudyName(studyId)
   const isPreferential = useStudyIsPreferential(studyId)
@@ -61,7 +63,9 @@ export const StudyDetail: FC<{
     studyName !== null ? `${studyName} (id=${studyId})` : `Study #${studyId}`
 
   useEffect(() => {
-    action.updateStudyDetail(studyId)
+    if (!isLoading) {
+      action.updateStudyDetail(studyId)
+    }
     action.updateAPIMeta()
   }, [])
 
@@ -86,7 +90,9 @@ export const StudyDetail: FC<{
     }
 
     const intervalId = setInterval(function () {
-      action.updateStudyDetail(studyId)
+      if (!isLoading) {
+        action.updateStudyDetail(studyId)
+      }
     }, interval)
     return () => clearInterval(intervalId)
   }, [reloadInterval, studyDetail, page])

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -16,7 +16,7 @@ import HomeIcon from "@mui/icons-material/Home"
 import { StudyNote } from "./Note"
 import { actionCreator } from "../action"
 import {
-  reloadingState,
+  studyDetailLoadingState,
   reloadIntervalState,
   useStudyDetailValue,
   useStudyIsPreferential,
@@ -54,7 +54,7 @@ export const StudyDetail: FC<{
   const action = actionCreator()
   const studyId = useURLVars()
   const studyDetail = useStudyDetailValue(studyId)
-  const isLoading = useRecoilValue<boolean>(reloadingState)
+  const isLoading = useRecoilValue<boolean>(studyDetailLoadingState)
   const reloadInterval = useRecoilValue<number>(reloadIntervalState)
   const studyName = useStudyName(studyId)
   const isPreferential = useStudyIsPreferential(studyId)

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -54,7 +54,9 @@ export const StudyDetail: FC<{
   const action = actionCreator()
   const studyId = useURLVars()
   const studyDetail = useStudyDetailValue(studyId)
-  const isLoading = useRecoilValue<boolean>(studyDetailLoadingState)
+  const isLoading = useRecoilValue<Record<number, boolean>>(
+    studyDetailLoadingState
+  )
   const reloadInterval = useRecoilValue<number>(reloadIntervalState)
   const studyName = useStudyName(studyId)
   const isPreferential = useStudyIsPreferential(studyId)
@@ -63,7 +65,7 @@ export const StudyDetail: FC<{
     studyName !== null ? `${studyName} (id=${studyId})` : `Study #${studyId}`
 
   useEffect(() => {
-    if (!isLoading) {
+    if (!isLoading[studyId]) {
       action.updateStudyDetail(studyId)
     }
     action.updateAPIMeta()
@@ -90,7 +92,7 @@ export const StudyDetail: FC<{
     }
 
     const intervalId = setInterval(function () {
-      if (!isLoading) {
+      if (!isLoading[studyId]) {
         action.updateStudyDetail(studyId)
       }
     }, interval)

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -54,9 +54,6 @@ export const StudyDetail: FC<{
   const action = actionCreator()
   const studyId = useURLVars()
   const studyDetail = useStudyDetailValue(studyId)
-  const isLoading = useRecoilValue<Record<number, boolean>>(
-    studyDetailLoadingState
-  )
   const reloadInterval = useRecoilValue<number>(reloadIntervalState)
   const studyName = useStudyName(studyId)
   const isPreferential = useStudyIsPreferential(studyId)
@@ -65,9 +62,7 @@ export const StudyDetail: FC<{
     studyName !== null ? `${studyName} (id=${studyId})` : `Study #${studyId}`
 
   useEffect(() => {
-    if (!isLoading[studyId]) {
-      action.updateStudyDetail(studyId)
-    }
+    action.updateStudyDetail(studyId)
     action.updateAPIMeta()
   }, [])
 
@@ -92,9 +87,7 @@ export const StudyDetail: FC<{
     }
 
     const intervalId = setInterval(function () {
-      if (!isLoading[studyId]) {
-        action.updateStudyDetail(studyId)
-      }
+      action.updateStudyDetail(studyId)
     }, interval)
     return () => clearInterval(intervalId)
   }, [reloadInterval, studyDetail, page])

--- a/optuna_dashboard/ts/components/StudyDetail.tsx
+++ b/optuna_dashboard/ts/components/StudyDetail.tsx
@@ -16,7 +16,6 @@ import HomeIcon from "@mui/icons-material/Home"
 import { StudyNote } from "./Note"
 import { actionCreator } from "../action"
 import {
-  studyDetailLoadingState,
   reloadIntervalState,
   useStudyDetailValue,
   useStudyIsPreferential,

--- a/optuna_dashboard/ts/state.ts
+++ b/optuna_dashboard/ts/state.ts
@@ -65,9 +65,9 @@ export const studySummariesLoadingState = atom<boolean>({
   default: false,
 })
 
-export const studyDetailLoadingState = atom<boolean>({
+export const studyDetailLoadingState = atom<Record<number, boolean>>({
   key: "studyDetailLoading",
-  default: false,
+  default: {},
 })
 
 export const useStudyDetailValue = (studyId: number): StudyDetail | null => {

--- a/optuna_dashboard/ts/state.ts
+++ b/optuna_dashboard/ts/state.ts
@@ -21,11 +21,6 @@ export const trialsUpdatingState = atom<{
   default: {},
 })
 
-export const reloadingState = atom<boolean>({
-  key: "reloadng",
-  default: false,
-})
-
 // TODO(c-bata): Consider representing the state as boolean.
 export const reloadIntervalState = atom<number>({
   key: "reloadInterval",
@@ -67,6 +62,11 @@ export const plotlypyIsAvailableState = atom<boolean>({
 
 export const studySummariesLoadingState = atom<boolean>({
   key: "studySummariesLoadingState",
+  default: false,
+})
+
+export const studyDetailLoadingState = atom<boolean>({
+  key: "studyDetailLoading",
   default: false,
 })
 

--- a/optuna_dashboard/ts/state.ts
+++ b/optuna_dashboard/ts/state.ts
@@ -21,6 +21,11 @@ export const trialsUpdatingState = atom<{
   default: {},
 })
 
+export const reloadingState = atom<boolean>({
+  key: "reloadng",
+  default: false,
+})
+
 // TODO(c-bata): Consider representing the state as boolean.
 export const reloadIntervalState = atom<number>({
   key: "reloadInterval",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
NA

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Optuna Dashboard performs near-real-time synchronization using API polling, but the current interval is 10 seconds.
If the number of trials is very large, it often does not return within 10 seconds.