### PR TITLE
Add comments explaining network access restrictions in iframe sandbox

### DIFF
--- a/tslib/react/src/hooks/useEvalTrialFilter.tsx
+++ b/tslib/react/src/hooks/useEvalTrialFilter.tsx
@@ -79,8 +79,10 @@ export const useEvalTrialFilter = <T extends Trial>(): [
   const renderIframeSandbox = () => {
     const iframeSrcDoc = `
         <script>
+          // Disable network access in the iframe for security reasons
           window.fetch = () => { throw new Error("Unexpected") }
           window.XMLHttpRequest = () => { throw new Error("Unexpected") }
+
           window.addEventListener('message', (event) => {
             const { data } = event;
             if (typeof data !== 'object' || data.type !== 'filter') return;


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #1106

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
This PR adds explanatory comments to clarify that `window.fetch` and `window.XMLHttpRequest` are disabled in the iframe as a security mitigation.