### PR TITLE
Add `useEvalTrialFilter` in `@optuna/react` package.

### DIFF
--- a/tslib/react/src/hooks/useEvalTrialFilter.tsx
+++ b/tslib/react/src/hooks/useEvalTrialFilter.tsx
@@ -1,0 +1,107 @@
+import { Trial } from "@optuna/types"
+import { ReactNode, useCallback, useEffect, useRef } from "react"
+
+type MessageRequest = {
+  type: "filter"
+  trials: Trial[]
+  filterFuncStr: string
+}
+
+type MessageResponse = {
+  type: "result"
+  filteredTrials: Trial[]
+  error?: Error
+}
+
+export const useEvalTrialFilter = (): [
+  (trials: Trial[], filterFuncStr: string) => Promise<Trial[]>,
+  () => ReactNode,
+] => {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null)
+  const pendingPromiseRef = useRef<{
+    resolve: (value: Trial[]) => void
+    reject: (reason?: Error) => void
+  } | null>(null)
+
+  const filterFunc = useCallback(
+    (trials: Trial[], filterFuncStr: string): Promise<Trial[]> => {
+      return new Promise((resolve, reject) => {
+        // TODO(c-bata): Support concurrent evaluations
+        if (!iframeRef.current || !iframeRef.current.contentWindow) {
+          return reject(new Error("Sandbox iframe is not ready"))
+        }
+
+        if (pendingPromiseRef.current) {
+          reject(new Error("Previous evaluation still running"))
+        }
+
+        pendingPromiseRef.current = { resolve, reject }
+
+        const message: MessageRequest = {
+          type: "filter",
+          trials,
+          filterFuncStr,
+        }
+
+        iframeRef.current.contentWindow.postMessage(message, "*")
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      const { data } = event
+
+      if (typeof data !== "object" || data.type !== "result") return
+
+      const response = data as MessageResponse
+
+      if (pendingPromiseRef.current) {
+        if (response.error) {
+          pendingPromiseRef.current.reject(response.error)
+        } else {
+          pendingPromiseRef.current.resolve(response.filteredTrials)
+        }
+        pendingPromiseRef.current = null
+      }
+    }
+
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
+  }, [])
+
+  const renderIframeSandbox = () => {
+    const iframeSrcDoc = `
+        <script>
+          window.fetch = () => { throw new Error("Unexpected") }
+          window.XMLHttpRequest = () => { throw new Error("Unexpected") }
+          window.addEventListener('message', (event) => {
+            const { data } = event;
+            if (typeof data !== 'object' || data.type !== 'filter') return;
+  
+            const { trials, filterFuncStr } = data;
+            try {
+              const filterFunc = eval('(' + filterFuncStr + ')');
+              const result = trials.filter(filterFunc);
+              parent.postMessage({ type: 'result', filteredTrials: result }, '*');
+            } catch (e) {
+              parent.postMessage({ type: 'result', filteredTrials: [], error: String(e) }, '*');
+            }
+          });
+        </script>
+      `
+
+    return (
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts"
+        style={{ display: "none" }}
+        srcDoc={iframeSrcDoc}
+        title="JavaScript function evaluation sandbox"
+      />
+    )
+  }
+
+  return [filterFunc, renderIframeSandbox]
+}

--- a/tslib/react/src/index.ts
+++ b/tslib/react/src/index.ts
@@ -14,6 +14,7 @@ export { PlotParallelCoordinate } from "./components/PlotParallelCoordinate"
 export { TrialTable } from "./components/TrialTable"
 export { GraphContainer } from "./components/GraphContainer"
 export { useGraphComponentState } from "./hooks/useGraphComponentState"
