### PR TITLE
Change `initialRowsPerPage` to 50 in `TrialTable`

### DIFF
--- a/tslib/react/src/components/TrialTable.tsx
+++ b/tslib/react/src/components/TrialTable.tsx
@@ -181,7 +181,7 @@ export const TrialTable: FC<{
     <DataGrid
       data={trials}
       columns={columns}
-      initialRowsPerPage={initialRowsPerPage}
+      initialRowsPerPage={initialRowsPerPage ?? 50}
     />
   )
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Follow up of #1003 

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

- Changed `initialRowsPerPage` to 50 in `TrialTable`
