### PR TITLE
CLI enable sqlite path

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -92,6 +92,16 @@ you can use the command line interface like ``optuna-dashboard <STORAGE_URL>``.
    Listening on http://localhost:8080/
    Hit Ctrl-C to quit.
 
+
+Alternatively, for local SQLite3 databases, you can provide the file path directly:
+
+.. code-block:: console
+
+   $ optuna-dashboard ./db.sqlite3
+   Listening on http://localhost:8080/
+   Hit Ctrl-C to quit.
+
+
 If you are using JournalStorage classes introduced in Optuna v3.1, you can use them like below:
 
 .. code-block:: console

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -18,7 +18,8 @@ from packaging import version
 from . import __version__
 from ._app import create_app
 from ._sql_profiler import register_profiler_view
-from ._storage_url import get_storage, STORAGE_CHOICES
+from ._storage_url import get_storage
+from ._storage_url import STORAGE_CHOICES
 from .artifact._backend_to_store import ArtifactBackendToStore
 from .artifact.file_system import FileSystemBackend
 

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -18,7 +18,7 @@ from packaging import version
 from . import __version__
 from ._app import create_app
 from ._sql_profiler import register_profiler_view
-from ._storage_url import get_storage
+from ._storage_url import get_storage, STORAGE_CHOICES
 from .artifact._backend_to_store import ArtifactBackendToStore
 from .artifact.file_system import FileSystemBackend
 
@@ -89,12 +89,18 @@ def auto_select_server(
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Real-time dashboard for Optuna.")
-    parser.add_argument("storage", help="Storage URL (e.g. sqlite:///example.db)", type=str)
+    parser.add_argument(
+        "storage",
+        help="A storage URL (e.g. sqlite:///example.db). Or path to a SQLite database file (to/db.sqlite3)"
+        " or Journal Storage file (e.g. to/journal.log)",
+        type=str,
+    )
     parser.add_argument(
         "--storage-class",
-        help="Storage class hint (e.g. JournalFileStorage)",
+        help="Storage class hint (default: None)",
         type=str,
         default=None,
+        choices=STORAGE_CHOICES,
     )
     parser.add_argument(
         "--port", help="port number (default: %(default)s)", type=int, default=8080
@@ -115,8 +121,7 @@ def main() -> None:
     parser.add_argument("--quiet", "-q", help="quiet", action="store_true")
     args = parser.parse_args()
 
-    storage: BaseStorage
-    storage = get_storage(args.storage, storage_class=args.storage_class)
+    storage: BaseStorage = get_storage(args.storage, storage_class=args.storage_class)
 
     artifact_store: ArtifactStore | None
     if args.artifact_dir is None:

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -91,13 +91,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Real-time dashboard for Optuna.")
     parser.add_argument(
         "storage",
-        help="a storage URL (e.g. sqlite:///example.db) or path to a SQLite database file (to/db.sqlite3)"
-        " or Journal Storage file (e.g. to/journal.log)",
+        help="a storage URL (e.g. sqlite:///example.db) or path to a SQLite database file"
+        " (to/db.sqlite3) or Journal Storage file (e.g. to/journal.log)",
         type=str,
     )
     parser.add_argument(
         "--storage-class",
-        help="storage class overwrite. Disables guess from the storage string (default: %(default)s)",
+        help="storage class overwrite. Disables guess from the storage string"
+        " (default: %(default)s)",
         type=str,
         default=None,
         choices=STORAGE_CHOICES,

--- a/optuna_dashboard/_cli.py
+++ b/optuna_dashboard/_cli.py
@@ -91,13 +91,13 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Real-time dashboard for Optuna.")
     parser.add_argument(
         "storage",
-        help="A storage URL (e.g. sqlite:///example.db). Or path to a SQLite database file (to/db.sqlite3)"
+        help="a storage URL (e.g. sqlite:///example.db) or path to a SQLite database file (to/db.sqlite3)"
         " or Journal Storage file (e.g. to/journal.log)",
         type=str,
     )
     parser.add_argument(
         "--storage-class",
-        help="Storage class hint (default: None)",
+        help="storage class overwrite. Disables guess from the storage string (default: %(default)s)",
         type=str,
         default=None,
         choices=STORAGE_CHOICES,
@@ -114,7 +114,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--artifact-dir",
-        help="directory to store artifact files",
+        help="directory of the artifact files store",
         default=None,
     )
     parser.add_argument("--version", "-v", action="version", version=__version__)


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

Follow-up: #799

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Since #800  the cli provides a clear error message when trying to start optuna-dashboard with a file path to a sqlite database. But actually, since optuna-dashboard knows it is a sqlite database, it would be more user-friendly to just open it. This has the additional benefit, that one can use the path auto-completion in bash. Specifying the url still works.

In short:

- Enable passing a sqlite db as path, e.g. `optuna-dashboard ./db.sqplite3`
- Improving help texts for the cli
- Adding to the quick start
