### PR TITLE
Follow-up #1244: Add multi-architecture support to Docker images

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -10,24 +10,28 @@ jobs:
       - uses: actions/checkout@v4
       - run: echo "REPO=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
       - run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
-      - name: Enable buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Docker build/push (tag)
         if: github.event_name == 'release'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPO }}:${{ env.TAG }}
       - name: Docker build/push (latest)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ghcr.io/${{ env.REPO }}:latest

--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
         with:
-          # https://hub.docker.com/layers/tonistiigi/binfmt/latest/images/sha256-b4c6a09270133b3c5b4dff94f83067df4dd27eced195fc6a1dbad102999e24dd
-          image: docker.io/tonistiigi/binfmt@sha256:sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
+          # Multi-platform manifest digest for tonistiigi/binfmt:latest (2026/08/12).
+          image: docker.io/tonistiigi/binfmt@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
           platforms: arm64
       - name: Enable buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
@@ -30,18 +30,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker build/push (tag)
+      - name: Docker build/push
         if: github.event_name == 'release'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: ghcr.io/${{ env.REPO }}:${{ env.TAG }}
-      - name: Docker build/push (latest)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ghcr.io/${{ env.REPO }}:latest
+          tags: |
+            ghcr.io/${{ env.REPO }}:${{ env.TAG }}
+            ghcr.io/${{ env.REPO }}:latest


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Fixes #1223
Follow-up #1244

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->

This PR follows up on #1244 by @chrmang and brings its multi-architecture Docker image support onto the latest `main` branch. In addition to the changes proposed in #1244, this PR:

- Resolves conflicts with the latest `main` branch.
- Pins all GitHub Actions to commit hashes to mitigate supply-chain risks.
- Pins the `tonistiigi/binfmt` image by its OCI manifest digest.
- Installs only the required `arm64` QEMU emulator.
- Builds the image once and applies both the release version tag and `latest` to the same multi-platform image.