### PR TITLE
Fix plot visualization issues with categorical parameters

### DIFF
--- a/tslib/react/src/components/PlotParallelCoordinate.tsx
+++ b/tslib/react/src/components/PlotParallelCoordinate.tsx
@@ -173,7 +173,7 @@ const plotCoordinate = (
     if (s.distribution.type === "CategoricalDistribution") {
       // categorical
       const vocabArr: string[] = s.distribution.choices.map(
-        (c) => c?.toString() ?? "null"
+        (c) => c?.value ?? "null"
       )
       const tickvals: number[] = vocabArr.map((_, i) => i)
       return {

--- a/tslib/react/src/components/PlotSlice.tsx
+++ b/tslib/react/src/components/PlotSlice.tsx
@@ -268,7 +268,7 @@ const plotSlice = (
     }
   } else {
     const vocabArr = selectedParamSpace.distribution.choices.map(
-      (c) => c?.toString() ?? "null"
+      (c) => c?.value ?? "null"
     )
     const tickvals: number[] = vocabArr.map((_v, i) => i)
     layout.xaxis = {

--- a/tslib/react/src/components/TrialTable.tsx
+++ b/tslib/react/src/components/TrialTable.tsx
@@ -78,7 +78,7 @@ export const TrialTable: FC<{
       const sortable = s.distribution.type !== "CategoricalDistribution"
       const filterChoices: (string | null)[] | undefined =
         s.distribution.type === "CategoricalDistribution"
-          ? s.distribution.choices.map((c) => c?.toString() ?? "null")
+          ? s.distribution.choices.map((c) => c?.value ?? "null")
           : undefined
       const hasMissingValue = trials.some(
         (t) => !t.params.some((p) => p.name === s.name)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes #977
Follow-up of PR #988

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

`toString()` was directly applied to `CategoricalChoiceType` object, causing the plot to display `[object Object]` unexpectedly. This PR fixes the issue by modifying it to extract the `value` instead.
