### PR TITLE
Added objective names to hyperparameter importance plot

### DIFF
--- a/tslib/react/src/components/PlotImportance.tsx
+++ b/tslib/react/src/components/PlotImportance.tsx
@@ -17,7 +17,7 @@ export const PlotImportance: FC<{
     colorTheme ??
     (theme.palette.mode === "dark" ? DarkColorTemplates.default : {})
   const objectiveNames: string[] = study
-    ? study.directions.map((_d, i) => `Objective ${i}`)
+    ? study.directions.map((_d, i) => study.metric_names?.[i] ?? `Objective ${i}`)
     : []
   useEffect(() => {
     if (study !== null && importance !== undefined && importance.length > 0) {

--- a/tslib/react/src/components/PlotImportance.tsx
+++ b/tslib/react/src/components/PlotImportance.tsx
@@ -18,8 +18,8 @@ export const PlotImportance: FC<{
     (theme.palette.mode === "dark" ? DarkColorTemplates.default : {})
   const objectiveNames: string[] = study
     ? study.directions.map(
-      (_d, i) => study.metric_names?.[i] ?? `Objective ${i}`
-    )
+        (_d, i) => study.metric_names?.[i] ?? `Objective ${i}`
+      )
     : []
   useEffect(() => {
     if (study !== null && importance !== undefined && importance.length > 0) {

--- a/tslib/react/src/components/PlotImportance.tsx
+++ b/tslib/react/src/components/PlotImportance.tsx
@@ -17,7 +17,9 @@ export const PlotImportance: FC<{
     colorTheme ??
     (theme.palette.mode === "dark" ? DarkColorTemplates.default : {})
   const objectiveNames: string[] = study
-    ? study.directions.map((_d, i) => study.metric_names?.[i] ?? `Objective ${i}`)
+    ? study.directions.map(
+      (_d, i) => study.metric_names?.[i] ?? `Objective ${i}`
+    )
     : []
   useEffect(() => {
     if (study !== null && importance !== undefined && importance.length > 0) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #1317 "Objective names not shown in hyperparameter importance plot"
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->

## What does this implement/fix? Explain your changes.
This implementation adds support for loading the objective names as labels for the hyperparameter importance plot. If no objective names are present, fall back to previous behavior (set the name to "Objective <objective_id>").
<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
