### PR TITLE
Improve tests for `JournalStorage`

### DIFF
--- a/tslib/storage/test/generate_assets.py
+++ b/tslib/storage/test/generate_assets.py
@@ -86,9 +86,12 @@ if __name__ == "__main__":
         RDBStorage("sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")),
     ]:
         create_optuna_storage(storage)
-    
+
     # Add a broken line to the random position in the journal.log to test error handling
-    broken_line = '{"op_code": ..., "worker_id": "0000", "study_id": 0, "datetime_start": "2024-04-01T12:00:00.000000"}\n'
+    broken_line = (
+        '{"op_code": ..., "worker_id": "0000", "study_id": 0,'
+        '"datetime_start": "2024-04-01T12:00:00.000000"}\n'
+    )
     with open(os.path.join(BASE_DIR, "journal.log"), "r+") as f:
         lines = f.readlines()
         lines.insert(random.randint(0, len(lines)), broken_line)

--- a/tslib/storage/test/generate_assets.py
+++ b/tslib/storage/test/generate_assets.py
@@ -88,7 +88,9 @@ if __name__ == "__main__":
         create_optuna_storage(storage)
 
     # Make a file including a broken line to the random position to test error handling
-    shutil.copyfile(os.path.join(BASE_DIR, "journal.log"), os.path.join(BASE_DIR, "journal-broken.log"))
+    shutil.copyfile(
+        os.path.join(BASE_DIR, "journal.log"), os.path.join(BASE_DIR, "journal-broken.log")
+    )
     broken_line = (
         '{"op_code": ..., "worker_id": "0000", "study_id": 0,'
         '"datetime_start": "2024-04-01T12:00:00.000000"}\n'

--- a/tslib/storage/test/generate_assets.py
+++ b/tslib/storage/test/generate_assets.py
@@ -87,12 +87,13 @@ if __name__ == "__main__":
     ]:
         create_optuna_storage(storage)
 
-    # Add a broken line to the random position in the journal.log to test error handling
+    # Make a file including a broken line to the random position to test error handling
+    shutil.copyfile(os.path.join(BASE_DIR, "journal.log"), os.path.join(BASE_DIR, "journal-broken.log"))
     broken_line = (
         '{"op_code": ..., "worker_id": "0000", "study_id": 0,'
         '"datetime_start": "2024-04-01T12:00:00.000000"}\n'
     )
-    with open(os.path.join(BASE_DIR, "journal.log"), "r+") as f:
+    with open(os.path.join(BASE_DIR, "journal-broken.log"), "r+") as f:
         lines = f.readlines()
         lines.insert(random.randint(0, len(lines)), broken_line)
         f.truncate(0)

--- a/tslib/storage/test/generate_assets.py
+++ b/tslib/storage/test/generate_assets.py
@@ -1,4 +1,6 @@
+import math
 import os.path
+import random
 import shutil
 
 import optuna
@@ -48,6 +50,34 @@ def create_optuna_storage(storage: BaseStorage) -> None:
 
     study.optimize(objective_single_dynamic, n_trials=50)
 
+    # Single objective study with 'inf', '-inf' value
+    study = optuna.create_study(study_name="single-inf", storage=storage)
+    print(f"Generating {study.study_name} for {type(storage).__name__}...")
+
+    def objective_single_inf(trial: optuna.Trial) -> float:
+        x = trial.suggest_float("x", -10, 10)
+        if trial.number % 3 == 0:
+            return float("inf")
+        elif trial.number % 3 == 1:
+            return float("-inf")
+        else:
+            return x**2
+
+    study.optimize(objective_single_inf, n_trials=50)
+
+    # Single objective with reported nan value
+    study = optuna.create_study(study_name="single-nan-report", storage=storage)
+    print(f"Generating {study.study_name} for {type(storage).__name__}...")
+
+    def objective_single_nan_report(trial: optuna.Trial) -> float:
+        x1 = trial.suggest_float("x1", 0, 10)
+        x2 = trial.suggest_float("x2", 0, 10)
+        trial.report(0.5, step=0)
+        trial.report(math.nan, step=1)
+        return (x1 - 2) ** 2 + (x2 - 5) ** 2
+
+    study.optimize(objective_single_nan_report, n_trials=100)
+
 
 if __name__ == "__main__":
     remove_assets()
