### PR TITLE
Fix docs for `save_plotly_graph_object`

### DIFF
--- a/optuna_dashboard/_custom_plot_data.py
+++ b/optuna_dashboard/_custom_plot_data.py
@@ -44,8 +44,8 @@ def save_plotly_graph_object(
     Args:
         study:
             Target study object.
-        plot_data:
-            The plotly's graph object to save.
+        figure:
+            A :class:`plotly.graph_objects.Figure` object to save.
         graph_object_id:
             Unique identifier of the graph object. If specified, the graph object is overwritten.
             This must be a valid HTML id attribute value.


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## What does this implement/fix? Explain your changes.

The current documentation about arguments for `save_plotly_graph_object` is incorrect.
This PR fixes the docs.

Before
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/e7d820bc-0c15-46c4-94cf-3d2c39040e69" />
After
<img width="1093" alt="image" src="https://github.com/user-attachments/assets/85ccab0f-3773-48d6-9c53-78e460d2428a" />

