### PR TITLE
Fix an error in TableArtifactViewer when keys have an empty string

### DIFF
--- a/optuna_dashboard/ts/components/Artifact/TableArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/Artifact/TableArtifactViewer.tsx
@@ -55,7 +55,7 @@ export const TableArtifactViewer: React.FC<TableArtifactViewerProps> = (
     })
     const keys = Array.from(unionSet)
     return keys.map((key) => ({
-      header: key,
+      header: key || " ",
       accessorFn: (info: Data) =>
         typeof info[key] === "object" ? JSON.stringify(info[key]) : info[key],
       enableSorting: true,

--- a/optuna_dashboard/ts/components/Artifact/TableArtifactViewer.tsx
+++ b/optuna_dashboard/ts/components/Artifact/TableArtifactViewer.tsx
@@ -55,6 +55,7 @@ export const TableArtifactViewer: React.FC<TableArtifactViewerProps> = (
     })
     const keys = Array.from(unionSet)
     return keys.map((key) => ({
+      // ``header`` cannot be a falsy value, so replace key with a string looking like an empty string.
       header: key || " ",
       accessorFn: (info: Data) =>
         typeof info[key] === "object" ? JSON.stringify(info[key]) : info[key],


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

This issue relates to
- https://github.com/optuna/optuna-dashboard/issues/911

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

In my implementation, I replaced an empty string in keys with `" "`, which circumvents the error.