### PR TITLE
Replace ubuntu version `20.04` with `latest`

### DIFF
--- a/.github/workflows/e2e-dashboard-tests.yml
+++ b/.github/workflows/e2e-dashboard-tests.yml
@@ -17,7 +17,7 @@ on:
       - 'optuna_dashboard/tsconfig.json'
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         optuna-version: ['optuna==3.1.0', 'git+https://github.com/optuna/optuna.git']


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

`ubuntu-20.04` image will be unsupported in the next April, so ubuntu-22.04, 24.04 or latest are alternatives. 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

I suppose other github action yaml files in this repo use `ubuntu-latest`, so use `latest`