### PR TITLE
Fix the problem that SAVE button and CLOSE button are invisible when editing Note

### DIFF
--- a/optuna_dashboard/ts/components/Note.tsx
+++ b/optuna_dashboard/ts/components/Note.tsx
@@ -331,9 +331,9 @@ const MarkdownEditorModal: FC<{
             resize: "none",
             width: "100%",
             height: "100%",
-            "& .MuiInputBase-root": { 
-              height: "100%", 
-              alignItems: "start" 
+            "& .MuiInputBase-root": {
+              height: "100%",
+              alignItems: "start",
             },
           }}
           inputRef={textAreaRef}

--- a/optuna_dashboard/ts/components/Note.tsx
+++ b/optuna_dashboard/ts/components/Note.tsx
@@ -331,7 +331,10 @@ const MarkdownEditorModal: FC<{
             resize: "none",
             width: "100%",
             height: "100%",
-            "& .MuiInputBase-root": { height: "100%", alignItems: "start" },
+            "& .MuiInputBase-root": { 
+              height: "100%", 
+              alignItems: "start" 
+            },
           }}
           inputRef={textAreaRef}
           defaultValue={latestNote.body}

--- a/optuna_dashboard/ts/components/Note.tsx
+++ b/optuna_dashboard/ts/components/Note.tsx
@@ -316,7 +316,6 @@ const MarkdownEditorModal: FC<{
         component="div"
         sx={{
           width: "100%",
-          height: "calc(100% - 100px)",
           flexGrow: 1,
           display: preview ? "none" : "flex",
           flexDirection: "row",
@@ -332,10 +331,7 @@ const MarkdownEditorModal: FC<{
             resize: "none",
             width: "100%",
             height: "100%",
-            "& .MuiInputBase-root": { height: "100%" },
-          }}
-          inputProps={{
-            style: { resize: "none", overflow: "scroll", height: "100%" },
+            "& .MuiInputBase-root": { height: "100%", alignItems: "start" },
           }}
           inputRef={textAreaRef}
           defaultValue={latestNote.body}

--- a/optuna_dashboard/ts/components/Note.tsx
+++ b/optuna_dashboard/ts/components/Note.tsx
@@ -272,7 +272,7 @@ const MarkdownEditorModal: FC<{
         bottom: 0,
         height: "100%",
         left: 0,
-        overflow: "hidden",
+        overflow: "scroll",
         position: "fixed",
         right: 0,
         top: 0,
@@ -316,6 +316,7 @@ const MarkdownEditorModal: FC<{
         component="div"
         sx={{
           width: "100%",
+          height: "calc(100% - 100px)",
           flexGrow: 1,
           display: preview ? "none" : "flex",
           flexDirection: "row",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [X] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

The problem is that we can't see SAVE button and CLOSE button when we edit markdown of Note. 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

The cause is textarea of markdown field expands infinitely (but I'm not sure why this happens).
So I set the height of the field using `calc`.

![スクリーンショット 2024-12-25 16 31 55](https://github.com/user-attachments/assets/15e57db6-54bd-4c0f-9609-255f0533a8eb)
