### PR TITLE
Fix best trial history for pruned trials

### DIFF
--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -299,7 +299,7 @@ const plotHistory = (
       for (let i = 0; i < feasibleTrials.length; i++) {
         const t = feasibleTrials[i]
         const value = target.getTargetValue(t) as number
-        if (value === null) {
+        if (t.state !== "Complete") {
           continue
         } else if (currentBest === null) {
           currentBest = value


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Pruned trials are incorrectly included in the best trials. For example, the second trial in the study below becomes the best.

```python
import optuna

study = optuna.create_study(study_name="tmp", storage="sqlite:///tmp.db")
trial = study.ask()
study.tell(trial, 1)
trial = study.ask()
trial.report(step=0, value=0)
study.tell(trial, state=optuna.trial.TrialState.PRUNED)
```