### PR TITLE
add Docker image multiarch support

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -10,24 +10,28 @@ jobs:
       - uses: actions/checkout@v4
       - run: echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Enable buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker build/push (tag)
         if: github.event_name == 'release'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPO }}:${{ env.TAG }}
       - name: Docker build/push (latest)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPO }}:latest


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Fixes #1223 Build multiarch Docker image

## What does this implement/fix? Explain your changes.

Changed GitHub pipeline to build multiarch OCI images for `linux/amd64` and `linux/arm64`. Other platforms may easily be added.
 
- Added QEMU pipeline step
- Added Docker Buildx pipeline step
- Updated GitHub Actions docker/login-action, docker/build-push-action to correspond to Docker documentation
- added platforms

Used documentation:
- https://github.com/docker/build-push-action?tab=readme-ov-file#usage
- https://docs.docker.com/build/ci/github-actions/multi-platform/

Verified to run on MacBook Pro, Apple M1 Pro Silicon, Tahoe 26.3.1
