### PR TITLE
Fix `getArtifactUrlPath` in `jupyterlab-optuna`

### DIFF
--- a/optuna_dashboard/ts/components/Preferential/PreferentialGraph.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialGraph.tsx
@@ -27,6 +27,7 @@ import { StudyDetail, Trial } from "ts/types/optuna"
 import { useStudyDetailValue } from "../../state"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
 import { getArtifactUrlPath } from "./PreferentialTrials"
+import { useConstants } from "../../constantsProvider"
 
 const elk = new ELK()
 const nodeWidth = 400
@@ -39,6 +40,7 @@ type NodeData = {
 }
 const GraphNode: FC<NodeProps<NodeData>> = ({ data, isConnectable }) => {
   const theme = useTheme()
+  const {environment} = useConstants()
   const trial = data.trial
   if (trial === undefined) {
     return null
@@ -56,7 +58,7 @@ const GraphNode: FC<NodeProps<NodeData>> = ({ data, isConnectable }) => {
   const artifact = trial.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     artifactId !== undefined
-      ? getArtifactUrlPath(trial.study_id, trial.trial_id, artifactId)
+      ? getArtifactUrlPath(environment, trial.study_id, trial.trial_id, artifactId)
       : ""
 
   return (

--- a/optuna_dashboard/ts/components/Preferential/PreferentialGraph.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialGraph.tsx
@@ -24,10 +24,10 @@ import ReactFlow, {
 import "reactflow/dist/style.css"
 
 import { StudyDetail, Trial } from "ts/types/optuna"
+import { useConstants } from "../../constantsProvider"
 import { useStudyDetailValue } from "../../state"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
 import { getArtifactUrlPath } from "./PreferentialTrials"
-import { useConstants } from "../../constantsProvider"
 
 const elk = new ELK()
 const nodeWidth = 400
@@ -40,7 +40,7 @@ type NodeData = {
 }
 const GraphNode: FC<NodeProps<NodeData>> = ({ data, isConnectable }) => {
   const theme = useTheme()
-  const {environment} = useConstants()
+  const { environment } = useConstants()
   const trial = data.trial
   if (trial === undefined) {
     return null
@@ -58,7 +58,12 @@ const GraphNode: FC<NodeProps<NodeData>> = ({ data, isConnectable }) => {
   const artifact = trial.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     artifactId !== undefined
-      ? getArtifactUrlPath(environment, trial.study_id, trial.trial_id, artifactId)
+      ? getArtifactUrlPath(
+          environment,
+          trial.study_id,
+          trial.trial_id,
+          artifactId
+        )
       : ""
 
   return (

--- a/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
@@ -17,12 +17,12 @@ import React, { FC, useState } from "react"
 
 import { PreferenceHistory, StudyDetail, Trial } from "ts/types/optuna"
 import { actionCreator } from "../../action"
+import { useConstants } from "../../constantsProvider"
 import { formatDate } from "../../dateUtil"
 import { useStudyDetailValue } from "../../state"
 import { TrialListDetail } from "../TrialList"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
 import { getArtifactUrlPath } from "./PreferentialTrials"
-import { useConstants } from "../../constantsProvider"
 
 type TrialType = "worst" | "none"
 
@@ -31,7 +31,7 @@ const CandidateTrial: FC<{
   type: TrialType
 }> = ({ trial, type }) => {
   const theme = useTheme()
-  const {environment} = useConstants()
+  const { environment } = useConstants()
   const trialWidth = 300
   const trialHeight = 300
   const studyDetail = useStudyDetailValue(trial.study_id)
@@ -49,7 +49,12 @@ const CandidateTrial: FC<{
   const artifact = trial.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     artifactId !== undefined
-      ? getArtifactUrlPath(environment, trial.study_id, trial.trial_id, artifactId)
+      ? getArtifactUrlPath(
+          environment,
+          trial.study_id,
+          trial.trial_id,
+          artifactId
+        )
       : ""
 
   const cardComponentSx = {

--- a/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialHistory.tsx
@@ -22,6 +22,7 @@ import { useStudyDetailValue } from "../../state"
 import { TrialListDetail } from "../TrialList"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
 import { getArtifactUrlPath } from "./PreferentialTrials"
+import { useConstants } from "../../constantsProvider"
 
 type TrialType = "worst" | "none"
 
@@ -30,6 +31,7 @@ const CandidateTrial: FC<{
   type: TrialType
 }> = ({ trial, type }) => {
   const theme = useTheme()
+  const {environment} = useConstants()
   const trialWidth = 300
   const trialHeight = 300
   const studyDetail = useStudyDetailValue(trial.study_id)
@@ -47,7 +49,7 @@ const CandidateTrial: FC<{
   const artifact = trial.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     artifactId !== undefined
-      ? getArtifactUrlPath(trial.study_id, trial.trial_id, artifactId)
+      ? getArtifactUrlPath(environment, trial.study_id, trial.trial_id, artifactId)
       : ""
 
   const cardComponentSx = {

--- a/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
@@ -36,13 +36,13 @@ import {
   Trial,
 } from "ts/types/optuna"
 import { actionCreator } from "../../action"
+import { useConstants } from "../../constantsProvider"
 import {
   isThreejsArtifact,
   useThreejsArtifactModal,
 } from "../Artifact/ThreejsArtifactViewer"
 import { TrialListDetail } from "../TrialList"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
-import { useConstants } from "../../constantsProvider"
 
 const SettingsPage: FC<{
   studyDetail: StudyDetail
@@ -184,7 +184,7 @@ export const getArtifactUrlPath = (
   trialId: number,
   artifactId: string
 ): string => {
-  const apiNamespace = environment === "jupyterlab" ? "/jupyterlab-optuna": ""
+  const apiNamespace = environment === "jupyterlab" ? "/jupyterlab-optuna" : ""
   return `${apiNamespace}/artifacts/${studyId}/${trialId}/${artifactId}`
 }
 
@@ -204,7 +204,7 @@ const PreferentialTrial: FC<{
   openThreejsArtifactModal,
 }) => {
   const theme = useTheme()
-  const {environment} = useConstants()
+  const { environment } = useConstants()
   const action = actionCreator()
   const [buttonHover, setButtonHover] = useState(false)
   const trialWidth = 400
@@ -218,7 +218,12 @@ const PreferentialTrial: FC<{
   const artifact = trial?.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     trial !== undefined && artifactId !== undefined
-      ? getArtifactUrlPath(environment, studyDetail.id, trial?.trial_id, artifactId)
+      ? getArtifactUrlPath(
+          environment,
+          studyDetail.id,
+          trial?.trial_id,
+          artifactId
+        )
       : ""
   const is3dModel =
     componentType.output_type === "artifact" &&

--- a/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
+++ b/optuna_dashboard/ts/components/Preferential/PreferentialTrials.tsx
@@ -42,6 +42,7 @@ import {
 } from "../Artifact/ThreejsArtifactViewer"
 import { TrialListDetail } from "../TrialList"
 import { PreferentialOutputComponent } from "./PreferentialOutputComponent"
+import { useConstants } from "../../constantsProvider"
 
 const SettingsPage: FC<{
   studyDetail: StudyDetail
@@ -178,11 +179,13 @@ const isComparisonReady = (
 }
 
 export const getArtifactUrlPath = (
+  environment: "jupyterlab" | "optuna-dashboard",
   studyId: number,
   trialId: number,
   artifactId: string
 ): string => {
-  return `/artifacts/${studyId}/${trialId}/${artifactId}`
+  const apiNamespace = environment === "jupyterlab" ? "/jupyterlab-optuna": ""
+  return `${apiNamespace}/artifacts/${studyId}/${trialId}/${artifactId}`
 }
 
 const PreferentialTrial: FC<{
@@ -201,6 +204,7 @@ const PreferentialTrial: FC<{
   openThreejsArtifactModal,
 }) => {
   const theme = useTheme()
+  const {environment} = useConstants()
   const action = actionCreator()
   const [buttonHover, setButtonHover] = useState(false)
   const trialWidth = 400
@@ -214,7 +218,7 @@ const PreferentialTrial: FC<{
   const artifact = trial?.artifacts.find((a) => a.artifact_id === artifactId)
   const urlPath =
     trial !== undefined && artifactId !== undefined
-      ? getArtifactUrlPath(studyDetail.id, trial?.trial_id, artifactId)
+      ? getArtifactUrlPath(environment, studyDetail.id, trial?.trial_id, artifactId)
       : ""
   const is3dModel =
     componentType.output_type === "artifact" &&


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Fixed an issue in `jupyterlab-optuna` where artifacts were not displayed correctly due to the Artifact URL path specified in the `getArtifactUrlPath` function being different from that in `optuna_dashboard`.

<img width="1155" alt="スクリーンショット 2024-08-28 13 50 28" src="https://github.com/user-attachments/assets/d7019d36-ae7d-464c-ac5d-f3bb562bb414">
