### PR TITLE
Add filtering out option for pruned trials in `PlotSlice`

### DIFF
--- a/tslib/react/src/components/PlotSlice.tsx
+++ b/tslib/react/src/components/PlotSlice.tsx
@@ -48,13 +48,14 @@ export const PlotSlice: FC<{
   const [paramTargets, selectedParamTarget, setParamTarget] =
     useParamTargets(searchSpace)
   const [logYScale, setLogYScale] = useState(false)
+  const [filterPrunedTrials, setFilterPrunedTrials] = useState(false)
 
   const trials = useFilteredTrials(
     study,
     selectedParamTarget !== null
       ? [selectedObjective, selectedParamTarget]
       : [selectedObjective],
-    false
+    filterPrunedTrials
   )
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
@@ -88,7 +89,11 @@ export const PlotSlice: FC<{
   }
 
   const handleLogYScaleChange = () => {
-    setLogYScale(!logYScale)
+    setLogYScale((cur) => !cur)
+  }
+
+  const handleFilterPrunedTrialsChange = () => {
+    setFilterPrunedTrials((cur) => !cur)
   }
 
   return (
@@ -98,6 +103,7 @@ export const PlotSlice: FC<{
         xs={3}
         container
         direction="column"
+        gap={2}
         sx={{ paddingRight: theme.spacing(2) }}
       >
         <Typography
@@ -143,6 +149,14 @@ export const PlotSlice: FC<{
           <Switch
             checked={logYScale}
             onChange={handleLogYScaleChange}
+            value="enable"
+          />
+        </FormControl>
+        <FormControl component="fieldset">
+          <FormLabel component="legend">Filter out pruned trials:</FormLabel>
+          <Switch
+            checked={filterPrunedTrials}
+            onChange={handleFilterPrunedTrialsChange}
             value="enable"
           />
         </FormControl>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Fixes #881 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Added filtering out option for pruned trials in `PlotSlice`
