### PR TITLE
Remove VS Code base64 transport and use stable study IDs

### DIFF
--- a/standalone_app/src/components/App.tsx
+++ b/standalone_app/src/components/App.tsx
@@ -49,7 +49,7 @@ export const App: FC = () => {
                 element={<StudyList toggleColorMode={toggleColorMode} />}
               />
               <Route
-                path=":idx"
+                path="study/:studyId"
                 element={<StudyDetail toggleColorMode={toggleColorMode} />}
               />
             </Routes>

--- a/standalone_app/src/components/StudyDetail.tsx
+++ b/standalone_app/src/components/StudyDetail.tsx
@@ -29,8 +29,8 @@ export const StudyDetail: FC<{
   toggleColorMode: () => void
 }> = ({ toggleColorMode }) => {
   const theme = useTheme()
-  const { idx } = useParams<{ idx: string }>()
-  const idxNumber = parseInt(idx || "", 10)
+  const { studyId } = useParams<{ studyId: string }>()
+  const studyIdNumber = Number(studyId)
 
   const { storage } = useContext(StorageContext)
   const [study, setStudy] = useState<Optuna.Study | null>(null)
@@ -39,11 +39,11 @@ export const StudyDetail: FC<{
       if (storage === null) {
         return
       }
-      const study = await storage.getStudy(idxNumber)
+      const study = await storage.getStudy(studyIdNumber)
       setStudy(study)
     }
     fetchStudy()
-  }, [storage, idxNumber])
+  }, [storage, studyIdNumber])
 
   const [importance, setImportance] = useState<Optuna.ParamImportance[][]>([])
   const filterFunc = (trial: Optuna.Trial, objectiveId: number): boolean => {

--- a/standalone_app/src/components/StudyList.tsx
+++ b/standalone_app/src/components/StudyList.tsx
@@ -179,12 +179,12 @@ export const StudyList: FC<{
           </CardContent>
         </Card>
         <Box sx={{ display: "flex", flexWrap: "wrap" }}>
-          {filteredStudies.map((study, idx) => (
+          {filteredStudies.map((study) => (
             <Card
               key={study.id}
               sx={{ margin: theme.spacing(2), width: "500px" }}
             >
-              <CardActionArea component={Link} to={`/${idx}`}>
+              <CardActionArea component={Link} to={`/study/${study.id}`}>
                 <CardContent>
                   <Typography variant="h5" sx={{ wordBreak: "break-all" }}>
                     {study.id}. {study.name}

--- a/standalone_app/src/vscode_entry.tsx
+++ b/standalone_app/src/vscode_entry.tsx
@@ -8,37 +8,40 @@ import {
 } from "./components/StorageProvider"
 import "./index.css"
 
+type WebviewMessage = {
+  type: "optunaStorage"
+  content: Uint8Array
+}
+
 export const AppWrapper: FC = () => {
   const { setStorage } = useContext(StorageContext)
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    window.addEventListener("message", (event) => {
-      const message = event.data
-      let fileContentBase64: string
-      let binaryString: string
-      let len: number
-      let bytes: Uint8Array
-      let arrayBuffer: ArrayBuffer
+    const handleMessage = (event: MessageEvent) => {
+      const message = event.data as WebviewMessage
 
       switch (message.type) {
         case "optunaStorage":
-          fileContentBase64 = message.content
-          binaryString = atob(fileContentBase64)
-          len = binaryString.length
-          bytes = new Uint8Array(len)
-          for (let i = 0; i < len; i++) {
-            bytes[i] = binaryString.charCodeAt(i)
-          }
-          // TODO(c-bata): Remove the following ts-ignore comment
-          // @ts-ignore
-          arrayBuffer = bytes.buffer
-          setStorage(getStorage(arrayBuffer))
+          setStorage(getStorage(toArrayBuffer(message.content)))
           break
       }
-    })
+    }
+    window.addEventListener("message", handleMessage)
+    return () => window.removeEventListener("message", handleMessage)
   }, [])
   return <App />
+}
+
+const toArrayBuffer = (content: Uint8Array): ArrayBuffer => {
+  if (
+    content.buffer instanceof ArrayBuffer &&
+    content.byteOffset === 0 &&
+    content.byteLength === content.buffer.byteLength
+  ) {
+    return content.buffer
+  }
+  return content.slice().buffer as ArrayBuffer
 }
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/tslib/react/test/loadStorageFromFile.ts
+++ b/tslib/react/test/loadStorageFromFile.ts
@@ -25,7 +25,7 @@ const loadStudiesFromStorage = async (
   const studySummaries = await storage.getStudies()
   const studies = (
     await Promise.all(
-      studySummaries.map((_summary, index) => storage.getStudy(index))
+      studySummaries.map((summary) => storage.getStudy(summary.id))
     )
   ).filter((s) => s !== null) as Optuna.Study[]
   setter((prev) => [...prev, ...studies])

--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -519,8 +519,8 @@ export class JournalFileStorage implements OptunaStorage {
   getStudies = async (): Promise<Optuna.StudySummary[]> => {
     return this.studies
   }
-  getStudy = async (idx: number): Promise<Optuna.Study | null> => {
-    return this.studies[idx] || null
+  getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
+    return this.studies.find((study) => study.id === studyId) || null
   }
   getErrors = (): { log: string; message: string }[] => {
     return this.errors

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -78,7 +78,7 @@ export class SQLite3Storage implements OptunaStorage {
     return this.summaries_cache
   }
 
-  getStudy = async (idx: number): Promise<Optuna.Study | null> => {
+  getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
     const db = await this.db
     const schemaVersion = getSchemaVersion(db)
     if (!isSupportedSchema(schemaVersion)) {
@@ -87,7 +87,9 @@ export class SQLite3Storage implements OptunaStorage {
     if (this.summaries_cache === null) {
       this.summaries_cache = getStudySummaries(db)
     }
-    const summary = this.summaries_cache[idx]
+    const summary = this.summaries_cache.find(
+      (summary) => summary.id === studyId
+    )
     if (summary === undefined) {
       return null
     }

--- a/tslib/storage/src/storage.ts
+++ b/tslib/storage/src/storage.ts
@@ -2,5 +2,5 @@ import * as Optuna from "@optuna/types"
 
 export type OptunaStorage = {
   getStudies: () => Promise<Optuna.StudySummary[]>
-  getStudy: (idx: number) => Promise<Optuna.Study | null>
+  getStudy: (studyId: number) => Promise<Optuna.Study | null>
 }

--- a/tslib/storage/test/journal.test.mjs
+++ b/tslib/storage/test/journal.test.mjs
@@ -13,8 +13,46 @@ describe("Test Journal File Storage", async () => {
   const storage = new mut.JournalFileStorage(buf)
   const studySummaries = await storage.getStudies()
   const studies = await Promise.all(
-    studySummaries.map((_summary, index) => storage.getStudy(index))
+    studySummaries.map((summary) => storage.getStudy(summary.id))
   )
+
+  it("loads a study by its ID instead of its position", async () => {
+    const journal = [
+      {
+        op_code: 0,
+        workor_id: "0000",
+        study_name: "study-0",
+        directions: [1],
+      },
+      {
+        op_code: 0,
+        workor_id: "0000",
+        study_name: "study-1",
+        directions: [1],
+      },
+      { op_code: 1, workor_id: "0000", study_id: 1 },
+      {
+        op_code: 0,
+        workor_id: "0000",
+        study_name: "study-2",
+        directions: [1],
+      },
+    ]
+      .map((operation) => JSON.stringify(operation))
+      .join("\n")
+    const storage = new mut.JournalFileStorage(
+      new TextEncoder().encode(journal).buffer
+    )
+    const summaries = await storage.getStudies()
+
+    assert.deepStrictEqual(
+      summaries.map((summary) => summary.id),
+      [0, 2]
+    )
+    assert.strictEqual(await storage.getStudy(1), null)
+    const study = await storage.getStudy(2)
+    assert.strictEqual(study?.name, "study-2")
+  })
 
   it("Check the study with dynamic search space", () => {
     const study = studies.find((s) => s.name === "single-objective-dynamic")

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -42,8 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
           }
         }
       }
-      const messageDisposable =
-        panel.webview.onDidReceiveMessage(handleMessage)
+      const messageDisposable = panel.webview.onDidReceiveMessage(handleMessage)
       panel.onDidDispose(() => messageDisposable.dispose())
     }
   )

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -30,36 +30,29 @@ export function activate(context: vscode.ExtensionContext) {
       const appPath = panel.webview.asWebviewUri(indexJsUri)
 
       panel.webview.html = getWebviewContent(appPath)
-      // biome-ignore lint/suspicious/noExplicitAny: <explanation>`
-      panel.webview.onDidReceiveMessage(async (message: any) => {
+      const handleMessage = async (message: { type: string }) => {
         switch (message.type) {
           case "webviewDidLoad": {
-            const storageContentBase64 = await readFileAsBase64(fileUri)
-            panel.webview.postMessage({
+            const content = await readFile(fileUri)
+            await panel.webview.postMessage({
               type: "optunaStorage",
-              content: storageContentBase64,
+              content,
             })
             break
           }
         }
-      })
+      }
+      const messageDisposable =
+        panel.webview.onDidReceiveMessage(handleMessage)
+      panel.onDidDispose(() => messageDisposable.dispose())
     }
   )
 
   context.subscriptions.push(disposable)
 }
 
-async function readFileAsBase64(uri: vscode.Uri): Promise<string> {
-  const uint8Array = await vscode.workspace.fs.readFile(uri)
-  const base64 = uint8ArrayToBase64(uint8Array)
-  return base64
-}
-
-function uint8ArrayToBase64(uint8Array: Uint8Array): string {
-  const binString = Array.prototype.map
-    .call(uint8Array, (ch) => String.fromCharCode(ch))
-    .join("")
-  return btoa(binString)
+async function readFile(uri: vscode.Uri): Promise<Uint8Array> {
+  return vscode.workspace.fs.readFile(uri)
 }
 
 function getWebviewContent(indexJsUri: vscode.Uri): string {


### PR DESCRIPTION
## Summary

- Send storage files from the VS Code extension host to the Webview as `Uint8Array` instead of base64-encoded strings.
- Remove the corresponding `atob` and binary-string conversion logic.
- Clean up the Webview message listener when the component unmounts.
- Change `OptunaStorage.getStudy` to use a study ID instead of a list index.
- Update SQLite and Journal lookups, routes, and Study links to use stable study IDs.
- Add a regression test covering Journal study IDs with deleted-study gaps.

The study detail route is now `/study/:studyId`.