### PR TITLE
[vscode] Use `biome ci` instead of `eslint`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 venv
 .venv
 standalone_app
+vscode

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "Dashboard for Optuna",
   "main": "index.js",
   "scripts": {
-    "fmt": "biome format --write . && biome check standalone_app --apply",
+    "fmt": "biome format --write . && biome check standalone_app vscode --apply",
     "lint": "npm run lint:eslint && npm run lint:biome",
     "lint:eslint": "eslint . --ext .ts,.tsx --max-warnings 0",
-    "lint:biome": "biome format . && biome ci standalone_app",
+    "lint:biome": "biome format . && biome ci standalone_app vscode",
     "watch": "NODE_ENV=development TYPESCRIPT_LOADER=esbuild-loader webpack --watch",
     "build": "webpack",
     "build:dev": "NODE_ENV=development TYPESCRIPT_LOADER=esbuild-loader webpack",

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -5,7 +5,7 @@ export function activate(context: vscode.ExtensionContext) {
     'Congratulations, your extension "optuna-dashboard" is now active in the web extension host!'
   )
 
-  let disposable = vscode.commands.registerCommand(
+  const disposable = vscode.commands.registerCommand(
     "optuna-dashboard.openOptunaDashboard",
     async (fileUri: vscode.Uri) => {
       // In VS Code, the path separator of fileUri is always '/'
@@ -30,15 +30,17 @@ export function activate(context: vscode.ExtensionContext) {
       const appPath = panel.webview.asWebviewUri(indexJsUri)
 
       panel.webview.html = getWebviewContent(appPath)
+      // biome-ignore lint/suspicious/noExplicitAny: <explanation>`
       panel.webview.onDidReceiveMessage(async (message: any) => {
         switch (message.type) {
-          case "webviewDidLoad":
+          case "webviewDidLoad": {
             const storageContentBase64 = await readFileAsBase64(fileUri)
             panel.webview.postMessage({
               type: "optunaStorage",
               content: storageContentBase64,
             })
             break
+          }
         }
       })
     }
@@ -55,9 +57,7 @@ async function readFileAsBase64(uri: vscode.Uri): Promise<string> {
 
 function uint8ArrayToBase64(uint8Array: Uint8Array): string {
   const binString = Array.prototype.map
-    .call(uint8Array, function (ch) {
-      return String.fromCharCode(ch)
-    })
+    .call(uint8Array, (ch) => String.fromCharCode(ch))
     .join("")
   return btoa(binString)
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #831 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Use `biome ci` instead of `eslint`.