### PR TITLE
Isolate JupyterLab extension React runtime

### DIFF
--- a/jupyterlab/package.json
+++ b/jupyterlab/package.json
@@ -59,6 +59,8 @@
         "@jupyterlab/coreutils": "^6.4.4",
         "@jupyterlab/launcher": "^4.4.4",
         "@jupyterlab/services": "^7.4.4",
+        "@lumino/messaging": "^2.0.4",
+        "@lumino/widgets": "^2.7.5",
         "@mui/icons-material": "^6.5.0",
         "@mui/material": "^6.5.0",
         "@mui/system": "^6.5.0",
@@ -118,6 +120,10 @@
             }
         },
         "extension": true,
+        "sharedPackages": {
+            "react": false,
+            "react-dom": false
+        },
         "webpackConfig": "./webpack.config.js",
         "outputDir": "jupyterlab_optuna/labextension"
     },

--- a/jupyterlab/src/widget.tsx
+++ b/jupyterlab/src/widget.tsx
@@ -1,14 +1,30 @@
-import { ReactWidget } from "@jupyterlab/ui-components"
+import { Message } from "@lumino/messaging"
+import { Widget } from "@lumino/widgets"
 import React from "react"
+import { createRoot, Root } from "react-dom/client"
 import { JupyterLabEntrypoint } from "./components/JupyterLabEntrypoint"
 
-export class OptunaDashboardWidget extends ReactWidget {
+export class OptunaDashboardWidget extends Widget {
+  private _root: Root | null = null
+
   constructor() {
     super()
     this.addClass("jp-react-widget")
   }
 
-  render(): React.ReactElement {
-    return <JupyterLabEntrypoint />
+  protected onAfterAttach(msg: Message): void {
+    super.onAfterAttach(msg)
+    if (this._root === null) {
+      this._root = createRoot(this.node)
+      this._root.render(<JupyterLabEntrypoint />)
+    }
+  }
+
+  dispose(): void {
+    if (this._root !== null) {
+      this._root.unmount()
+      this._root = null
+    }
+    super.dispose()
   }
 }

--- a/jupyterlab/src/widget.tsx
+++ b/jupyterlab/src/widget.tsx
@@ -1,7 +1,7 @@
 import { Message } from "@lumino/messaging"
 import { Widget } from "@lumino/widgets"
 import React from "react"
-import { createRoot, Root } from "react-dom/client"
+import { Root, createRoot } from "react-dom/client"
 import { JupyterLabEntrypoint } from "./components/JupyterLabEntrypoint"
 
 export class OptunaDashboardWidget extends Widget {

--- a/jupyterlab/webpack.config.js
+++ b/jupyterlab/webpack.config.js
@@ -1,4 +1,12 @@
+const path = require("path");
+
 module.exports = {
+    resolve: {
+        alias: {
+            react: path.resolve(__dirname, "node_modules/react"),
+            "react-dom": path.resolve(__dirname, "node_modules/react-dom"),
+        },
+    },
     ignoreWarnings: [
         (warning) =>
         typeof warning.message === "string" &&

--- a/jupyterlab/yarn.lock
+++ b/jupyterlab/yarn.lock
@@ -4008,6 +4008,8 @@ __metadata:
     "@jupyterlab/coreutils": ^6.4.4
     "@jupyterlab/launcher": ^4.4.4
     "@jupyterlab/services": ^7.4.4
+    "@lumino/messaging": ^2.0.4
+    "@lumino/widgets": ^2.7.5
     "@mui/icons-material": ^6.5.0
     "@mui/material": ^6.5.0
     "@mui/system": ^6.5.0


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up https://github.com/optuna/optuna-dashboard/pull/1295

## What does this implement/fix? Explain your changes.

This PR fixes the JupyterLab extension runtime error caused by mixing JupyterLab's React runtime with the extension's React runtime.

JupyterLab currently provides React 18 through its shared module scope, while optuna-dashboard has moved to React 19. The extension previously used `ReactWidget`, which made JupyterLab render React elements created by the extension. This caused React runtime mismatches when opening the dashboard inside JupyterLab.

This PR isolates the extension's React runtime by:

- replacing `ReactWidget` with a Lumino `Widget`
- mounting the Optuna Dashboard React tree with `createRoot`
- unmounting the React root on widget disposal
- excluding `react` and `react-dom` from JupyterLab shared packages
- aliasing `react` and `react-dom` to the extension-local packages so linked dashboard code uses the same React runtime

This keeps the JupyterLab shell integration on JupyterLab/Lumino APIs while rendering Optuna Dashboard with its own React runtime.
