### PR TITLE
Add trial filter to `TrialList`

### DIFF
--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -99,7 +99,7 @@ const useTrials = (
   const [filteredTrials, setFilteredTrials] = useState<Trial[]>([])
   useEffect(() => {
     let result = studyDetail !== null ? studyDetail.trials : []
-    if (excludedStates.length === 0) {
+    if (excludedStates.length !== 0) {
       excludedStates.forEach((s) => {
         result = result.filter((t) => t.state !== s)
       })


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
A part of #1105 and a subsequent PR for #1120.

## What does this implement/fix? Explain your changes.

This PR implements a trial filter functionality in `TrialList`.
- Added a Search Icon button to the left of the existing filter button
- Clicking the Search Icon button will display a popover containing a text field and an Apply button
- Enter a query, then click Apply to filter the trials in TrialList

<img width="627" height="390" alt="image" src="https://github.com/user-attachments/assets/fc585789-3681-45f3-a748-09897ab77d3b" />

You can use [this script](https://gist.github.com/toshihikoyanase/4b1c7d95036a6b2fb380a490da08a347) to check the functionality. Please input filtering functions in JavaScript as queries such as `(t) => t.number < 2`.

Discussion:
- The search icon follows the design in #1105 Screenshot, but it functions as part of the filtering process. 
- It also needs to be clearly distinguished from the other filter functionality (i.e., selecting predefined category values).
- Consider adding a Clear button to allow users to reset the query and display all trials. While clearing the query can be achieved by leaving the text field empty and clicking Apply, this functionality was omitted in this PR.

