### PR TITLE
Improve scatter plot order

### DIFF
--- a/optuna_dashboard/ts/components/GraphParetoFront.tsx
+++ b/optuna_dashboard/ts/components/GraphParetoFront.tsx
@@ -343,6 +343,16 @@ const plotParetoFront = (
       mode
     ),
     makeScatterObject(
+      infeasibleTrials,
+      objectiveXId,
+      objectiveYId,
+      "%{text}<extra>Infeasible Trial</extra>",
+      false,
+      false,
+      false,
+      mode
+    ),
+    makeScatterObject(
       feasibleTrials.filter((t, i) => isDominated[i]),
       objectiveXId,
       objectiveYId,
@@ -361,16 +371,6 @@ const plotParetoFront = (
       "%{text}<extra>Best Trial</extra>",
       false,
       true,
-      false,
-      mode
-    ),
-    makeScatterObject(
-      infeasibleTrials,
-      objectiveXId,
-      objectiveYId,
-      "%{text}<extra>Infeasible Trial</extra>",
-      false,
-      false,
       false,
       mode
     ),

--- a/optuna_dashboard/ts/components/GraphRank.tsx
+++ b/optuna_dashboard/ts/components/GraphRank.tsx
@@ -360,6 +360,25 @@ const plotRank = (
   const plotData: Partial<plotly.PlotData>[] = [
     {
       type: "scatter",
+      x: xValues.filter((_, i) => !rankPlotInfo.is_feasible[i]),
+      y: yValues.filter((_, i) => !rankPlotInfo.is_feasible[i]),
+      marker: {
+        color: "#cccccc",
+        size: 10,
+        line: {
+          color: "Grey",
+          width: 0.5,
+        },
+      },
+      mode: "markers",
+      showlegend: false,
+      hovertemplate: "%{hovertext}<extra></extra>",
+      hovertext: rankPlotInfo.hovertext.filter(
+        (_, i) => !rankPlotInfo.is_feasible[i]
+      ),
+    },
+    {
+      type: "scatter",
       x: xValues.filter((_, i) => rankPlotInfo.is_feasible[i]),
       y: yValues.filter((_, i) => rankPlotInfo.is_feasible[i]),
       marker: {
@@ -381,25 +400,6 @@ const plotRank = (
       hovertemplate: "%{hovertext}<extra></extra>",
       hovertext: rankPlotInfo.hovertext.filter(
         (_, i) => rankPlotInfo.is_feasible[i]
-      ),
-    },
-    {
-      type: "scatter",
-      x: xValues.filter((_, i) => !rankPlotInfo.is_feasible[i]),
-      y: yValues.filter((_, i) => !rankPlotInfo.is_feasible[i]),
-      marker: {
-        color: "#cccccc",
-        size: 10,
-        line: {
-          color: "Grey",
-          width: 0.5,
-        },
-      },
-      mode: "markers",
-      showlegend: false,
-      hovertemplate: "%{hovertext}<extra></extra>",
-      hovertext: rankPlotInfo.hovertext.filter(
-        (_, i) => !rankPlotInfo.is_feasible[i]
       ),
     },
   ]

--- a/tslib/react/src/components/PlotHistory.tsx
+++ b/tslib/react/src/components/PlotHistory.tsx
@@ -334,6 +334,8 @@ const plotHistory = (
   }
 
   const plotData: Partial<plotly.PlotData>[] = []
+  const feasiblePlotData: Partial<plotly.PlotData>[] = []
+  const bestValuePlotData: Partial<plotly.PlotData>[] = []
   const infeasiblePlotData: Partial<plotly.PlotData>[] = []
   const unselectedPlotData: Partial<plotly.PlotData>[] = []
   for (const h of historyPlotInfos) {
@@ -363,7 +365,7 @@ const plotHistory = (
       infeasibleTrials.length === 0
         ? "%{text}<extra>Trial</extra>"
         : "%{text}<extra>Feasible Trial</extra>"
-    plotData.push({
+    feasiblePlotData.push({
       x: feasibleTrials.map(getAxisX),
       y: feasibleTrials.map(
         (t: Optuna.Trial): number => target.getTargetValue(t) as number
@@ -424,7 +426,7 @@ const plotHistory = (
         xForLinePlot.push(getAxisX(h.trials[h.trials.length - 1]))
         yForLinePlot.push(yForLinePlot[yForLinePlot.length - 1])
       }
-      plotData.push({
+      bestValuePlotData.push({
         x: xForLinePlot,
         y: yForLinePlot,
         name: `Best Value of ${h.study_name}`,
@@ -470,7 +472,10 @@ const plotHistory = (
       showlegend: false,
     })
   }
-  plotData.push(...infeasiblePlotData)
+
   plotData.push(...unselectedPlotData)
+  plotData.push(...infeasiblePlotData)
+  plotData.push(...feasiblePlotData)
+  plotData.push(...bestValuePlotData)
   return plotly.react(plotDomId, plotData, layout)
 }

--- a/tslib/react/src/components/PlotSlice.tsx
+++ b/tslib/react/src/components/PlotSlice.tsx
@@ -245,6 +245,17 @@ const plotSlice = (
   const trace: plotly.Data[] = [
     {
       type: "scatter",
+      x: infeasibleValues,
+      y: infeasibleObjectiveValues,
+      mode: "markers",
+      name: "Infeasible Trial",
+      marker: {
+        color: "#cccccc",
+        reversescale: true,
+      },
+    },
+    {
+      type: "scatter",
       x: feasibleValues,
       y: feasibleObjectiveValues,
       mode: "markers",
@@ -260,17 +271,6 @@ const plotSlice = (
           color: "Grey",
           width: 0.5,
         },
-      },
-    },
-    {
-      type: "scatter",
-      x: infeasibleValues,
-      y: infeasibleObjectiveValues,
-      mode: "markers",
-      name: "Infeasible Trial",
-      marker: {
-        color: "#cccccc",
-        reversescale: true,
       },
     },
   ]


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [X] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

Scatter plots became difficult to read when the number of data points was large.
This occurred because the graph was rendered in the order data was added for plotting.
In the previous implementation, data was registered in the following sequence:

1. feasible trial
2. infeasible trial

As a result, infeasible solutions were plotted above feasible solutions.
By reorganizing the data registration order, I improve the visibility of the desired feasible solutions in the plot.
This PR reorders the trials in the following sequence:
1. unselected trial (for trials selection)
2. infeasible trial
3. feasible trial
4. best trial (for history)

||previos|this pr|
|---|---|---|
|history|<img width="738" height="440" alt="Screenshot 2025-07-10 at 20 32 15" src="https://github.com/user-attachments/assets/a49b58c4-1527-4580-82ce-6ab08e04a45e" />|<img width="834" height="344" alt="Screenshot 2025-07-10 at 20 33 38" src="https://github.com/user-attachments/assets/a306179c-dbc6-4471-baf1-1beb12b0090d" />|
|pareto front|<img width="540" height="466" alt="Screenshot 2025-07-10 at 20 33 05" src="https://github.com/user-attachments/assets/73c324d3-b953-42de-ae6e-3ce1f5dcd0c0" />|<img width="669" height="365" alt="Screenshot 2025-07-10 at 20 25 04" src="https://github.com/user-attachments/assets/3b2bb875-c1ac-4e46-8d9a-ddeea745a848" />|
|slice|<img width="714" height="464" alt="Screenshot 2025-07-10 at 20 31 19" src="https://github.com/user-attachments/assets/7e929fe0-0ee2-42d6-9d16-984e0d5c0c1a" />|<img width="831" height="351" alt="Screenshot 2025-07-10 at 20 30 32" src="https://github.com/user-attachments/assets/3d1b5b8d-2f07-4d8d-9150-a6ff0b8c4842" />|
|rank|<img width="717" height="458" alt="Screenshot 2025-07-10 at 20 31 41" src="https://github.com/user-attachments/assets/0de6b39c-1716-4fdb-9f61-cbc7f262eae2" />|<img width="804" height="358" alt="Screenshot 2025-07-10 at 20 30 52" src="https://github.com/user-attachments/assets/9f1446c2-b525-417f-83d0-34fdf0e44660" />|

Regarding history plots, however, colors were automatically assigned based on drawing order. In this PR, the drawing order has changed, causing color changes.
While I could directly specify colors in the code, using different colors for each color scheme would make hardcoding them undesirable, so I left it as is.
For continuity with previous implementations, I could consider keeping the drawing order unchanged, but please provide feedback on this point.
