### PR TITLE
[hotfix] Fix JupyterLab extension CI build failure by adding skipLibCheck

### DIFF
--- a/.github/workflows/jupyterlab-tests.yml
+++ b/.github/workflows/jupyterlab-tests.yml
@@ -17,6 +17,7 @@ on:
       - 'jupyterlab/pyproject.toml'
       - 'jupyterlab/package.json'
       - 'jupyterlab/yarn.lock'
+      - 'jupyterlab/tsconfig.json'
 jobs:
   test-build:
     name: Test build for JupyterLab extension

--- a/jupyterlab/tsconfig.json
+++ b/jupyterlab/tsconfig.json
@@ -19,6 +19,7 @@
       "plotly.js-dist-min": ["node_modules/@types/plotly.js"]
     },
     "rootDir": "src",
+    "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
     "target": "ES2018"


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
To resolve https://github.com/optuna/optuna-dashboard/actions/runs/17229971571/job/48881727130
