### PR TITLE
Add a checkbox to ask whether to delete artifacts associated to study/trial

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -180,9 +180,9 @@ def create_app(
     @app.delete("/api/studies/<study_id:int>")
     @json_api_view
     def delete_study(study_id: int) -> dict[str, Any]:
-        remove_associated_artifacts = (
-            True if request.params.get("remove_associated_artifacts") == "true" else False
-        )
+        data = request.json or {}
+        remove_associated_artifacts = data.get("remove_associated_artifacts", True)
+
         if artifact_store is not None and remove_associated_artifacts:
             delete_all_artifacts(artifact_store, storage, study_id)
 

--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -180,7 +180,10 @@ def create_app(
     @app.delete("/api/studies/<study_id:int>")
     @json_api_view
     def delete_study(study_id: int) -> dict[str, Any]:
-        if artifact_store is not None:
+        remove_associated_artifacts = (
+            True if request.params.get("remove_associated_artifacts") == "true" else False
+        )
+        if artifact_store is not None and remove_associated_artifacts:
             delete_all_artifacts(artifact_store, storage, study_id)
 
         try:

--- a/optuna_dashboard/ts/action.ts
+++ b/optuna_dashboard/ts/action.ts
@@ -284,9 +284,9 @@ export const actionCreator = () => {
       })
   }
 
