### PR TITLE
Update 3dm library path

### DIFF
--- a/optuna_dashboard/ts/components/Artifact/ThreejsArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/Artifact/ThreejsArtifactViewer.tsx
@@ -198,7 +198,7 @@ function loadRhino3dm(
   handleLoadedGeometries: (geometries: THREE.BufferGeometry[]) => THREE.Box3
 ) {
   const rhino3dmLoader = new Rhino3dmLoader()
-  rhino3dmLoader.setLibraryPath("https://cdn.jsdelivr.net/npm/rhino3dm@7.15.0/")
+  rhino3dmLoader.setLibraryPath("https://cdn.jsdelivr.net/npm/rhino3dm@8.4.0/")
   rhino3dmLoader.load(props.src, (object: THREE.Object3D) => {
     const meshes = object.children as THREE.Mesh[]
     const rhinoGeometries = meshes.map((mesh) => mesh.geometry)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Update wasm, which is used to load 3dm models in three.js, to the latest version.
