### PR TITLE
Add scrollbar to ParallelCoordinate plot card

### DIFF
--- a/tslib/react/src/components/PlotParallelCoordinate.tsx
+++ b/tslib/react/src/components/PlotParallelCoordinate.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material"
+import { Box } from "@mui/system"
 import * as Optuna from "@optuna/types"
 import * as plotly from "plotly.js-dist-min"
 import React, { FC, ReactNode, useEffect, useState } from "react"
@@ -298,22 +299,25 @@ const useTargets = (
         label="Check All"
       />
       <Divider />
-      {allTargets.map((t, i) => {
-        const key = t.toLabel(study?.metric_names)
-        return (
-          <FormControlLabel
-            key={key}
-            control={
-              <Checkbox
-                checked={checked.length > i ? checked[i] : true}
-                onChange={handleOnChange}
-                name={i.toString()}
-              />
-            }
-            label={t.toLabel(study?.metric_names)}
-          />
-        )
-      })}
+      <Box sx={{ maxHeight: "300px", overflowX: "hidden", overflowY: "auto" }}>
+        {allTargets.map((t, i) => {
+          const key = t.toLabel(study?.metric_names)
+          return (
+            <FormControlLabel
+              sx={{ width: "100%" }}
+              key={key}
+              control={
+                <Checkbox
+                  checked={checked.length > i ? checked[i] : true}
+                  onChange={handleOnChange}
+                  name={i.toString()}
+                />
+              }
+              label={t.toLabel(study?.metric_names)}
+            />
+          )
+        })}
+      </Box>
     </FormGroup>
   )
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

With the current implementation of ParallelCoordinates, when the number of axes to be displayed is large, the cards become very long, making it difficult to see subsequent cards.
How about adding a scroll bar to limit the height of the cards?

| without height limit (Current) | with height limit |
|---|---|
| <img width="1171" alt="Screenshot 2024-11-25 at 22 05 23" src="https://github.com/user-attachments/assets/63d5f5e1-fdb6-45be-8ca0-22bd21c7f1b7"> | <img width="1125" alt="Screenshot 2024-11-25 at 22 09 42" src="https://github.com/user-attachments/assets/06027ada-5e6c-4ea1-807d-44d0882aa45b"> |


