### PR TITLE
Add filter for `Best Trial` on `TrialList.tsx`

### DIFF
--- a/optuna_dashboard/ts/components/TrialList.tsx
+++ b/optuna_dashboard/ts/components/TrialList.tsx
@@ -15,6 +15,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material"
+import Checkbox from "@mui/material/Checkbox"
 import Chip from "@mui/material/Chip"
 import Divider from "@mui/material/Divider"
 import List from "@mui/material/List"
@@ -22,7 +23,6 @@ import ListItem from "@mui/material/ListItem"
 import ListItemButton from "@mui/material/ListItemButton"
 import ListItemText from "@mui/material/ListItemText"
 import ListSubheader from "@mui/material/ListSubheader"
-import Checkbox from "@mui/material/Checkbox"
 import * as Optuna from "@optuna/types"
 import React, { FC, ReactNode, useMemo, useState, useEffect } from "react"
 
@@ -622,7 +622,9 @@ export const TrialList: FC<{ studyDetail: StudyDetail | null }> = ({
                       disableRipple
                     />
                   </ListItemIcon>
-                    <ListItemText primary={`Best Trial (${visibleBestTrialCount})`} />
+                  <ListItemText
+                    primary={`Best Trial (${visibleBestTrialCount})`}
+                  />
                 </MenuItem>
               </Menu>
             </ListSubheader>


### PR DESCRIPTION
## Contributor License Agreement
* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #654.

## What does this implement/fix? Explain your changes.
This PR adds a new **“Best Trial” filter** to the Trials List page. The goal is to make it easier to quickly view only the best trials.

- **New Best Trial filter** in the filter menu.
- **Displays the number of best trials** (after applying the current filters).
- **URL persistence** using `?best=true`.
- **Navigation preservation**: switching between trials keeps the filter state intact.
- **UI integration**: Best Trial chips remain consistent across the list and detail panels.
- **Enabled/disabled behavior**: the Best Trial filter is disabled only if the study has zero best trials, not based on current filters.

### 📸 Screenshots/ Recording
Before:
<img width="377" height="328" alt="image" src="https://github.com/user-attachments/assets/316bf8df-1038-446c-b964-614b627a3642" />

After:
https://github.com/user-attachments/assets/e203c02e-8b06-4036-ae03-a0e3119a4420