### PR TITLE
Fix FutureWarning of system attrs in preferential optimization

### DIFF
--- a/optuna_dashboard/preferential/_study.py
+++ b/optuna_dashboard/preferential/_study.py
@@ -294,7 +294,7 @@ class PreferentialStudy:
             for t in trials
             if t.number not in worse_trial_numbers and t._trial_id not in skipped_trial_ids
         ]
-        return len(active_trials) < get_n_generate(self._study.system_attrs)
+        return len(active_trials) < get_n_generate(self._study._storage.get_study_system_attrs(self._study._study_id))
 
 
 def get_best_trials(study_id: int, storage: optuna.storages.BaseStorage) -> list[FrozenTrial]:

--- a/python_tests/test_preference_setting.py
+++ b/python_tests/test_preference_setting.py
@@ -12,7 +12,7 @@ class FeedbackSettingTestCase(TestCase):
     def test_widget_to_dict_from_dict(self) -> None:
         study = PreferentialStudy(optuna.create_study())
         register_preference_feedback_component(study, "artifact", "image_key")
-        system_attrs = study._study.system_attrs
+        system_attrs = study._study._storage.get_study_system_attrs(study._study._study_id)
         feedback_type = system_attrs.get(_SYSTEM_ATTR_FEEDBACK_COMPONENT, {})
         assert "output_type" in feedback_type
         assert feedback_type["output_type"] == "artifact"


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This fixes FutureWarning in preferential optimization by replacing  study.system_attrs with get_study_system_attrs. The related test is also fixed.
