### PR TITLE
Add `metric_names` into `Study` type

### DIFF
--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -29,6 +29,13 @@ interface JournalOpDeleteStudy extends JournalOpBase {
   study_id: number
 }
 
+interface JournalOpSetStudySystemAttr extends JournalOpBase {
+  study_id: number
+  system_attr: { 
+    "study:metric_names": string[]
+   }
+}
+
 interface JournalOpCreateTrial extends JournalOpBase {
   study_id: number
   datetime_start?: string
@@ -177,6 +184,14 @@ class JournalStorage {
 
   public applyDeleteStudy(log: JournalOpDeleteStudy): void {
     this.studies = this.studies.filter((item) => item.id !== log.study_id)
+  }
+
+  public applyStudySystemAttr(log: JournalOpSetStudySystemAttr): void {
+    const thisStudy = this.studies.find((item) => item.id === log.study_id)
+    if (thisStudy === undefined) {
+      return
+    }
+    thisStudy.metric_names = log.system_attr["study:metric_names"]
   }
 
   public applyCreateTrial(log: JournalOpCreateTrial): void {
@@ -393,7 +408,9 @@ const loadJournalStorage = (
         // Unsupported
         break
       case JournalOperation.SET_STUDY_SYSTEM_ATTR:
-        // Unsupported
+        journalStorage.applyStudySystemAttr(
+          parsedLog as JournalOpSetStudySystemAttr
+        )
         break
       case JournalOperation.CREATE_TRIAL:
         journalStorage.applyCreateTrial(parsedLog as JournalOpCreateTrial)

--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -31,9 +31,9 @@ interface JournalOpDeleteStudy extends JournalOpBase {
 
 interface JournalOpSetStudySystemAttr extends JournalOpBase {
   study_id: number
-  system_attr: { 
+  system_attr: {
     "study:metric_names": string[]
-   }
+  }
 }
 
 interface JournalOpCreateTrial extends JournalOpBase {

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -372,10 +372,7 @@ const parseDistributionJSON = (t: string): Optuna.Distribution => {
   }
 }
 
-const getStudySystemAttributes = (
-  db: SQLite3DB,
-  studyId: number
-) => {
+const getStudySystemAttributes = (db: SQLite3DB, studyId: number) => {
   let attrs: { metric_names: string[] } | undefined
   db.exec({
     sql: `SELECT key, value_json FROM study_system_attributes WHERE study_id = ${studyId} AND key = 'dashboard:objective_names'`,

--- a/tslib/storage/test/generate_assets.py
+++ b/tslib/storage/test/generate_assets.py
@@ -78,6 +78,24 @@ def create_optuna_storage(storage: BaseStorage) -> None:
 
     study.optimize(objective_single_nan_report, n_trials=100)
 
+    # Multi-objective study with metric names
+    study = optuna.create_study(
+        study_name="multi-objective-metric-names",
+        storage=storage,
+        directions=["minimize", "minimize"],
+    )
+    print(f"Generating {study.study_name} for {type(storage).__name__}...")
+    study.set_metric_names(["value1", "value2"])
+
+    def objective_multi(trial: optuna.Trial) -> tuple[float, float]:
+        x = trial.suggest_float("x", 0, 5)
+        y = trial.suggest_float("y", 0, 3)
+        v0 = 4 * x**2 + 4 * y**2
+        v1 = (x - 5) ** 2 + (y - 5) ** 2
+        return v0, v1
+
+    study.optimize(objective_multi, n_trials=50)
+
 
 if __name__ == "__main__":
     remove_assets()

--- a/tslib/storage/test/journal.test.mjs
+++ b/tslib/storage/test/journal.test.mjs
@@ -52,8 +52,13 @@ describe("Test Journal File Storage", async () => {
     )
   })
 
+  it("Check metric_names function", () => {
+    const study = studies.find((s) => s.name === "multi-objective-metric-names")
+    assert.deepStrictEqual(study.metric_names, ["value1", "value2"])
+  })
+
   it("Check the number of studies", () => {
-    const N_STUDIES = 4
+    const N_STUDIES = 5
     assert.strictEqual(studies.length, N_STUDIES)
   })
 })

--- a/tslib/types/src/index.ts
+++ b/tslib/types/src/index.ts
@@ -60,6 +60,7 @@ export type Study = {
   union_user_attrs: AttributeSpec[]
   datetime_start?: Date
   trials: Trial[]
+  metric_names?: string[]
 }
 
 export type Trial = {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

NA 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Add `metric_names` into `Study` type
  - `metric_names` here and `objective_names` in `optuna_dashboard/ts` are equivalent (`objective_names` will be renamed into `metric_names` later)
