### PR TITLE
Sort artifact cards by filename

### DIFF
--- a/optuna_dashboard/ts/components/Artifact/StudyArtifactCards.tsx
+++ b/optuna_dashboard/ts/components/Artifact/StudyArtifactCards.tsx
@@ -41,6 +41,15 @@ export const StudyArtifactCards: FC<{ study: StudyDetail }> = ({ study }) => {
 
   const width = "200px"
   const height = "150px"
+  const artifacts = [...study.artifacts].sort((a, b) => {
+    if (a.filename < b.filename) {
+      return -1
+    } else if (a.filename > b.filename) {
+      return 1
+    } else {
+      return 0
+    }
+  })
 
   return (
     <>
@@ -48,7 +57,7 @@ export const StudyArtifactCards: FC<{ study: StudyDetail }> = ({ study }) => {
         component="div"
         sx={{ display: "flex", flexWrap: "wrap", p: theme.spacing(1, 0) }}
       >
-        {study.artifacts.map((artifact) => {
+        {artifacts.map((artifact) => {
           const urlPath = `/artifacts/${study.id}/${artifact.artifact_id}`
           return (
             <Card

--- a/optuna_dashboard/ts/components/Artifact/TrialArtifactCards.tsx
+++ b/optuna_dashboard/ts/components/Artifact/TrialArtifactCards.tsx
@@ -44,6 +44,15 @@ export const TrialArtifactCards: FC<{ trial: Trial }> = ({ trial }) => {
 
   const width = "200px"
   const height = "150px"
+  const artifacts = [...trial.artifacts].sort((a, b) => {
+    if (a.filename < b.filename) {
+      return -1
+    } else if (a.filename > b.filename) {
+      return 1
+    } else {
+      return 0
+    }
+  })
 
   return (
     <>
@@ -57,7 +66,7 @@ export const TrialArtifactCards: FC<{ trial: Trial }> = ({ trial }) => {
         component="div"
         sx={{ display: "flex", flexWrap: "wrap", p: theme.spacing(1, 0) }}
       >
-        {trial.artifacts.map((artifact) => {
+        {artifacts.map((artifact) => {
           const urlPath = `/artifacts/${trial.study_id}/${trial.trial_id}/${artifact.artifact_id}`
           return (
             <Card


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

![image](https://github.com/user-attachments/assets/1f325215-e616-4ca6-8ed5-27d565c785ae)

In the current implementation, the artifact cards are sorted by `artifact_id`, which is only used internally.
It is more intuitive to sort the cards either by the time added or filename.
As artifact meta does  not include the time when it was added, I simply sorted by filename.

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

With this change, artifact cards will be sorted by filename.

![image](https://github.com/user-attachments/assets/1755b9ee-95ff-4785-8933-eb4316f8eb2a)