-  const deleteStudy = (studyId: number) => {
+  const deleteStudy = (studyId: number, removeAssociatedArtifacts: boolean) => {
     apiClient
-      .deleteStudy(studyId)
+      .deleteStudy(studyId, removeAssociatedArtifacts)
       .then(() => {
         setStudySummaries(studySummaries.filter((s) => s.study_id !== studyId))
         enqueueSnackbar(`Success to delete a study (id=${studyId})`, {

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -185,7 +185,10 @@ export abstract class APIClient {
     studyName: string,
     directions: Optuna.StudyDirection[]
   ): Promise<StudySummary>
-  abstract deleteStudy(studyId: number): Promise<void>
+  abstract deleteStudy(
+    studyId: number,
+    removeAssociatedArtifacts: boolean
+  ): Promise<void>
   abstract renameStudy(
     studyId: number,
     studyName: string

--- a/optuna_dashboard/ts/axiosClient.ts
+++ b/optuna_dashboard/ts/axiosClient.ts
@@ -121,9 +121,11 @@ export class AxiosClient extends APIClient {
     removeAssociatedArtifacts: boolean
   ): Promise<void> =>
     this.axiosInstance
-      .delete(
-        `/api/studies/${studyId}?remove_associated_artifacts=${removeAssociatedArtifacts}`
-      )
+      .delete(`/api/studies/${studyId}`, {
+        data: {
+          remove_associated_artifacts: removeAssociatedArtifacts,
+        },
+      })
       .then(() => {
         return
       })

--- a/optuna_dashboard/ts/axiosClient.ts
+++ b/optuna_dashboard/ts/axiosClient.ts
@@ -116,10 +116,17 @@ export class AxiosClient extends APIClient {
             : undefined,
         }
       })
-  deleteStudy = (studyId: number): Promise<void> =>
-    this.axiosInstance.delete(`/api/studies/${studyId}`).then(() => {
-      return
-    })
+  deleteStudy = (
+    studyId: number,
+    removeAssociatedArtifacts: boolean
+  ): Promise<void> =>
+    this.axiosInstance
+      .delete(
+        `/api/studies/${studyId}?remove_associated_artifacts=${removeAssociatedArtifacts}`
+      )
+      .then(() => {
+        return
+      })
   renameStudy = (studyId: number, studyName: string): Promise<StudySummary> =>
     this.axiosInstance
       .post<RenameStudyResponse>(`/api/studies/${studyId}/rename`, {

--- a/optuna_dashboard/ts/components/Artifact/DeleteArtifactDialog.tsx
+++ b/optuna_dashboard/ts/components/Artifact/DeleteArtifactDialog.tsx
@@ -1,10 +1,12 @@
 import {
+  Alert,
   Button,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  useTheme,
 } from "@mui/material"
 import React, { ReactNode, useState, FC } from "react"
 import { Artifact } from "ts/types/optuna"
@@ -111,6 +113,7 @@ const DeleteDialog: FC<{
   filename,
   handleDeleteArtifact,
 }) => {
+  const theme = useTheme()
   return (
     <Dialog
       open={openDeleteArtifactDialog}
@@ -123,10 +126,18 @@ const DeleteDialog: FC<{
         Delete artifact
       </DialogTitle>
       <DialogContent>
-        <DialogContentText>
+        <DialogContentText
+          sx={{
+            marginBottom: theme.spacing(2),
+          }}
+        >
           Are you sure you want to delete an artifact ("
           {filename}")?
         </DialogContentText>
+        <Alert severity="warning">
+          If this artifact is linked to another study or trial, it will no
+          longer be accessible from that study or trial as well.
+        </Alert>
       </DialogContent>
       <DialogActions>
         <Button onClick={handleCloseDeleteArtifactDialog} color="primary">

--- a/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
+++ b/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
@@ -10,6 +10,8 @@ import {
   FormControlLabel,
 } from "@mui/material"
 import React, { ReactNode, useState } from "react"
+import { useRecoilValue } from "recoil"
+import { artifactIsAvailable as artifactIsAvailableState } from "../state"
 import { actionCreator } from "../action"
 
 export const useDeleteStudyDialog = (): [
@@ -17,6 +19,7 @@ export const useDeleteStudyDialog = (): [
   () => ReactNode,
 ] => {
   const action = actionCreator()
+  const artifactIsAvailable = useRecoilValue(artifactIsAvailableState)
 
   const [openDeleteStudyDialog, setOpenDeleteStudyDialog] = useState(false)
   const [deleteStudyID, setDeleteStudyID] = useState(-1)
@@ -55,20 +58,24 @@ export const useDeleteStudyDialog = (): [
           <DialogContentText>
             Are you sure you want to delete a study (id={deleteStudyID})?
           </DialogContentText>
-          <FormControlLabel
-            label="Remove associated trial/study artifacts."
-            control={
-              <Checkbox
-                checked={removeAssociatedArtifacts}
-                onChange={() => setRemoveAssociatedArtifacts((cur) => !cur)}
+          {artifactIsAvailable && (
+            <>
+              <FormControlLabel
+                label="Remove associated trial/study artifacts."
+                control={
+                  <Checkbox
+                    checked={removeAssociatedArtifacts}
+                    onChange={() => setRemoveAssociatedArtifacts((cur) => !cur)}
+                  />
+                }
               />
-            }
-          />
-          {removeAssociatedArtifacts && (
-            <Alert severity="warning">
-              If artifacts are linked to another study or trial, they will no
-              longer be accessible from that study or trial as well.
-            </Alert>
+              {removeAssociatedArtifacts && (
+                <Alert severity="warning">
+                  If artifacts are linked to another study or trial, they will
+                  no longer be accessible from that study or trial as well.
+                </Alert>
+              )}
+            </>
           )}
         </DialogContent>
         <DialogActions>

--- a/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
+++ b/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
@@ -11,8 +11,8 @@ import {
 } from "@mui/material"
 import React, { ReactNode, useState } from "react"
 import { useRecoilValue } from "recoil"
-import { artifactIsAvailable as artifactIsAvailableState } from "../state"
 import { actionCreator } from "../action"
+import { artifactIsAvailable as artifactIsAvailableState } from "../state"
 
 export const useDeleteStudyDialog = (): [
   (studyId: number) => void,

--- a/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
+++ b/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
@@ -1,10 +1,13 @@
 import {
+  Alert,
   Button,
+  Checkbox,
   Dialog,
   DialogActions,
   DialogContent,
   DialogContentText,
   DialogTitle,
+  FormControlLabel,
 } from "@mui/material"
 import React, { ReactNode, useState } from "react"
 import { actionCreator } from "../action"
@@ -17,16 +20,18 @@ export const useDeleteStudyDialog = (): [
 
   const [openDeleteStudyDialog, setOpenDeleteStudyDialog] = useState(false)
   const [deleteStudyID, setDeleteStudyID] = useState(-1)
+  const [removeAssociatedArtifacts, setRemoveAssociatedArtifacts] =
+    useState(false)
 
   const handleCloseDeleteStudyDialog = () => {
     setOpenDeleteStudyDialog(false)
     setDeleteStudyID(-1)
+    setRemoveAssociatedArtifacts(false)
   }
 
   const handleDeleteStudy = () => {
-    action.deleteStudy(deleteStudyID)
-    setOpenDeleteStudyDialog(false)
-    setDeleteStudyID(-1)
+    action.deleteStudy(deleteStudyID, removeAssociatedArtifacts)
+    handleCloseDeleteStudyDialog()
   }
 
   const openDialog = (studyId: number) => {
@@ -42,12 +47,29 @@ export const useDeleteStudyDialog = (): [
           handleCloseDeleteStudyDialog()
         }}
         aria-labelledby="delete-study-dialog-title"
+        fullWidth
+        maxWidth="xs"
       >
         <DialogTitle id="delete-study-dialog-title">Delete study</DialogTitle>
         <DialogContent>
           <DialogContentText>
             Are you sure you want to delete a study (id={deleteStudyID})?
           </DialogContentText>
+          <FormControlLabel
+            label="Remove associated trial/study artifacts."
+            control={
+              <Checkbox
+                checked={removeAssociatedArtifacts}
+                onChange={() => setRemoveAssociatedArtifacts((cur) => !cur)}
+              />
+            }
+          />
+          {removeAssociatedArtifacts && (
+            <Alert severity="warning">
+              If articles are linked to another study or trial, they will no
+              longer be accessible from that study or trial as well.
+            </Alert>
+          )}
         </DialogContent>
         <DialogActions>
           <Button onClick={handleCloseDeleteStudyDialog} color="primary">

--- a/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
+++ b/optuna_dashboard/ts/components/DeleteStudyDialog.tsx
@@ -66,7 +66,7 @@ export const useDeleteStudyDialog = (): [
           />
           {removeAssociatedArtifacts && (
             <Alert severity="warning">
-              If articles are linked to another study or trial, they will no
+              If artifacts are linked to another study or trial, they will no
               longer be accessible from that study or trial as well.
             </Alert>
           )}

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -7,8 +7,6 @@ from unittest import TestCase
 
 import optuna
 from optuna import get_all_study_summaries
-from optuna.artifacts import upload_artifact
-from optuna.artifacts.exceptions import ArtifactNotFound
 from optuna.study import StudyDirection
 from optuna_dashboard._app import create_app
 from optuna_dashboard._app import create_new_study
@@ -526,7 +524,14 @@ class APITestCase(TestCase):
         self.assertEqual(status, 204)
         self.assertEqual(len(get_all_study_summaries(storage)), 1)
 
+    @pytest.mark.skipif(
+        version.parse(optuna.__version__) < version.parse("3.4.0"),
+        reason="Needs optuna.artifacts",
+    )
     def test_delete_study_with_removing_artifacts(self) -> None:
+        from optuna.artifacts import upload_artifact
+        from optuna.artifacts.exceptions import ArtifactNotFound
+
         storage = optuna.storages.InMemoryStorage()
         study = optuna.create_study(storage=storage)
         with tempfile.TemporaryDirectory() as tmpdir_name:
@@ -556,7 +561,13 @@ class APITestCase(TestCase):
 
         self.assertEqual(len(get_all_study_summaries(storage)), 0)
 
+    @pytest.mark.skipif(
+        version.parse(optuna.__version__) < version.parse("3.4.0"),
+        reason="Needs optuna.artifacts",
+    )
     def test_delete_study_without_removing_artifacts(self) -> None:
+        from optuna.artifacts import upload_artifact
+
         storage = optuna.storages.InMemoryStorage()
         study = optuna.create_study(storage=storage)
         with tempfile.TemporaryDirectory() as tmpdir_name:

--- a/python_tests/test_api.py
+++ b/python_tests/test_api.py
@@ -550,7 +550,7 @@ class APITestCase(TestCase):
                 app,
                 f"/api/studies/{study._study_id}",
                 "DELETE",
-                queries={"remove_associated_artifacts": "true"},
+                body=json.dumps({"remove_associated_artifacts": True}),
                 content_type="application/json",
             )
             self.assertEqual(status, 204)
@@ -586,7 +586,7 @@ class APITestCase(TestCase):
                 app,
                 f"/api/studies/{study._study_id}",
                 "DELETE",
-                queries={"remove_associated_artifacts": "false"},
+                body=json.dumps({"remove_associated_artifacts": False}),
                 content_type="application/json",
             )
             self.assertEqual(status, 204)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

NA

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

When deleting a study, all artifacts associated with that study were previously deleted as well. However, the problem occurred when a study was copied, resulting in multiple IDs pointing to the same artifact. In such cases, after deleting the artifact and one ID, the other IDs were pointing to a non-existent reference. This PR addresses the problem by introducing a feature that allows users to choose whether or not to delete the associated artifacts.

## Dialog Design

<img width="779" alt="1" src="https://github.com/optuna/optuna-dashboard/assets/83964523/3aaafa7d-a2b5-4861-a1c3-d53e3b5a7e38">
<img width="779" alt="2" src="https://github.com/optuna/optuna-dashboard/assets/83964523/bb99583a-1b0b-4593-b964-108aa571c8aa">

To align with the design changes mentioned above, I have also modified `DeleteArtifactDialog`:
<img width="779" alt="3" src="https://github.com/optuna/optuna-dashboard/assets/83964523/808b081b-646e-4b80-b598-a492f886d39f">
