### PR TITLE
add 5 as the default option of the row number of study user attributes

### DIFF
--- a/tslib/react/src/components/DataGrid.tsx
+++ b/tslib/react/src/components/DataGrid.tsx
@@ -131,7 +131,13 @@ function DataGrid<T>({
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
   )
-  const rowsPerPageOptions = [5, 10, 50, 100, { label: "All", value: data.length }]
+  const rowsPerPageOptions = [
+    5,
+    10,
+    50,
+    100,
+    { label: "All", value: data.length },
+  ]
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize:

--- a/tslib/react/src/components/DataGrid.tsx
+++ b/tslib/react/src/components/DataGrid.tsx
@@ -131,13 +131,13 @@ function DataGrid<T>({
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
   )
-  const rowsPerPageOptions = [10, 50, 100, { label: "All", value: data.length }]
+  const rowsPerPageOptions = [5, 10, 50, 100, { label: "All", value: data.length }]
   const [pagination, setPagination] = React.useState<PaginationState>({
     pageIndex: 0,
     pageSize:
       initialRowsPerPage && rowsPerPageOptions.includes(initialRowsPerPage)
         ? initialRowsPerPage
-        : 50,
+        : 5,
   })
 
   const table = useReactTable({


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes second one of https://github.com/optuna/optuna-dashboard/issues/994

## What does this implement/fix? Explain your changes.

I added 5 as an option of the row number of study user attrs.
And, I set 5 as the default option if `initialRowPerPage` is null (Probably).


<img width="1553" alt="スクリーンショット 2024-12-18 16 42 45" src="https://github.com/user-attachments/assets/ac570776-7973-47fc-86a5-98f101ec6c96" />


<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
