### PR TITLE
Make unselect trial visible

### DIFF
--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -261,9 +261,9 @@ const makeMarker = (
       line:
         mode === "dark"
           ? { width: 0.25, color: "#666666" }
-          : { width: 0.25, color: "#cccccc" },
+          : { width: 0.50, color: "#cccccc" },
       // @ts-ignore
-      color: "#FFFFFF00",
+      color: "#ffffff00",
     }
   } else {
     return {

--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -261,7 +261,7 @@ const makeMarker = (
       line:
         mode === "dark"
           ? { width: 0.25, color: "#666666" }
-          : { width: 0.50, color: "#cccccc" },
+          : { width: 0.5, color: "#cccccc" },
       // @ts-ignore
       color: "#ffffff00",
     }

--- a/tslib/react/src/utils/trialFilter.ts
+++ b/tslib/react/src/utils/trialFilter.ts
@@ -100,8 +100,7 @@ const filterTrials = (
   targets: Target[],
   filterPruned: boolean,
   includeInfeasible = true,
-  includeDominated = true,
-  selectedTrials: number[] = []
+  includeDominated = true
 ): Optuna.Trial[] => {
   if (study === null) {
     return []
@@ -118,9 +117,6 @@ const filterTrials = (
 
   return trials.filter((t, i) => {
     if (isDominated.length > 0 && isDominated[i]) {
-      return false
-    }
-    if (selectedTrials.length !== 0 && !selectedTrials.includes(t.number)) {
       return false
     }
     if (t.state !== "Complete" && t.state !== "Pruned") {
@@ -172,7 +168,6 @@ export const useFilteredTrialsFromStudies = (
   studies: Optuna.Study[],
   targets: Target[],
   filterPruned: boolean,
-  selectedTrials: number[] = [],
   includeInfeasible = true,
   includeDominated = true
 ): Optuna.Trial[][] =>
@@ -183,18 +178,10 @@ export const useFilteredTrialsFromStudies = (
         targets,
         filterPruned,
         includeInfeasible,
-        includeDominated,
-        selectedTrials
+        includeDominated
       )
     )
-  }, [
-    studies,
-    targets,
-    filterPruned,
-    includeInfeasible,
-    includeDominated,
-    selectedTrials,
-  ])
+  }, [studies, targets, filterPruned, includeInfeasible, includeDominated])
 
 export const useObjectiveTargets = (
   study: Optuna.Study | null


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Trials that were not selected in Trials(Selection) were not displayed.
However, since it is easier to understand if the plot shows whether a trial was selected or not, only lines are drawn for trials that were not selected.

|before|this pr|
|---|---|
|<img width="888" alt="Screenshot 2025-03-16 at 0 04 42" src="https://github.com/user-attachments/assets/153beed8-064e-4469-9268-0ec4c865df02" />|<img width="911" alt="Screenshot 2025-03-16 at 0 01 59" src="https://github.com/user-attachments/assets/92140300-aa52-4962-a4da-30b19547fd6f" />
|<img width="696" alt="Screenshot 2025-03-16 at 0 04 06" src="https://github.com/user-attachments/assets/c154ed72-f83b-4f49-a4c0-571493896ba8" />|<img width="692" alt="Screenshot 2025-03-16 at 0 02 38" src="https://github.com/user-attachments/assets/9f12d2f4-e72a-4e12-b43c-c59c358f370e" />|


