### PR TITLE
Sync `wasm-bindgen-cli` version with `Cargo.lock`

### DIFF
--- a/.github/workflows/e2e-standalone-tests.yml
+++ b/.github/workflows/e2e-standalone-tests.yml
@@ -26,11 +26,6 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen and wasm-opt
-        run: |
-          cargo install wasm-bindgen-cli
-          cargo install wasm-opt
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -45,9 +40,13 @@ jobs:
         run: |
           uv sync --group test
 
-      - name: Build rustlib
+      - name: Build rustlib for standalone_app
         working-directory: rustlib
-        run: ./build.sh
+        run: |
+          WASM_BINDGEN_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "wasm-bindgen") | .version')
+          cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+          cargo install wasm-opt
+          ./build.sh
 
       - name: Build tslib
         run: make tslib

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,17 +24,17 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Install wasm-bindgen and wasm-opt
-        run: |
-          cargo install wasm-bindgen-cli
-          cargo install wasm-opt
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-      - name: Build rustlib
+      - name: Build rustlib for standalone_app
         working-directory: rustlib
-        run: ./build.sh
+        run: |
+          WASM_BINDGEN_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "wasm-bindgen") | .version')
+          cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+          cargo install wasm-opt
+          ./build.sh
       - name: Build tslib
         run: make tslib
       - name: Build standalone_app

--- a/.github/workflows/typescript-tests.yml
+++ b/.github/workflows/typescript-tests.yml
@@ -127,14 +127,13 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Install wasm-bindgen and wasm-opt
-        run: |
-          cargo install wasm-bindgen-cli
-          cargo install wasm-opt
-
       - name: Build rustlib for standalone_app
         working-directory: rustlib
-        run: ./build.sh
+        run: |
+          WASM_BINDGEN_VERSION=$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "wasm-bindgen") | .version')
+          cargo install wasm-bindgen-cli --version $WASM_BINDGEN_VERSION
+          cargo install wasm-opt
+          ./build.sh
 
       - name: Setup tslib
         run: make tslib


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up #1152 and #1165.

## What does this implement/fix? Explain your changes.

Prevents version mismatches that cause CI failures by ensuring CLI and library versions are synchronized.
https://github.com/drager/wasm-pack/blob/cd1718aa7babb656796b8aae3c177ddacce28028/src/lockfile.rs#L37-L66
