### PR TITLE
Add `npm install` command in serve-browser-app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ tslib-test: tslib
 
 .PHONY: serve-browser-app
 serve-browser-app: tslib $(RUSTLIB_OUT)
-	cd standalone_app && npm run watch
+	cd standalone_app && npm install && npm run watch
 
 .PHONY: vscode-extension
 vscode-extension: vscode/assets/bundle.js


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

N/A

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Made a fix by adding the missing `npm install` to the build command for `serve-browser-app` in `Makefile`.
