### PR TITLE
Fix: Correctly sort numeric values in TrialTable (params and user_attrs)

### DIFF
--- a/tslib/react/src/components/TrialTable.tsx
+++ b/tslib/react/src/components/TrialTable.tsx
@@ -127,6 +127,24 @@ export const TrialTable: FC<{
             header: `Param ${s.name}`,
             enableSorting: sortable,
             sortUndefined: "last",
+            sortingFn: (rowA, rowB, columnId) => {
+              const valA = rowA.getValue(columnId) as string | null
+              const valB = rowB.getValue(columnId) as string | null
+              const numA = Number(valA)
+              const numB = Number(valB)
+
+              if (
+                valA !== null &&
+                valB !== null &&
+                !Number.isNaN(numA) &&
+                !Number.isNaN(numB)
+              ) {
+                return numA - numB
+              }
+              return (valA ?? "").localeCompare(valB ?? "", undefined, {
+                numeric: true,
+              })
+            },
             enableColumnFilter: filterChoices !== undefined,
             filterFn: multiValueFilter,
           }
@@ -150,6 +168,24 @@ export const TrialTable: FC<{
             header: `UserAttribute ${attr_spec.key}`,
             enableSorting: attr_spec.sortable,
             sortUndefined: "last",
+            sortingFn: (rowA, rowB, columnId) => {
+              const valA = rowA.getValue(columnId) as string | null
+              const valB = rowB.getValue(columnId) as string | null
+              const numA = Number(valA)
+              const numB = Number(valB)
+
+              if (
+                valA !== null &&
+                valB !== null &&
+                !Number.isNaN(numA) &&
+                !Number.isNaN(numB)
+              ) {
+                return numA - numB
+              }
+              return (valA ?? "").localeCompare(valB ?? "", undefined, {
+                numeric: true,
+              })
+            },
             enableColumnFilter: false,
           }
         )


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Fixes #1207  

## What does this implement/fix? Explain your changes.

Previously, the default sorting treated these values as strings/text. This caused negative numbers to appear in reverse order (e.g., `-1` appearing before `-2` in ascending sort), as they were sorted by character rather than numeric value.

I have added a `sortingFn` to the column definitions for both Params and User Attributes in `TrialTable.tsx`. This function safely converts values to numbers for comparison, ensuring that negative numbers, scientific notation, and mixed types sort in the expected numeric order.