### PR TITLE
Disable contour plot by default when the number of trials is huge

### DIFF
--- a/optuna_dashboard/ts/components/Preferential/PreferentialAnalytics.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialAnalytics.tsx
@@ -24,7 +24,10 @@ export const PreferentialAnalytics: FC<{ studyId: number }> = ({ studyId }) => {
     { field: "value", label: "Value", sortable: true },
   ]
   return (
-    <Box sx={{ display: "flex", width: "100%", flexDirection: "column" }}>
+    <Box
+      component="div"
+      sx={{ display: "flex", width: "100%", flexDirection: "column" }}
+    >
       <Grid2 container spacing={2} sx={{ padding: theme.spacing(0, 2) }}>
         <Grid2 xs={14}>
           <Paper elevation={2} sx={{ padding: theme.spacing(2) }}>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

NA

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Disable contour plot by default when the number of trials is huge

![contour_disabled](https://github.com/optuna/optuna-dashboard/assets/83964523/f8e02791-aa79-4c20-ad0b-7c5c6fa62728)

