### PR TITLE
Fix Docker build action

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ startsWith(github.event.release.tag_name, 'v') && !startsWith(github.event.release.tag_name, 'jupyterlab-v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,28 @@
 FROM node:22 AS front-builder
 
-# pnpm prompts "recreate node_modules?" before wiping the dir. Docker build
-# has no TTY, so the prompt aborts with ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY;
-# CI=true tells pnpm to skip the prompt and proceed.
+# Keep pnpm non-interactive during Docker builds.
 ENV CI=true
 RUN corepack enable
 
-WORKDIR /usr/src/tslib/types
-ADD ./tslib/types/ /usr/src/tslib/types/
-RUN pnpm install --frozen-lockfile && pnpm run build
-
-WORKDIR /usr/src/tslib/storage
-ADD ./tslib/storage/ /usr/src/tslib/storage/
-RUN pnpm install --frozen-lockfile && pnpm run build
-
-WORKDIR /usr/src/tslib/react
-ADD ./tslib/react/ /usr/src/tslib/react/
-RUN pnpm install --frozen-lockfile && pnpm run build
-
 WORKDIR /usr/src/optuna_dashboard
-ADD ./optuna_dashboard /usr/src/optuna_dashboard
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /usr/src/optuna_dashboard/
+COPY optuna_dashboard/package.json /usr/src/optuna_dashboard/optuna_dashboard/package.json
+COPY standalone_app/package.json /usr/src/optuna_dashboard/standalone_app/package.json
+COPY vscode/package.json /usr/src/optuna_dashboard/vscode/package.json
+COPY tslib/types/package.json /usr/src/optuna_dashboard/tslib/types/package.json
+COPY tslib/storage/package.json /usr/src/optuna_dashboard/tslib/storage/package.json
+COPY tslib/react/package.json /usr/src/optuna_dashboard/tslib/react/package.json
 RUN pnpm install --frozen-lockfile
-RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm run build:prd
+
+COPY ./tslib/types/ /usr/src/optuna_dashboard/tslib/types/
+COPY ./tslib/storage/ /usr/src/optuna_dashboard/tslib/storage/
+COPY ./tslib/react/ /usr/src/optuna_dashboard/tslib/react/
+COPY ./optuna_dashboard /usr/src/optuna_dashboard/optuna_dashboard
+RUN pnpm --filter @optuna/types run build
+RUN pnpm --filter @optuna/storage run build
+RUN pnpm --filter @optuna/react run build
+RUN pnpm --filter @optuna/optuna-dashboard run build:pkg
+RUN NODE_OPTIONS="--max-old-space-size=4096" pnpm --filter @optuna/optuna-dashboard run build:prd
 
 FROM python:3.12-bookworm AS python-builder
 
@@ -31,7 +32,7 @@ RUN pip install --progress-bar off PyMySQL[rsa] psycopg2-binary gunicorn
 
 ADD ./pyproject.toml /usr/src/pyproject.toml
 ADD ./optuna_dashboard /usr/src/optuna_dashboard
-COPY --from=front-builder /usr/src/optuna_dashboard/public/ /usr/src/optuna_dashboard/public/
+COPY --from=front-builder /usr/src/optuna_dashboard/optuna_dashboard/public/ /usr/src/optuna_dashboard/public/
 RUN pip install --progress-bar off .
 
 FROM python:3.12-slim-bookworm AS runner


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
To resolve https://github.com/optuna/optuna-dashboard/actions/runs/27666892436/job/81822647330

```
#17 [front-builder  5/15] RUN pnpm install --frozen-lockfile && pnpm run build
#17 0.247 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.7.0.tgz
#17 1.432 [ERR_PNPM_NO_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
#17 1.432 
#17 1.432 Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
#17 ERROR: process "/bin/sh -c pnpm install --frozen-lockfile && pnpm run build" did not complete successfully: exit code: 1

#14 [python-builder 3/8] RUN pip install --upgrade pip setuptools
#14 CANCELED
------
 > [front-builder  5/15] RUN pnpm install --frozen-lockfile && pnpm run build:
0.247 ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11.7.0.tgz
1.432 [ERR_PNPM_NO_LOCKFILE] Cannot install with "frozen-lockfile" because pnpm-lock.yaml is absent
1.432 
1.432 Note that in CI environments this setting is true by default. If you still need to run install in such cases, use "pnpm install --no-frozen-lockfile"
------
Dockerfile:11
--------------------
   9 |     WORKDIR /usr/src/tslib/types
  10 |     ADD ./tslib/types/ /usr/src/tslib/types/
  11 | >>> RUN pnpm install --frozen-lockfile && pnpm run build
  12 |     
  13 |     WORKDIR /usr/src/tslib/storage
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile && pnpm run build" did not complete successfully: exit code: 1
Reference
Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c pnpm install --frozen-lockfile && pnpm run build" did not complete successfully: exit code: 1
```

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This PR fixes the Docker image release workflow after the pnpm workspace migration.

- Skip Docker image publishing for `jupyterlab-v...` releases, matching the PyPI release workflow behavior.
- Update the Dockerfile to install pnpm dependencies from the workspace root with `pnpm-lock.yaml`.
- Build frontend packages with `pnpm --filter ...` instead of running `pnpm install` in each package directory.
- Adjust the frontend artifact copy path for the new workspace-root build layout.