### PR TITLE
Remove packaging from `install_requires`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ classifiers = [
 dependencies = [
     "bottle>=0.13.0",
     "optuna>=3.6.0",
-    "packaging",
     "tomli; python_version<'3.11'",
 ]
 dynamic = ["version"]
@@ -125,6 +124,7 @@ test = [
     "boto3",
     "coverage",
     "openai",
+    "packaging",
     "plotly",
     "pytest",
     "respx",


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
According to the output of `git grep packaging`, this library is not referenced except for `python_tests/` now.