@@ -56,3 +86,12 @@ if __name__ == "__main__":
         RDBStorage("sqlite:///" + os.path.join(BASE_DIR, "db.sqlite3")),
     ]:
         create_optuna_storage(storage)
+    
+    # Add a broken line to the random position in the journal.log to test error handling
+    broken_line = '{"op_code": ..., "worker_id": "0000", "study_id": 0, "datetime_start": "2024-04-01T12:00:00.000000"}\n'
+    with open(os.path.join(BASE_DIR, "journal.log"), "r+") as f:
+        lines = f.readlines()
+        lines.insert(random.randint(0, len(lines)), broken_line)
+        f.truncate(0)
+        f.seek(0, os.SEEK_SET)
+        f.writelines(lines)

--- a/tslib/storage/test/journal.test.mjs
+++ b/tslib/storage/test/journal.test.mjs
@@ -15,7 +15,6 @@ describe("Test Journal File Storage", async () => {
   const studies = await Promise.all(
     studySummaries.map((_summary, index) => storage.getStudy(index))
   )
-  const errors = storage.getErrors()
 
   it("Check the study including Infinities", () => {
     const study = studies.find((s) => s.study_name === "single-inf")
@@ -38,7 +37,14 @@ describe("Test Journal File Storage", async () => {
     }
   })
 
-  it("Check the parsing errors", () => {
+  it("Check the parsing errors", async () => {
+    const blob = await openAsBlob(
+      path.resolve(".", "test", "asset", "journal-broken.log")
+    )
+    const buf = await blob.arrayBuffer()
+    const storage = new mut.JournalFileStorage(buf)
+    const errors = storage.getErrors()
+
     assert.strictEqual(errors.length, 1)
     assert.strictEqual(
       errors[0].message,

--- a/tslib/storage/test/journal.test.mjs
+++ b/tslib/storage/test/journal.test.mjs
@@ -1,19 +1,53 @@
 import assert from "node:assert"
 import { openAsBlob } from "node:fs"
 import path from "node:path"
-import test from "node:test"
+import { describe, it } from "node:test"
 
 import * as mut from "../pkg/journal.js"
 
-const n_studies = 2
-
-test("Test Journal File Storage", async () => {
+describe("Test Journal File Storage", async () => {
   const blob = await openAsBlob(
     path.resolve(".", "test", "asset", "journal.log")
   )
   const buf = await blob.arrayBuffer()
   const storage = new mut.JournalFileStorage(buf)
-  const studies = await storage.getStudies()
+  const studySummaries = await storage.getStudies()
+  const studies = await Promise.all(
+    studySummaries.map((_summary, index) => storage.getStudy(index))
+  )
+  const errors = storage.getErrors()
 
-  assert.strictEqual(studies.length, n_studies)
+  it("Check the study including Infinities", () => {
+    const study = studies.find((s) => s.study_name === "single-inf")
+    study.trials.forEach((trial, index) => {
+      if (index % 3 === 0) {
+        assert.strictEqual(trial.values[0], Infinity)
+      } else if (index % 3 === 1) {
+        assert.strictEqual(trial.values[0], -Infinity)
+      }
+    })
+  })
+
+  it("Check the study including NaNs", () => {
+    const study = studies.find((s) => s.study_name === "single-nan-report")
+    for (const trial of study.trials) {
+      assert.strictEqual(
+        trial.intermediate_values.find((v) => v.step === 1).value,
+        NaN
+      )
+    }
+  })
+
+  it("Check the parsing errors", () => {
+    assert.strictEqual(errors.length, 1)
+    assert.strictEqual(
+      errors[0].message,
+      `Unexpected token '.', ..."op_code": ..., "work"... is not valid JSON`
+    )
+  })
+
+  it("Check the number of studies", () => {
+    const N_STUDIES = 4
+    assert.strictEqual(studies.length, N_STUDIES)
+  })
 })


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Follow up PR of #860 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Improved the parsing error handling in `JournalStorage`:
  - The implementation was designed so that even a single error line would cause the entire system to crash, but error lines can now be pushed into `errors` variables to prevent it.
- Added tests for `JournalStorage`:
  - Checking studies including `Infinity`, `-Infinity`, `NaN`.
  - Checking if the system does not crash even when lines that cannot be parsed are included in the file.

## Reference

- [Node Test runner](https://nodejs.org/api/test.html#describeit-syntax)