### PR TITLE
Replace bash-specific pushd/popd with POSIX cd in devcontainer script

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -3,6 +3,6 @@
 uv sync --all-extras --group test --group lint
 
 make tslib
-pushd optuna_dashboard
+cd optuna_dashboard
 npm install
-popd
+cd ..


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

None

## What does this implement/fix? Explain your changes.

This PR fixes a failure in the Dev Container setup script caused by the use of `pushd` and `popd` commands in a script running under `#!/bin/sh`.

**The Problem:**
The `.devcontainer/postCreateCommand.sh` script uses `pushd` and `popd`, which are Bash extensions and not defined in the POSIX `sh` standard. This causes the script to fail on systems where `/bin/sh` is a strict POSIX shell (like `dash`), preventing the environment from building.

**The Fix:**
Replaced `pushd` and `popd` with standard `cd` commands. This allows the script to run successfully using the default `#!/bin/sh` interpreter without requiring a dependency on `bash`.
