### PR TITLE
Rename objective_names to metric_names

### DIFF
--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -65,6 +65,7 @@ export interface StudyDetailResponse {
   has_intermediate_values: boolean
   note: Note
   is_preferential: boolean
+  // TODO(c-bata): Rename this to metric_names after releasing the new Jupyter Lab extension.
   objective_names?: string[]
   form_widgets?: FormWidgets
   preferences?: [number, number][]

--- a/optuna_dashboard/ts/axiosClient.ts
+++ b/optuna_dashboard/ts/axiosClient.ts
@@ -62,7 +62,7 @@ export class AxiosClient extends APIClient {
           union_user_attrs: res.data.union_user_attrs,
           has_intermediate_values: res.data.has_intermediate_values,
           note: res.data.note,
-          objective_names: res.data.objective_names,
+          metric_names: res.data.objective_names,
           form_widgets: res.data.form_widgets,
           is_preferential: res.data.is_preferential,
           feedback_component_type: res.data.feedback_component_type,

--- a/optuna_dashboard/ts/components/GraphContour.tsx
+++ b/optuna_dashboard/ts/components/GraphContour.tsx
@@ -130,7 +130,7 @@ const ContourFrontend: FC<{
   const searchSpace = useMergedUnionSearchSpace(study?.union_search_space)
   const [xParam, setXParam] = useState<SearchSpaceItem | null>(null)
   const [yParam, setYParam] = useState<SearchSpaceItem | null>(null)
-  const objectiveNames: string[] = study?.objective_names || []
+  const metricNames: string[] = study?.metric_names || []
 
   if (xParam === null && searchSpace.length > 0) {
     setXParam(searchSpace[0])
@@ -182,8 +182,8 @@ const ContourFrontend: FC<{
             <Select value={objectiveId} onChange={handleObjectiveChange}>
               {study.directions.map((d, i) => (
                 <MenuItem value={i} key={i}>
-                  {objectiveNames.length === study?.directions.length
-                    ? objectiveNames[i]
+                  {metricNames.length === study?.directions.length
+                    ? metricNames[i]
                     : `${i}`}
                 </MenuItem>
               ))}

--- a/optuna_dashboard/ts/components/GraphHistory.tsx
+++ b/optuna_dashboard/ts/components/GraphHistory.tsx
@@ -32,7 +32,7 @@ interface HistoryPlotInfo {
   study_name: string
   trials: Optuna.Trial[]
   directions: Optuna.StudyDirection[]
-  objective_names?: string[]
+  metric_names?: string[]
 }
 
 export const GraphHistory: FC<{
@@ -63,7 +63,7 @@ export const GraphHistory: FC<{
       study_name: study?.name,
       trials: trials[index],
       directions: study?.directions,
-      objective_names: study?.objective_names,
+      metric_names: study?.metric_names,
     }
     return h
   })
@@ -164,7 +164,7 @@ export const GraphHistory: FC<{
             >
               {targets.map((t, i) => (
                 <MenuItem value={t.identifier()} key={i}>
-                  {t.toLabel(studies[0].objective_names)}
+                  {t.toLabel(studies[0].metric_names)}
                 </MenuItem>
               ))}
             </Select>
@@ -253,7 +253,7 @@ const plotHistory = (
       b: 0,
     },
     yaxis: {
-      title: target.toLabel(historyPlotInfos[0].objective_names),
+      title: target.toLabel(historyPlotInfos[0].metric_names),
       type: logScale ? "log" : "linear",
     },
     xaxis: {
@@ -293,7 +293,7 @@ const plotHistory = (
       y: feasibleTrials.map(
         (t: Optuna.Trial): number => target.getTargetValue(t) as number
       ),
-      name: `${target.toLabel(h.objective_names)} of ${h.study_name}`,
+      name: `${target.toLabel(h.metric_names)} of ${h.study_name}`,
       marker: {
         size: markerSize,
       },

--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -69,7 +69,7 @@ const GraphParetoFrontFrontend: FC<{
   const navigate = useNavigate()
   const [objectiveXId, setObjectiveXId] = useState<number>(0)
   const [objectiveYId, setObjectiveYId] = useState<number>(1)
-  const objectiveNames: string[] = study?.objective_names || []
+  const metricNames: string[] = study?.metric_names || []
 
   const handleObjectiveXChange = (event: SelectChangeEvent<number>) => {
     setObjectiveXId(event.target.value as number)
@@ -130,8 +130,8 @@ const GraphParetoFrontFrontend: FC<{
               <Select value={objectiveXId} onChange={handleObjectiveXChange}>
                 {study.directions.map((d, i) => (
                   <MenuItem value={i} key={i}>
-                    {objectiveNames.length === study?.directions.length
-                      ? objectiveNames[i]
+                    {metricNames.length === study?.directions.length
+                      ? metricNames[i]
                       : `${i}`}
                   </MenuItem>
                 ))}
@@ -142,8 +142,8 @@ const GraphParetoFrontFrontend: FC<{
               <Select value={objectiveYId} onChange={handleObjectiveYChange}>
                 {study.directions.map((d, i) => (
                   <MenuItem value={i} key={i}>
-                    {objectiveNames.length === study?.directions.length
-                      ? objectiveNames[i]
+                    {metricNames.length === study?.directions.length
+                      ? metricNames[i]
                       : `${i}`}
                   </MenuItem>
                 ))}

--- a/optuna_dashboard/ts/components/GraphRank.tsx
+++ b/optuna_dashboard/ts/components/GraphRank.tsx
@@ -91,7 +91,7 @@ const GraphRankFrontend: FC<{
   const searchSpace = useMergedUnionSearchSpace(study?.union_search_space)
   const [xParam, setXParam] = useState<SearchSpaceItem | null>(null)
   const [yParam, setYParam] = useState<SearchSpaceItem | null>(null)
-  const objectiveNames: string[] = study?.objective_names || []
+  const metricNames: string[] = study?.metric_names || []
 
   if (xParam === null && searchSpace.length > 0) {
     setXParam(searchSpace[0])
@@ -150,8 +150,8 @@ const GraphRankFrontend: FC<{
             <Select value={objectiveId} onChange={handleObjectiveChange}>
               {study.directions.map((d, i) => (
                 <MenuItem value={i} key={i}>
-                  {objectiveNames.length === study?.directions.length
-                    ? objectiveNames[i]
+                  {metricNames.length === study?.directions.length
+                    ? metricNames[i]
                     : `${i}`}
                 </MenuItem>
               ))}

--- a/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
@@ -165,7 +165,7 @@ const CandidateTrial: FC<{
               trial={trial}
               isBestTrial={() => false}
               directions={[]}
-              objectiveNames={[]}
+              metricNames={[]}
             />
           </Box>
         </Box>

--- a/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
@@ -629,7 +629,7 @@ export const PreferentialTrials: FC<{ studyDetail: StudyDetail | null }> = ({
                     ?.state === "Complete" ?? false
                 }
                 directions={[]}
-                objectiveNames={[]}
+                metricNames={[]}
               />
             </Box>
           </Box>

--- a/optuna_dashboard/ts/components/TrialFormWidgets.tsx
+++ b/optuna_dashboard/ts/components/TrialFormWidgets.tsx
@@ -35,10 +35,10 @@ type WidgetState = {
 
 export const TrialFormWidgets: FC<{
   trial: Trial
-  objectiveNames: string[]
+  metricNames: string[]
   directions: Optuna.StudyDirection[]
   formWidgets?: FormWidgets
-}> = ({ trial, objectiveNames, directions, formWidgets }) => {
+}> = ({ trial, metricNames, directions, formWidgets }) => {
   if (
     formWidgets === undefined ||
     trial.state === "Pruned" ||
@@ -56,8 +56,8 @@ export const TrialFormWidgets: FC<{
         : "Set Objective Value Form"
   const widgetNames = formWidgets.widgets.map((widget, i) => {
     if (formWidgets.output_type === "objective") {
-      if (objectiveNames.at(i) !== undefined) {
-        return objectiveNames[i]
+      if (metricNames.at(i) !== undefined) {
+        return metricNames[i]
       }
       return directions.length === 1 ? "Objective" : `Objective ${i}`
     } else if (formWidgets.output_type === "user_attr") {

--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -126,9 +126,9 @@ export const TrialListDetail: FC<{
   trial: Trial
   isBestTrial: (trialId: number) => boolean
   directions: Optuna.StudyDirection[]
-  objectiveNames: string[]
+  metricNames: string[]
   formWidgets?: FormWidgets
-}> = ({ trial, isBestTrial, directions, objectiveNames, formWidgets }) => {
+}> = ({ trial, isBestTrial, directions, metricNames, formWidgets }) => {
   const theme = useTheme()
   const action = actionCreator()
   const artifactEnabled = useRecoilValue<boolean>(artifactIsAvailable)
@@ -290,7 +290,7 @@ export const TrialListDetail: FC<{
       <TrialFormWidgets
         trial={trial}
         directions={directions}
-        objectiveNames={objectiveNames}
+        metricNames={metricNames}
         formWidgets={formWidgets}
       />
       <Box
@@ -561,7 +561,7 @@ export const TrialList: FC<{ studyDetail: StudyDetail | null }> = ({
                   trial={t}
                   isBestTrial={isBestTrial}
                   directions={studyDetail?.directions || []}
-                  objectiveNames={studyDetail?.objective_names || []}
+                  metricNames={studyDetail?.metric_names || []}
                   formWidgets={studyDetail?.form_widgets}
                 />
               ))}

--- a/optuna_dashboard/ts/components/TrialTable.tsx
+++ b/optuna_dashboard/ts/components/TrialTable.tsx
@@ -32,7 +32,7 @@ export const TrialTable: FC<{
 
   const theme = useTheme()
   const trials: Trial[] = studyDetail !== null ? studyDetail.trials : []
-  const objectiveNames: string[] = studyDetail?.objective_names || []
+  const metricNames: string[] = studyDetail?.metric_names || []
 
   const columnHelper = createColumnHelper<Trial>()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -63,8 +63,8 @@ export const TrialTable: FC<{
         columnHelper.accessor((row) => row["values"]?.[objectiveId], {
           id: `values_${objectiveId}`,
           header:
-            objectiveNames.length === studyDetail?.directions.length
-              ? objectiveNames[objectiveId]
+            metricNames.length === studyDetail?.directions.length
+              ? metricNames[objectiveId]
               : `Objective ${objectiveId}`,
           enableSorting: true,
           enableColumnFilter: false,

--- a/optuna_dashboard/ts/types/optuna.ts
+++ b/optuna_dashboard/ts/types/optuna.ts
@@ -155,7 +155,7 @@ export type StudyDetail = {
   has_intermediate_values: boolean
   note: Note
   is_preferential: boolean
-  objective_names?: string[]
+  metric_names?: string[]
   form_widgets?: FormWidgets
   feedback_component_type: FeedbackComponentType
   preferences?: [number, number][]


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
This PR fixes a bug that `objective_names` are not properly displayed in some plot components.

### Before
<img width="1834" alt="Screenshot 2024-08-20 10 15 42" src="https://github.com/user-attachments/assets/a73da579-dbe1-46eb-91ab-e214be7a1c91">


### After

<img width="1834" alt="Screenshot 2024-08-20 10 16 53" src="https://github.com/user-attachments/assets/b9fb38ee-3b87-470a-9e03-c3fa0665e7a7">