+export { useEvalTrialFilter } from "./hooks/useEvalTrialFilter"
 export {
   Target,
   useFilteredTrials,

--- a/tslib/react/test/useEvalTrialFilter.test.tsx
+++ b/tslib/react/test/useEvalTrialFilter.test.tsx
@@ -1,0 +1,213 @@
+import * as Optuna from "@optuna/types"
+import { render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+import { useEvalTrialFilter } from "../src/hooks/useEvalTrialFilter"
+
+describe("useEvalTrialFilter Tests", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const distribution: Optuna.FloatDistribution = {
+    type: "FloatDistribution",
+    low: 0,
+    high: 10,
+    step: null,
+    log: false,
+  }
+  const mockTrials: Optuna.Trial[] = [
+    {
+      trial_id: 1,
+      study_id: 1,
+      number: 0,
+      state: "Complete",
+      values: [0.1],
+      params: [
+        {
+          name: "x",
+          param_internal_value: 0.1,
+          param_external_type: "float",
+          param_external_value: "0.1",
+          distribution,
+        },
+      ],
+      intermediate_values: [],
+      user_attrs: [],
+      datetime_start: new Date("2023-01-01T00:00:00Z"),
+      datetime_complete: new Date("2023-01-01T00:01:00Z"),
+      constraints: [],
+    },
+    {
+      trial_id: 2,
+      study_id: 1,
+      number: 1,
+      state: "Complete",
+      values: [0.5],
+      params: [
+        {
+          name: "x",
+          param_internal_value: 0.1,
+          param_external_type: "float",
+          param_external_value: "0.1",
+          distribution,
+        },
+      ],
+      intermediate_values: [],
+      user_attrs: [],
+      datetime_start: new Date("2023-01-01T00:00:00Z"),
+      datetime_complete: new Date("2023-01-01T00:01:00Z"),
+      constraints: [],
+    },
+    {
+      trial_id: 3,
+      study_id: 1,
+      number: 2,
+      state: "Complete",
+      values: [0.9],
+      params: [
+        {
+          name: "x",
+          param_internal_value: 0.1,
+          param_external_type: "float",
+          param_external_value: "0.1",
+          distribution,
+        },
+      ],
+      intermediate_values: [],
+      user_attrs: [],
+      datetime_start: new Date("2023-01-01T00:00:00Z"),
+      datetime_complete: new Date("2023-01-01T00:01:00Z"),
+      constraints: [],
+    },
+  ]
+
+  test("renders iframe sandbox with correct attributes", () => {
+    const TestWrapper = () => {
+      const [, renderIframe] = useEvalTrialFilter()
+      return <div>{renderIframe()}</div>
+    }
+
+    render(<TestWrapper />)
+
+    const iframe = document.querySelector("iframe")
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute("sandbox", "allow-scripts")
+    expect(iframe).toHaveStyle("display: none")
+    expect(iframe).toHaveAttribute("srcdoc")
+  })
+
+  test("filtering works with valid JavaScript function", async () => {
+    let filterFunc: ((
+      trials: Optuna.Trial[],
+      filterFuncStr: string
+    ) => Promise<Optuna.Trial[]>) | null = null
+
+    const TestWrapper = () => {
+      const [filter, renderIframe] = useEvalTrialFilter()
+      filterFunc = filter
+      return <div>{renderIframe()}</div>
+    }
+    render(<TestWrapper />)
+
+    // Wait for iframe to be ready
+    await waitFor(() => {
+      expect(document.querySelector("iframe")).toBeInTheDocument()
+    })
+    expect(filterFunc).not.toBeNull()
+
+    // Call the filter function
+    const resultPromise = filterFunc!(
+      mockTrials,
+      "(trial) => trial.values[0] > 0.3"
+    )
+
+    // Simulate iframe response
+    const messageEvent = new MessageEvent("message", {
+      data: {
+        type: "result",
+        filteredTrials: mockTrials.filter((t) => t.values !== undefined && t.values[0] > 0.3),
+      },
+    })
+
+    window.dispatchEvent(messageEvent)
+
+    const result = await resultPromise
+    expect(result).toHaveLength(2)
+    expect(result[0].trial_id).toBe(2)
+    expect(result[1].trial_id).toBe(3)
+  })
+
+  test("handles JavaScript execution errors", async () => {
+    let filterFunc: ((
+      trials: Optuna.Trial[],
+      filterFuncStr: string
+    ) => Promise<Optuna.Trial[]>) | null = null
+
+    const TestWrapper = () => {
+      const [filter, renderIframe] = useEvalTrialFilter()
+      filterFunc = filter
+      return <div>{renderIframe()}</div>
+    }
+    render(<TestWrapper />)
+
+    // Wait for iframe to be ready
+    await waitFor(() => {
+      expect(document.querySelector("iframe")).toBeInTheDocument()
+    })
+    expect(filterFunc).not.toBeNull()
+
+    // Call the filter function
+    const resultPromise = filterFunc!(mockTrials, "invalid javascript")
+
+    // Simulate iframe error response
+    const messageEvent = new MessageEvent("message", {
+      data: {
+        type: "result",
+        filteredTrials: [],
+        error: "SyntaxError: Unexpected token",
+      },
+    })
+    window.dispatchEvent(messageEvent)
+    await expect(resultPromise).rejects.toBe("SyntaxError: Unexpected token")
+  })
+
+  test("rejects when iframe is not ready", async () => {
+    let filterFunc: ((
+      trials: Optuna.Trial[],
+      filterFuncStr: string
+    ) => Promise<Optuna.Trial[]>) | null = null
+
+    const TestWrapper = () => {
+      const [filter] = useEvalTrialFilter()
+      filterFunc = filter
+      return <div>No iframe</div>
+    }
+    render(<TestWrapper />)
+    expect(filterFunc).not.toBeNull()
+
+    const resultPromise = filterFunc!(mockTrials, "(trial) => true")
+    await expect(resultPromise).rejects.toThrow("Sandbox iframe is not ready")
+  })
+
+  test("cleans up event listener on unmount", () => {
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener")
+
+    const TestWrapper = () => {
+      const [, renderIframe] = useEvalTrialFilter()
+      return <div>{renderIframe()}</div>
+    }
+
+    const { unmount } = render(<TestWrapper />)
+
+    unmount()
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith(
+      "message",
+      expect.any(Function)
+    )
+  })
+})


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Refs #1105 

## What does this implement/fix? Explain your changes.
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
This PR adds `useEvalTrialFilter` for calling `eval()` function in an isolated environment using `<iframe></iframe>` tag. Usage is like below:

https://github.com/optuna/optuna-dashboard/commit/87e0e2e974788cbfa1062d34b49aa151350e0d73

<img width="1892" height="814" alt="Screenshot 2025-07-16 17 52 18" src="https://github.com/user-attachments/assets/8759d064-3163-4c79-92fb-870e245d05b6" />
