### PR TITLE
Remove a warning message of `PedAnovaImportanceEvaluator`

### DIFF
--- a/optuna_dashboard/_importance.py
+++ b/optuna_dashboard/_importance.py
@@ -29,7 +29,6 @@ except Exception as e:
 try:
     from optuna.importance import PedAnovaImportanceEvaluator  # type: ignore[attr-defined]
 except ImportError:
-    _logger.warning("optuna>=3.6.0 is required for PedAnovaImportanceEvaluator.")
     PedAnovaImportanceEvaluator = None  # type: ignore
 
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #820

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Remove a warning message since it isn't a problem to use Optuna Dashboard with `optuna<3.6.0`.