### PR TITLE
fix(storage): show human-readable error for uninitialized sqlite data…

### DIFF
--- a/optuna_dashboard/_storage_url.py
+++ b/optuna_dashboard/_storage_url.py
@@ -99,7 +99,12 @@ def get_rdb_storage(storage_url: str) -> RDBStorage:
         # instead of a raw SQLAlchemy traceback.
         err_msg = str(e).lower()
         cause_msg = str(e.__cause__).lower() if e.__cause__ else ""
-        if "no such table" in err_msg or "version_info" in err_msg or "no such table" in cause_msg or "version_info" in cause_msg:
+        if (
+            "no such table" in err_msg
+            or "version_info" in err_msg
+            or "no such table" in cause_msg
+            or "version_info" in cause_msg
+        ):
             print(
                 f"Error: The database at '{storage_url}' does not contain an Optuna schema.\n"
                 "Please run an Optuna study first to initialize the database:\n\n"

--- a/optuna_dashboard/_storage_url.py
+++ b/optuna_dashboard/_storage_url.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+import optuna
 import os.path
 from pathlib import Path
 import re
@@ -80,7 +82,35 @@ def guess_storage_from_url(storage_url: str) -> BaseStorage:
 
 
 def get_rdb_storage(storage_url: str) -> RDBStorage:
-    return RDBStorage(storage_url, skip_compatibility_check=True, skip_table_creation=True)
+    """Create an RDBStorage instance for the dashboard (read-only viewer).
+
+    Raises SystemExit with a clear message if the database schema has not been
+    initialized (i.e., no Optuna study has ever been run against this storage).
+    """
+    try:
+        return RDBStorage(
+            storage_url,
+            skip_compatibility_check=True,
+            skip_table_creation=True,
+        )
+    except optuna.exceptions.StorageInternalError as e:
+        # This typically happens when the database exists but has no Optuna schema
+        # (e.g., a brand-new empty SQLite file). Provide a human-readable error
+        # instead of a raw SQLAlchemy traceback.
+        err_msg = str(e).lower()
+        cause_msg = str(e.__cause__).lower() if e.__cause__ else ""
+        if "no such table" in err_msg or "version_info" in err_msg or "no such table" in cause_msg or "version_info" in cause_msg:
+            print(
+                f"Error: The database at '{storage_url}' does not contain an Optuna schema.\n"
+                "Please run an Optuna study first to initialize the database:\n\n"
+                "    import optuna\n"
+                "    study = optuna.create_study(storage='<your-storage-url>')\n"
+                "    study.optimize(objective, n_trials=1)\n\n"
+                "Then re-run optuna-dashboard.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        raise  # Re-raise unexpected StorageInternalError variants unchanged
 
 
 def get_journal_file_storage(file_path: str) -> JournalStorage:

--- a/python_tests/test_storage_url.py
+++ b/python_tests/test_storage_url.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import tempfile
+import os
+import pytest
 from unittest import TestCase
 import warnings
 
@@ -9,6 +11,7 @@ import optuna.storages
 from optuna.storages import JournalStorage
 from optuna.storages import RDBStorage
 from optuna_dashboard._storage_url import get_storage
+from optuna_dashboard._storage_url import get_rdb_storage
 import sqlalchemy.exc
 
 
@@ -65,3 +68,13 @@ class GetStorageTestCase(TestCase):
         with tempfile.NamedTemporaryFile() as file:
             with self.assertRaises(FileNotFoundError):
                 get_storage(f"sqlite:///{file.name}", storage_class="JournalFileStorage")
+
+    def test_get_rdb_storage_empty_db_exits_cleanly(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            empty_db_path = f.name
+        try:
+            with pytest.raises(SystemExit) as exc_info:
+                get_rdb_storage(f"sqlite:///{empty_db_path}")
+            assert exc_info.value.code == 1
+        finally:
+            os.unlink(empty_db_path)


### PR DESCRIPTION
### What problem does this fix?
This fixes Issue #469 where launching the dashboard against an entirely empty or uninitialized SQLite database crashes the application with a confusing `SQLAlchemy` backend traceback rather than providing guidance to the user.

### Root cause
When `RDBStorage` initializes with `skip_table_creation=True`, it throws an underlying `sqlite3.OperationalError: no such table` inside a generic wrapper exception because the Optuna schema does not exist yet.

### What the fix does
It cleanly intercepts `optuna.exceptions.StorageInternalError` during `get_rdb_storage()` initialization, specifically inspects the `__cause__` string for missing table warnings, and prints clear CLI instructions on how to initialize a database before exiting with code `1`.

### How I tested it
* Manually ran `optuna-dashboard sqlite:///empty_db.sqlite3` on a blank file and confirmed the new CLI instruction message appeared and exited immediately.
* Manually generated a valid study database via a Python script and verified the dashboard booted correctly without hitting the new error trap.
* Added a new `pytest` unit test simulating the empty-database crash and asserting the `SystemExit` code `1` behavior.
* Ran the entire `python_tests/` suite locally to ensure no other URL inference testing logic broke.

### Edge cases considered
* Inspected `e.__cause__` because the true missing table detail gets wrapped deeply inside the SDK's generic exception structure.
* Re-raised the unchanged `StorageInternalError` if it is triggered by an unrelated issue (e.g. data length violation) to avoid accidentally swallowing real bugs.
