### PR TITLE
Minor fix date axis in Timeline Chart for consistency with other charts

### DIFF
--- a/optuna_dashboard/ts/components/GraphTimeline.tsx
+++ b/optuna_dashboard/ts/components/GraphTimeline.tsx
@@ -157,7 +157,7 @@ const plotTimeline = (
     xaxis: {
       title: "Datetime",
       type: "date",
-      range: [minDatetime.toISOString(), maxDatetime.toISOString()],
+      range: [minDatetime, maxDatetime],
     },
     yaxis: {
       title: "Trial",
@@ -188,7 +188,7 @@ const plotTimeline = (
       x: runDurations,
       y: bars.map((b) => b.number),
       // @ts-ignore: To suppress ts(2322)
-      base: starts.map((s) => s.toISOString()),
+      base: starts,
       name: state,
       text: bars.map((b) => makeHovertext(b)),
       hovertemplate: "%{text}<extra>" + state + "</extra>",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

N/A

## What does this implement/fix? Explain your changes.

The datetime or x-axis in the Timeline Chart is not consistent with datetime values in other places (History Chart and Trial detail). Given a timestamp from the database, the datetime axis in the Timeline Chart uses the UTC value, while other datetime values use the local value. If this is expected, I guess there should be a note or description in the chart.

![optuna - timeline chart inconsistent date axis](https://github.com/user-attachments/assets/88f0498c-e0f0-45a3-b769-1340c9f2ce79)

I fixed it by simply removing the `.toISOString()`. Thus, instead of receiving a datetime string in UTC, Plotly receives a Date object. According to the [Plotly docs](https://plotly.com/javascript/reference/layout/xaxis/#layout-xaxis-range), the x-axis range supports `Date` objects. I have also successfully tested my fix to ensure that it is working.


