### PR TITLE
Add Hovertext to history plot

### DIFF
--- a/tslib/react/src/components/PlotHistory.tsx
+++ b/tslib/react/src/components/PlotHistory.tsx
@@ -18,6 +18,7 @@ import * as plotly from "plotly.js-dist-min"
 import { ChangeEvent, FC, useEffect, useState } from "react"
 
 import { useGraphComponentState } from "../hooks/useGraphComponentState"
+import { makeHovertext } from "../utils/graph"
 import {
   Target,
   useFilteredTrialsFromStudies,
@@ -332,6 +333,10 @@ const plotHistory = (
         infeasibleTrials.push(t)
       }
     }
+    const hovertemplate =
+      infeasibleTrials.length === 0
+        ? "%{text}<extra>Trial</extra>"
+        : "%{text}<extra>Feasible Trial</extra>"
     plotData.push({
       x: feasibleTrials.map(getAxisX),
       y: feasibleTrials.map(
@@ -343,6 +348,8 @@ const plotHistory = (
       },
       mode: "markers",
       type: "scatter",
+      text: feasibleTrials.map((t) => makeHovertext(t)),
+      hovertemplate: hovertemplate,
     })
 
     const objectiveId = target.getObjectiveId()
@@ -411,6 +418,8 @@ const plotHistory = (
       },
       mode: "markers",
       type: "scatter",
+      text: infeasibleTrials.map((t) => makeHovertext(t)),
+      hovertemplate: "%{text}<extra>Infeasible Trial</extra>",
       showlegend: false,
     })
   }

--- a/tslib/react/src/utils/graph.ts
+++ b/tslib/react/src/utils/graph.ts
@@ -1,0 +1,21 @@
+import * as Optuna from "@optuna/types"
+
+export const makeHovertext = (trial: Optuna.Trial): string => {
+  return JSON.stringify(
+    {
+      number: trial.number,
+      values: trial.values,
+      params: trial.params
+        .map((p) => [p.name, p.param_external_value])
+        .reduce(
+          (obj, [key, value]) => {
+            obj[key as string] = value
+            return obj
+          },
+          {} as Record<string, Optuna.CategoricalChoiceType>
+        ),
+    },
+    undefined,
+    "  "
+  ).replace(/\n/g, "<br>")
+}


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes #842 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Hyperparemeter as shown below in histoy plot.

<img width="1222" alt="Screenshot 2024-09-26 at 21 28 34" src="https://github.com/user-attachments/assets/b61f38fb-124e-42ff-a1b2-996b8ec9150c">

The Hovertext function is in utils directory with the assumption that it will be used in other plots.