### PR TITLE
fix timeline width to extend full-width

### DIFF
--- a/tslib/react/src/components/PlotTimeline.tsx
+++ b/tslib/react/src/components/PlotTimeline.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, Grid, Typography, useTheme } from "@mui/material"
+import { Card, CardContent, Typography, useTheme } from "@mui/material"
 import * as Optuna from "@optuna/types"
 import * as plotly from "plotly.js-dist-min"
 import { FC, useEffect } from "react"
@@ -32,9 +32,7 @@ export const PlotTimeline: FC<{
         >
           Timeline
         </Typography>
-        <Grid item xs={12}>
-          <div id={plotDomId} />
-        </Grid>
+        <div id={plotDomId} />
       </CardContent>
     </Card>
   )

--- a/tslib/react/src/components/PlotTimeline.tsx
+++ b/tslib/react/src/components/PlotTimeline.tsx
@@ -32,7 +32,7 @@ export const PlotTimeline: FC<{
         >
           Timeline
         </Typography>
-        <Grid item xs={9}>
+        <Grid item xs={12}>
           <div id={plotDomId} />
         </Grid>
       </CardContent>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [ x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes the first one the issue https://github.com/optuna/optuna-dashboard/issues/994

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Adjust the width ratio of the timeline figure to make it full-width
