### PR TITLE
Remove the default implementation of set_objective_names

### DIFF
--- a/optuna_dashboard/_named_objectives.py
+++ b/optuna_dashboard/_named_objectives.py
@@ -28,23 +28,13 @@ def set_objective_names(study: optuna.Study, names: list[str]) -> None:
           set_objective_names(study, ["val_loss", "flops"])
     """
 
-    if hasattr(study, "set_metric_names"):
-        warnings.warn(
-            "`set_objective_names()` function is deprecated."
-            " Please use `study.set_metric_names()` instead."
-            " See https://optuna-dashboard.readthedocs.io/en/latest/errors.html for details.",
-            category=FutureWarning,
-        )
-        study.set_metric_names(names)
-        return
-
-    storage = study._storage
-    study_id = study._study_id
-
-    directions = storage.get_study_directions(study_id)
-    if len(directions) != len(names):
-        raise ValueError("names must be the same length with the number of objectives.")
-    storage.set_study_system_attr(study_id, SYSTEM_ATTR_NAME, names)
+    warnings.warn(
+        "`set_objective_names()` function is deprecated."
+        " Please use `study.set_metric_names()` instead."
+        " See https://optuna-dashboard.readthedocs.io/en/latest/errors.html for details.",
+        category=FutureWarning,
+    )
+    study.set_metric_names(names)
 
 
 def get_objective_names(system_attrs: dict[str, Any]) -> Optional[list[str]]:


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
`study.set_metric_names()` is added at Optuna 3.2, which we already dropped the support for.

* https://github.com/optuna/optuna-dashboard/blob/e073a30c0f66b2f194e96888bb8d892fa64c81cb/pyproject.toml#L31
* https://optuna.readthedocs.io/en/latest/reference/generated/optuna.study.Study.html#optuna.study.Study.set_metric_names