### PR TITLE
Avoid repeated error popups by LLM-powered trial filter

### DIFF
--- a/optuna_dashboard/ts/hooks/useTrialFilterQuery.ts
+++ b/optuna_dashboard/ts/hooks/useTrialFilterQuery.ts
@@ -88,7 +88,7 @@ export const useTrialFilterQuery = (
             const newFailedCache = new Set(failedCache)
             newFailedCache.add(userQuery)
             setFailedCache(newFailedCache)
-            
+
             enqueueSnackbar(
               `Failed to evaluate trial filtering function after ${nRetry} attempts (error=${errMsg})`,
               { variant: "error" }
@@ -104,7 +104,16 @@ export const useTrialFilterQuery = (
       }
       throw new Error("Must not reach here.")
     },
-    [apiClient, enqueueSnackbar, filterByJSFuncStr, nRetry, cache, setCache, failedCache, setFailedCache]
+    [
+      apiClient,
+      enqueueSnackbar,
+      filterByJSFuncStr,
+      nRetry,
+      cache,
+      setCache,
+      failedCache,
+      setFailedCache,
+    ]
   )
   return [filterByUserQuery, renderIframe]
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #1120

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

As pointed out in https://github.com/optuna/optuna-dashboard/pull/1120#discussion_r2239292524, LLM-powered trial filter is executed every time the component re-renderes. As a result, if LLM keeps returning broken JavaScript functions, error popups will continues to appear.