### PR TITLE
Fix type of datetime start and complete of mock studies

### DIFF
--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -261,8 +261,8 @@ const getTrials = (
         params: [], // Set this column later
         user_attrs: [], // Set this column later
         constraints: [],
-        datetime_start: vals[3],
-        datetime_complete: vals[4],
+        datetime_start: new Date(vals[3]),
+        datetime_complete: new Date(vals[4]),
       }
       trials.push(trial)
     },


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
https://github.com/optuna/optuna-dashboard/pull/951

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
To run a story of https://github.com/optuna/optuna-dashboard/pull/951, I found that mock trials' datetime is string.
This PR will convert those string to Date.
