### PR TITLE
Exclude ts/types/pkg dirs from jupyterlab-optuna's wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ jupyterlab-extension: tslib
 	cd optuna_dashboard && npm install && npm run build:pkg
 	rm -rf jupyterlab/jupyterlab_optuna/vendor/
 	mkdir -p jupyterlab/jupyterlab_optuna/vendor/
-	rsync -a --exclude=node_modules optuna_dashboard/ jupyterlab/jupyterlab_optuna/vendor/optuna_dashboard/
+	rsync -a --exclude=node_modules --exclude=pkg --exclude=ts --exclude=types --exclude=public optuna_dashboard/ jupyterlab/jupyterlab_optuna/vendor/optuna_dashboard/
 	cd jupyterlab && uv run jlpm install && uv run jlpm run build && uv run python -m build --wheel
 
 .PHONY: python-package


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Exclude ts/types/pkg dirs from jupyterlab-optuna's wheel to reduce the wheel size.