### PR TITLE
Support colorTheme in Plotlypy mode

### DIFF
--- a/optuna_dashboard/ts/hooks/usePlot.ts
+++ b/optuna_dashboard/ts/hooks/usePlot.ts
@@ -1,8 +1,10 @@
+import { useTheme } from "@mui/material"
 import { useQuery } from "@tanstack/react-query"
 import { AxiosError } from "axios"
 import * as plotly from "plotly.js-dist-min"
 import { PlotType } from "../apiClient"
 import { useAPIClient } from "../apiClientProvider"
+import { usePlotlyColorTheme } from "../state"
 
 export const usePlot = ({
   numCompletedTrials,
@@ -13,6 +15,9 @@ export const usePlot = ({
   studyId: number | undefined
   plotType: PlotType
 }) => {
+  const theme = useTheme()
+  const colorTheme = usePlotlyColorTheme(theme.palette.mode)
+
   const { apiClient } = useAPIClient()
   const { data, isLoading, error } = useQuery<
     { data: plotly.Data[]; layout: plotly.Layout },
@@ -32,7 +37,7 @@ export const usePlot = ({
 
   return {
     data: data?.data,
-    layout: data?.layout,
+    layout: { ...data?.layout, template: colorTheme },
     isLoading,
     error,
   }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes #844 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Modified `optuna_dashboard/ts/hooks/usePlot.ts` to receive `colorTheme` and include it in `layout.template`, allowing color theme changes to be supported in modes using `Plotlypy`.
