### PR TITLE
Migrate from wasm-pack to custom WASM build process

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,8 +12,8 @@ RUN npm install -g vsce
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-# Install wasm-pack and wasm-opt
-RUN curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+# Install wasm-bindgen-cli and wasm-opt
+RUN cargo install -f wasm-bindgen-cli
 RUN wget https://github.com/WebAssembly/binaryen/releases/download/version_113/binaryen-version_113-x86_64-linux.tar.gz && \
     tar -zxvf binaryen-version_113-x86_64-linux.tar.gz && \
     mv binaryen-version_113/ /root/.binaryen && \

--- a/.github/workflows/e2e-standalone-tests.yml
+++ b/.github/workflows/e2e-standalone-tests.yml
@@ -23,9 +23,13 @@ jobs:
 
       - name: Install Rust toolchains
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Install wasm-bindgen and wasm-opt
+        run: |
+          cargo install wasm-bindgen-cli
+          cargo install wasm-opt
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -43,7 +47,7 @@ jobs:
 
       - name: Build rustlib
         working-directory: rustlib
-        run: wasm-pack build --target web
+        run: ./build.sh
 
       - name: Build tslib
         run: make tslib

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,15 +22,19 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust toolchains
         uses: dtolnay/rust-toolchain@stable
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-bindgen and wasm-opt
+        run: |
+          cargo install wasm-bindgen-cli
+          cargo install wasm-opt
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
       - name: Build rustlib
         working-directory: rustlib
-        run: wasm-pack build --target web
+        run: ./build.sh
       - name: Build tslib
         run: make tslib
       - name: Build standalone_app

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -53,6 +53,16 @@ jobs:
         with:
           node-version: '20'
       
+      - name: Install Rust toolchains
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen and wasm-opt
+        run: |
+          cargo install wasm-bindgen-cli
+          cargo install wasm-opt
+      
       - name: Setup tslib
         run: make tslib
       
@@ -64,9 +74,7 @@ jobs:
 
       - name: Build rustlib for standalone_app
         working-directory: rustlib
-        run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-          wasm-pack build --target web
+        run: ./build.sh
 
       - name: Type Check standalone_app
         working-directory: standalone_app
@@ -114,11 +122,19 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install Rust toolchains
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-bindgen and wasm-opt
+        run: |
+          cargo install wasm-bindgen-cli
+          cargo install wasm-opt
+
       - name: Build rustlib for standalone_app
         working-directory: rustlib
-        run: |
-          curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-          wasm-pack build --target web
+        run: ./build.sh
 
       - name: Setup tslib
         run: make tslib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,8 +163,7 @@ The release process(compiling TypeScript files, packaging Python distributions a
 Please install [wasm-bindgen-cli](https://rustwasm.github.io/wasm-bindgen/reference/cli.html) and [wasm-opt](https://docs.rs/wasm-opt/latest/wasm_opt/), and then execute the following command.
 
 ```
-$ cargo install -f wasm-bindgen-cli
-$ cargo install wasm-opt
+$ cargo install wasm-bindgen-cli wasm-opt
 $ make serve-browser-app
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,9 +160,11 @@ The release process(compiling TypeScript files, packaging Python distributions a
 
 ## Standalone Single-page Application
 
-Please install [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) and execute the following command.
+Please install [wasm-bindgen-cli](https://rustwasm.github.io/wasm-bindgen/reference/cli.html) and [wasm-opt](https://docs.rs/wasm-opt/latest/wasm_opt/), and then execute the following command.
 
 ```
+$ cargo install -f wasm-bindgen-cli
+$ cargo install wasm-opt
 $ make serve-browser-app
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ RUSTLIB_OUT = rustlib/pkg/optuna_wasm.js rustlib/pkg/optuna_wasm_bg.wasm rustlib
 STANDALONE_SRC := $(shell find ./standalone_app/src -name '*.ts' -o -name '*.tsx')
 
 $(RUSTLIB_OUT): rustlib/src/*.rs rustlib/Cargo.toml
-	cd rustlib && wasm-pack build --target web
+	rustlib/build.sh
 
 vscode/assets/bundle.js: $(RUSTLIB_OUT) $(STANDALONE_SRC) tslib
 	cd standalone_app && npm install && npm run build:vscode

--- a/rustlib/build.sh
+++ b/rustlib/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+DIR=$(cd $(dirname $0); pwd)
+OUTPUT_DIR=${DIR}/pkg
+
+set -ex
+
+pushd ${DIR}
+cargo build --target wasm32-unknown-unknown --release
+wasm-bindgen ./target/wasm32-unknown-unknown/release/optuna_wasm.wasm --out-dir ${OUTPUT_DIR} --target web
+wasm-opt -Oz -o pkg/optuna_wasm_bg.wasm pkg/optuna_wasm_bg.wasm
+cat << 'EOF' > pkg/package.json
+{
+  "name": "optuna-wasm",
+  "version": "0.1.0",
+  "files": [
+    "optuna_wasm_bg.wasm",
+    "optuna_wasm.js",
+    "optuna_wasm.d.ts"
+  ],
+  "module": "optuna_wasm.js",
+  "types": "optuna_wasm.d.ts"
+}
+EOF
+popd


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

`wasm-pack` is no longer maintained, so I've created a custom `./rustlib/build.sh` script that uses `cargo build`, `wasm-bindgen`, and `wasm-opt` directly.

- Remove `wasm-pack` installation steps from all workflows
- Add `wasm-bindgen-cli` and `wasm-opt` installation
- Replace `wasm-pack build --target web` with `./build.sh`
