### PR TITLE
Move Journal storage loading to a Web Worker

### DIFF
--- a/standalone_app/src/browser_app_entry.tsx
+++ b/standalone_app/src/browser_app_entry.tsx
@@ -1,12 +1,24 @@
+import type { StorageWorkerFactory } from "@optuna/storage"
 import React from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./components/App"
 import { StorageProvider } from "./components/StorageProvider"
 import "./index.css"
 
+const workerFactory: StorageWorkerFactory = async () => {
+  const worker = new Worker(
+    new URL("../../tslib/storage/src/journal_worker.ts", import.meta.url),
+    { type: "module" }
+  )
+  return {
+    worker,
+    dispose: () => {},
+  }
+}
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <StorageProvider>
+    <StorageProvider workerFactory={workerFactory}>
       <App />
     </StorageProvider>
   </React.StrictMode>

--- a/standalone_app/src/components/StorageLoader.tsx
+++ b/standalone_app/src/components/StorageLoader.tsx
@@ -15,35 +15,33 @@ import {
   useRef,
   useState,
 } from "react"
-import { StorageContext, getStorage } from "./StorageProvider"
+import { StorageContext } from "./StorageProvider"
 
 export const StorageLoader: FC = () => {
   const theme = useTheme()
   const [dragOver, setDragOver] = useState<boolean>(false)
-  const { setStorage } = useContext(StorageContext)
+  const { loadStorage, loading, error } = useContext(StorageContext)
 
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const loadStorageFromFile = (file: File): void => {
-    const r = new FileReader()
-    r.addEventListener("load", () => {
-      const arrayBuffer = r.result as ArrayBuffer | null
-      if (arrayBuffer !== null) {
-        const s = getStorage(arrayBuffer)
-        setStorage(s)
-      }
-    })
-    r.readAsArrayBuffer(file)
+  const loadStorageFromFile = async (file: File): Promise<void> => {
+    await loadStorage(await file.arrayBuffer())
   }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (loading) {
+      return
+    }
     const f = e.target.files?.[0]
     if (!f) {
       return
     }
-    loadStorageFromFile(f)
+    void loadStorageFromFile(f)
   }
   const handleClick: MouseEventHandler = () => {
+    if (loading) {
+      return
+    }
     if (!inputRef || !inputRef.current) {
       return
     }
@@ -52,12 +50,15 @@ export const StorageLoader: FC = () => {
   const handleDrop: DragEventHandler = (e) => {
     e.stopPropagation()
     e.preventDefault()
+    if (loading) {
+      return
+    }
     const file = e.dataTransfer.files?.[0]
     setDragOver(false)
     if (!file) {
       return
     }
-    loadStorageFromFile(file)
+    void loadStorageFromFile(file)
   }
   const handleDragOver: DragEventHandler = (e) => {
     e.stopPropagation()
@@ -84,7 +85,7 @@ export const StorageLoader: FC = () => {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <CardActionArea onClick={handleClick}>
+      <CardActionArea onClick={handleClick} disabled={loading}>
         <CardContent
           sx={{
             display: "flex",
@@ -104,12 +105,17 @@ export const StorageLoader: FC = () => {
             onChange={handleFileChange}
             style={{ display: "none" }}
           />
-          <Typography>Load an Optuna Storage</Typography>
+          <Typography>
+            {loading ? "Loading an Optuna Storage" : "Load an Optuna Storage"}
+          </Typography>
           <Typography
             sx={{ textAlign: "center", color: theme.palette.grey.A400 }}
           >
             Drag your SQLite3/JournalStorage file here or click to browse.
           </Typography>
+          {error !== null && (
+            <Typography color="error">{error.message}</Typography>
+          )}
         </CardContent>
       </CardActionArea>
     </Card>

--- a/standalone_app/src/components/StorageProvider.tsx
+++ b/standalone_app/src/components/StorageProvider.tsx
@@ -1,31 +1,111 @@
-import { JournalFileStorage } from "@optuna/storage"
 import { SQLite3Storage } from "@optuna/storage"
 import type { OptunaStorage } from "@optuna/storage"
-import React, { FC, createContext, useState } from "react"
+import { type StorageWorkerFactory, openStorage } from "@optuna/storage"
+import React, {
+  FC,
+  createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 export const StorageContext = createContext<{
   storage: OptunaStorage | null
-  setStorage: (storage: OptunaStorage) => void
+  loadStorage: (
+    arrayBuffer: ArrayBuffer,
+    workerFactory?: StorageWorkerFactory
+  ) => Promise<void>
+  closeStorage: () => Promise<void>
+  loading: boolean
+  error: Error | null
 }>({
   storage: null,
-  setStorage: () => {},
+  loadStorage: async () => {},
+  closeStorage: async () => {},
+  loading: false,
+  error: null,
 })
 
-export const getStorage = (arrayBuffer: ArrayBuffer): OptunaStorage => {
-  const header = new Uint8Array(arrayBuffer, 0, 16)
+export const getStorage = async (
+  arrayBuffer: ArrayBuffer,
+  workerFactory: StorageWorkerFactory
+): Promise<OptunaStorage> => {
+  const header = new Uint8Array(
+    arrayBuffer,
+    0,
+    Math.min(arrayBuffer.byteLength, 16)
+  )
   const headerString = new TextDecoder().decode(header)
   if (headerString === "SQLite format 3\u0000") {
     return new SQLite3Storage(arrayBuffer)
   }
-  return new JournalFileStorage(arrayBuffer)
+  return openStorage(arrayBuffer, workerFactory)
 }
 
 export const StorageProvider: FC<{
   children: React.ReactNode
-}> = ({ children }) => {
+  workerFactory?: StorageWorkerFactory
+}> = ({ children, workerFactory }) => {
   const [storage, setStorage] = useState<OptunaStorage | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const storageRef = useRef<OptunaStorage | null>(null)
+
+  const closeStorage = useCallback(async () => {
+    const currentStorage = storageRef.current
+    storageRef.current = null
+    setStorage(null)
+    if (currentStorage !== null) {
+      await currentStorage.close()
+    }
+  }, [])
+
+  const loadStorage = useCallback(
+    async (
+      arrayBuffer: ArrayBuffer,
+      overrideWorkerFactory?: StorageWorkerFactory
+    ) => {
+      setLoading(true)
+      setError(null)
+      try {
+        if (storageRef.current !== null) {
+          throw new Error("Storage is already open")
+        }
+        const factory = overrideWorkerFactory ?? workerFactory
+        if (factory === undefined) {
+          throw new Error("A storage worker factory is required")
+        }
+        const nextStorage = await getStorage(arrayBuffer, factory)
+        storageRef.current = nextStorage
+        setStorage(nextStorage)
+      } catch (loadError) {
+        const normalizedError =
+          loadError instanceof Error
+            ? loadError
+            : new Error("Failed to load storage")
+        setError(normalizedError)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [workerFactory]
+  )
+
+  useEffect(() => {
+    return () => {
+      const currentStorage = storageRef.current
+      storageRef.current = null
+      if (currentStorage !== null) {
+        void currentStorage.close()
+      }
+    }
+  }, [])
+
   return (
-    <StorageContext.Provider value={{ storage, setStorage }}>
+    <StorageContext.Provider
+      value={{ storage, loadStorage, closeStorage, loading, error }}
+    >
       {children}
     </StorageContext.Provider>
   )

--- a/standalone_app/src/components/StorageProvider.tsx
+++ b/standalone_app/src/components/StorageProvider.tsx
@@ -19,12 +19,14 @@ export const StorageContext = createContext<{
   closeStorage: () => Promise<void>
   loading: boolean
   error: Error | null
+  reportError: (error: unknown) => void
 }>({
   storage: null,
   loadStorage: async () => {},
   closeStorage: async () => {},
   loading: false,
   error: null,
+  reportError: () => {},
 })
 
 export const getStorage = async (
@@ -51,60 +53,106 @@ export const StorageProvider: FC<{
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const storageRef = useRef<OptunaStorage | null>(null)
+  const loadingRef = useRef(false)
+  const generationRef = useRef(0)
+  const mountedRef = useRef(true)
 
-  const closeStorage = useCallback(async () => {
-    const currentStorage = storageRef.current
-    storageRef.current = null
-    setStorage(null)
-    if (currentStorage !== null) {
-      await currentStorage.close()
+  const reportError = useCallback((loadError: unknown) => {
+    const normalizedError =
+      loadError instanceof Error
+        ? loadError
+        : new Error("Storage request failed")
+    if (mountedRef.current) {
+      setError(normalizedError)
     }
   }, [])
+
+  const closeStorage = useCallback(async () => {
+    generationRef.current += 1
+    const currentStorage = storageRef.current
+    storageRef.current = null
+    if (mountedRef.current) {
+      setStorage(null)
+      setLoading(false)
+    }
+    if (currentStorage !== null) {
+      try {
+        await currentStorage.close()
+      } catch (closeError) {
+        reportError(closeError)
+      }
+    }
+  }, [reportError])
 
   const loadStorage = useCallback(
     async (
       arrayBuffer: ArrayBuffer,
       overrideWorkerFactory?: StorageWorkerFactory
     ) => {
+      if (!mountedRef.current || loadingRef.current) {
+        return
+      }
+      if (storageRef.current !== null) {
+        reportError(new Error("Storage is already open"))
+        return
+      }
+
+      loadingRef.current = true
+      const generation = ++generationRef.current
       setLoading(true)
       setError(null)
       try {
-        if (storageRef.current !== null) {
-          throw new Error("Storage is already open")
-        }
         const factory = overrideWorkerFactory ?? workerFactory
         if (factory === undefined) {
           throw new Error("A storage worker factory is required")
         }
         const nextStorage = await getStorage(arrayBuffer, factory)
+
+        if (!mountedRef.current || generation !== generationRef.current) {
+          await nextStorage.close()
+          return
+        }
+
         storageRef.current = nextStorage
         setStorage(nextStorage)
       } catch (loadError) {
-        const normalizedError =
-          loadError instanceof Error
-            ? loadError
-            : new Error("Failed to load storage")
-        setError(normalizedError)
+        if (mountedRef.current && generation === generationRef.current) {
+          reportError(loadError)
+        }
       } finally {
-        setLoading(false)
+        loadingRef.current = false
+        if (mountedRef.current && generation === generationRef.current) {
+          setLoading(false)
+        }
       }
     },
-    [workerFactory]
+    [reportError, workerFactory]
   )
 
   useEffect(() => {
+    mountedRef.current = true
     return () => {
+      mountedRef.current = false
+      generationRef.current += 1
+      loadingRef.current = false
       const currentStorage = storageRef.current
       storageRef.current = null
       if (currentStorage !== null) {
-        void currentStorage.close()
+        void currentStorage.close().catch(() => {})
       }
     }
   }, [])
 
   return (
     <StorageContext.Provider
-      value={{ storage, loadStorage, closeStorage, loading, error }}
+      value={{
+        storage,
+        loadStorage,
+        closeStorage,
+        loading,
+        error,
+        reportError,
+      }}
     >
       {children}
     </StorageContext.Provider>

--- a/standalone_app/src/components/StudyDetail.tsx
+++ b/standalone_app/src/components/StudyDetail.tsx
@@ -35,14 +35,20 @@ export const StudyDetail: FC<{
   const { storage } = useContext(StorageContext)
   const [study, setStudy] = useState<Optuna.Study | null>(null)
   useEffect(() => {
+    let active = true
     const fetchStudy = async () => {
       if (storage === null) {
         return
       }
       const study = await storage.getStudy(studyIdNumber)
-      setStudy(study)
+      if (active) {
+        setStudy(study)
+      }
     }
-    fetchStudy()
+    void fetchStudy()
+    return () => {
+      active = false
+    }
   }, [storage, studyIdNumber])
 
   const [importance, setImportance] = useState<Optuna.ParamImportance[][]>([])

--- a/standalone_app/src/components/StudyDetail.tsx
+++ b/standalone_app/src/components/StudyDetail.tsx
@@ -32,7 +32,7 @@ export const StudyDetail: FC<{
   const { studyId } = useParams<{ studyId: string }>()
   const studyIdNumber = Number(studyId)
 
-  const { storage } = useContext(StorageContext)
+  const { storage, reportError } = useContext(StorageContext)
   const [study, setStudy] = useState<Optuna.Study | null>(null)
   useEffect(() => {
     let active = true
@@ -40,16 +40,22 @@ export const StudyDetail: FC<{
       if (storage === null) {
         return
       }
-      const study = await storage.getStudy(studyIdNumber)
-      if (active) {
-        setStudy(study)
+      try {
+        const study = await storage.getStudy(studyIdNumber)
+        if (active) {
+          setStudy(study)
+        }
+      } catch (error) {
+        if (active) {
+          reportError(error)
+        }
       }
     }
     void fetchStudy()
     return () => {
       active = false
     }
-  }, [storage, studyIdNumber])
+  }, [reportError, storage, studyIdNumber])
 
   const [importance, setImportance] = useState<Optuna.ParamImportance[][]>([])
   const filterFunc = (trial: Optuna.Trial, objectiveId: number): boolean => {

--- a/standalone_app/src/components/StudyList.tsx
+++ b/standalone_app/src/components/StudyList.tsx
@@ -43,14 +43,20 @@ export const StudyList: FC<{
   const [sortBy, setSortBy] = useState<"id-asc" | "id-desc">("id-asc")
   const studyFilterText = useDeferredValue(_studyFilterText)
   useEffect(() => {
+    let active = true
     const fetchStudies = async () => {
       if (storage === null) {
         return
       }
       const studies = await storage.getStudies()
-      setStudies(studies)
+      if (active) {
+        setStudies(studies)
+      }
     }
-    fetchStudies()
+    void fetchStudies()
+    return () => {
+      active = false
+    }
   }, [storage])
   const filteredStudies = useMemo(() => {
     const studyFilter = (row: Optuna.StudySummary): boolean => {
@@ -203,7 +209,7 @@ export const StudyList: FC<{
             </Card>
           ))}
         </Box>
-        {!IS_VSCODE && <StorageLoader />}
+        {!IS_VSCODE && storage === null && <StorageLoader />}
       </Container>
     </div>
   )

--- a/standalone_app/src/components/StudyList.tsx
+++ b/standalone_app/src/components/StudyList.tsx
@@ -36,7 +36,7 @@ export const StudyList: FC<{
   toggleColorMode: () => void
 }> = ({ toggleColorMode }) => {
   const theme = useTheme()
-  const { storage } = useContext(StorageContext)
+  const { storage, reportError } = useContext(StorageContext)
   const [studies, setStudies] = useState<Optuna.StudySummary[]>([])
 
   const [_studyFilterText, setStudyFilterText] = useState<string>("")
@@ -48,16 +48,22 @@ export const StudyList: FC<{
       if (storage === null) {
         return
       }
-      const studies = await storage.getStudies()
-      if (active) {
-        setStudies(studies)
+      try {
+        const studies = await storage.getStudies()
+        if (active) {
+          setStudies(studies)
+        }
+      } catch (error) {
+        if (active) {
+          reportError(error)
+        }
       }
     }
     void fetchStudies()
     return () => {
       active = false
     }
-  }, [storage])
+  }, [reportError, storage])
   const filteredStudies = useMemo(() => {
     const studyFilter = (row: Optuna.StudySummary): boolean => {
       const keywords = studyFilterText.split(" ")

--- a/standalone_app/src/vscode_entry.tsx
+++ b/standalone_app/src/vscode_entry.tsx
@@ -1,36 +1,58 @@
-import React, { FC, useEffect, useContext } from "react"
+import type { StorageWorkerFactory } from "@optuna/storage"
+import React, { FC, useContext, useEffect } from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./components/App"
-import {
-  StorageContext,
-  StorageProvider,
-  getStorage,
-} from "./components/StorageProvider"
+import { StorageContext, StorageProvider } from "./components/StorageProvider"
 import "./index.css"
 
 type WebviewMessage = {
   type: "optunaStorage"
   content: Uint8Array
+  workerUri: string
 }
 
 export const AppWrapper: FC = () => {
-  const { setStorage } = useContext(StorageContext)
+  const { loadStorage } = useContext(StorageContext)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data as WebviewMessage
 
       switch (message.type) {
         case "optunaStorage":
-          setStorage(getStorage(toArrayBuffer(message.content)))
+          void loadStorage(
+            toArrayBuffer(message.content),
+            createWebviewWorkerFactory(message.workerUri)
+          )
           break
       }
     }
     window.addEventListener("message", handleMessage)
     return () => window.removeEventListener("message", handleMessage)
-  }, [])
+  }, [loadStorage])
   return <App />
+}
+
+const createWebviewWorkerFactory = (
+  workerUri: string
+): StorageWorkerFactory => {
+  return async () => {
+    const response = await fetch(workerUri)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch storage worker: ${response.status}`)
+    }
+    const blobUrl = URL.createObjectURL(await response.blob())
+    try {
+      const worker = new Worker(blobUrl)
+      return {
+        worker,
+        dispose: () => URL.revokeObjectURL(blobUrl),
+      }
+    } catch (error) {
+      URL.revokeObjectURL(blobUrl)
+      throw error
+    }
+  }
 }
 
 const toArrayBuffer = (content: Uint8Array): ArrayBuffer => {

--- a/standalone_app/webpack.config.js
+++ b/standalone_app/webpack.config.js
@@ -15,11 +15,19 @@ module.exports = {
             config: [__filename],
         }
     },
-    entry: [__dirname + '/src/vscode_entry.tsx'],
+    entry: {
+        bundle: __dirname + '/src/vscode_entry.tsx',
+        'storage-worker': path.resolve(__dirname, '../tslib/storage/src/journal_worker.ts'),
+    },
     output: {
         path: path.resolve(__dirname, '../vscode/assets/'),
-        filename: 'bundle.js',
-        publicPath: '/'
+        filename: '[name].js',
+        publicPath: '/',
+        clean: true,
+    },
+    optimization: {
+        splitChunks: false,
+        runtimeChunk: false,
     },
     module: {
         rules: [

--- a/tslib/storage/src/index.ts
+++ b/tslib/storage/src/index.ts
@@ -1,3 +1,20 @@
 export { JournalFileStorage } from "./journal.js"
 export { SQLite3Storage } from "./sqlite.js"
+export {
+  openStorage,
+  StorageWorkerClient,
+  StorageWorkerError,
+} from "./worker_client.js"
 export type { OptunaStorage } from "./storage.js"
+export type {
+  OpenStorageResult,
+  StorageWarning,
+  StorageWorkerRequest,
+  StorageWorkerRequestWithoutId,
+  StorageWorkerResponse,
+} from "./worker_protocol.js"
+export type {
+  StorageWorker,
+  StorageWorkerFactory,
+  StorageWorkerHandle,
+} from "./worker_client.js"

--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -525,4 +525,5 @@ export class JournalFileStorage implements OptunaStorage {
   getErrors = (): { log: string; message: string }[] => {
     return this.errors
   }
+  close = async (): Promise<void> => {}
 }

--- a/tslib/storage/src/journal_worker.ts
+++ b/tslib/storage/src/journal_worker.ts
@@ -1,0 +1,116 @@
+import { JournalFileStorage } from "./journal"
+import type {
+  StorageWorkerRequest,
+  StorageWorkerResponse,
+} from "./worker_protocol"
+
+type WorkerScope = {
+  onmessage: (event: MessageEvent<StorageWorkerRequest>) => void
+  postMessage: (message: StorageWorkerResponse) => void
+}
+
+let storage: JournalFileStorage | null = null
+
+const workerScope = self as unknown as WorkerScope
+
+class WorkerRequestError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message)
+  }
+}
+
+const createError = (error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      code: error instanceof WorkerRequestError ? error.code : "request_failed",
+      message: error.message,
+      details: error instanceof WorkerRequestError ? error.details : undefined,
+    }
+  }
+  return {
+    code: "request_failed",
+    message: "Unknown worker error",
+  }
+}
+
+const postError = (id: number, error: unknown): void => {
+  workerScope.postMessage({
+    id,
+    ok: false,
+    error: createError(error),
+  })
+}
+
+const ensureJournal = (buffer: ArrayBuffer): void => {
+  const headerLength = Math.min(buffer.byteLength, 16)
+  const header = new TextDecoder().decode(
+    new Uint8Array(buffer, 0, headerLength)
+  )
+  if (header === "SQLite format 3\u0000") {
+    throw new WorkerRequestError(
+      "unsupported_format",
+      "SQLite storage is not supported by this worker"
+    )
+  }
+}
+
+workerScope.onmessage = async (event) => {
+  const request = event.data
+
+  try {
+    switch (request.type) {
+      case "open": {
+        if (storage !== null) {
+          throw new WorkerRequestError(
+            "invalid_state",
+            "Storage is already open"
+          )
+        }
+        ensureJournal(request.buffer)
+        storage = new JournalFileStorage(request.buffer)
+        workerScope.postMessage({
+          id: request.id,
+          ok: true,
+          result: {
+            format: "journal",
+            warnings: storage.getErrors(),
+          },
+        })
+        break
+      }
+      case "getStudies": {
+        if (storage === null) {
+          throw new WorkerRequestError("invalid_state", "Storage is not open")
+        }
+        workerScope.postMessage({
+          id: request.id,
+          ok: true,
+          result: await storage.getStudies(),
+        })
+        break
+      }
+      case "getStudy": {
+        if (storage === null) {
+          throw new WorkerRequestError("invalid_state", "Storage is not open")
+        }
+        workerScope.postMessage({
+          id: request.id,
+          ok: true,
+          result: await storage.getStudy(request.studyId),
+        })
+        break
+      }
+      case "close": {
+        storage = null
+        workerScope.postMessage({ id: request.id, ok: true, result: null })
+        break
+      }
+    }
+  } catch (error) {
+    postError(request.id, error)
+  }
+}

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -45,6 +45,7 @@ type SQLite3DB = {
 export class SQLite3Storage implements OptunaStorage {
   db: Promise<SQLite3DB>
   summaries_cache: Optuna.StudySummary[] | null
+  private closed = false
   constructor(arrayBuffer: ArrayBuffer) {
     this.db = this.initDB(arrayBuffer)
     this.summaries_cache = null
@@ -73,12 +74,18 @@ export class SQLite3Storage implements OptunaStorage {
   }
 
   getStudies = async (): Promise<Optuna.StudySummary[]> => {
+    if (this.closed) {
+      throw new Error("Storage is closed")
+    }
     const db = await this.db
     this.summaries_cache = getStudySummaries(db)
     return this.summaries_cache
   }
 
   getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
+    if (this.closed) {
+      throw new Error("Storage is closed")
+    }
     const db = await this.db
     const schemaVersion = getSchemaVersion(db)
     if (!isSupportedSchema(schemaVersion)) {
@@ -94,6 +101,15 @@ export class SQLite3Storage implements OptunaStorage {
       return null
     }
     return getStudy(db, schemaVersion, summary)
+  }
+
+  close = async (): Promise<void> => {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    const db = await this.db
+    db.close()
   }
 }
 

--- a/tslib/storage/src/storage.ts
+++ b/tslib/storage/src/storage.ts
@@ -3,4 +3,5 @@ import * as Optuna from "@optuna/types"
 export type OptunaStorage = {
   getStudies: () => Promise<Optuna.StudySummary[]>
   getStudy: (studyId: number) => Promise<Optuna.Study | null>
+  close: () => Promise<void>
 }

--- a/tslib/storage/src/worker_client.ts
+++ b/tslib/storage/src/worker_client.ts
@@ -1,0 +1,225 @@
+import type * as Optuna from "@optuna/types"
+import type { OptunaStorage } from "./storage"
+import type {
+  OpenStorageResult,
+  StorageWorkerRequest,
+  StorageWorkerRequestWithoutId,
+  StorageWorkerResponse,
+} from "./worker_protocol"
+
+export type StorageWorker = {
+  postMessage: (message: StorageWorkerRequest, transfer: Transferable[]) => void
+  addEventListener: (type: string, listener: (event: Event) => void) => void
+  removeEventListener: (type: string, listener: (event: Event) => void) => void
+  terminate: () => void
+}
+
+export type StorageWorkerHandle = {
+  worker: StorageWorker
+  dispose: () => void
+}
+
+export type StorageWorkerFactory = () => Promise<StorageWorkerHandle>
+
+export class StorageWorkerError extends Error {
+  readonly code: string
+  readonly details: unknown
+
+  constructor(code: string, message: string, details?: unknown) {
+    super(message)
+    this.name = "StorageWorkerError"
+    this.code = code
+    this.details = details
+  }
+}
+
+type ClientState = "opening" | "ready" | "closing" | "closed" | "failed"
+
+type PendingRequest = {
+  resolve: (value: unknown) => void
+  reject: (reason: unknown) => void
+}
+
+export class StorageWorkerClient implements OptunaStorage {
+  private state: ClientState = "opening"
+  private nextRequestId = 0
+  private readonly pending = new Map<number, PendingRequest>()
+  private readonly handle: StorageWorkerHandle
+  private openPromise!: Promise<OpenStorageResult>
+  private closePromise: Promise<void> | null = null
+  private openResult: OpenStorageResult | null = null
+  private disposed = false
+
+  private readonly handleMessage = (event: Event): void => {
+    const response = (event as MessageEvent<StorageWorkerResponse>).data
+    const pending = this.pending.get(response.id)
+    if (pending === undefined) {
+      return
+    }
+    this.pending.delete(response.id)
+    if (response.ok) {
+      pending.resolve(response.result)
+    } else {
+      pending.reject(
+        new StorageWorkerError(
+          response.error.code,
+          response.error.message,
+          response.error.details
+        )
+      )
+    }
+  }
+
+  private readonly handleWorkerFailure = (event: Event): void => {
+    const errorEvent = event as ErrorEvent
+    const message = errorEvent.message || "Storage worker failed"
+    this.fail(new StorageWorkerError("worker_failed", message))
+  }
+
+  private constructor(handle: StorageWorkerHandle) {
+    this.handle = handle
+    handle.worker.addEventListener("message", this.handleMessage)
+    handle.worker.addEventListener("error", this.handleWorkerFailure)
+    handle.worker.addEventListener("messageerror", this.handleWorkerFailure)
+  }
+
+  public static async open(
+    buffer: ArrayBuffer,
+    workerFactory: StorageWorkerFactory
+  ): Promise<StorageWorkerClient> {
+    const client = new StorageWorkerClient(await workerFactory())
+    const openPromise = client.request<OpenStorageResult>(
+      { type: "open", buffer },
+      [buffer]
+    )
+    client.openPromise = openPromise
+
+    try {
+      client.openResult = await openPromise
+      client.state = "ready"
+      return client
+    } catch (error) {
+      client.fail(error)
+      throw error
+    }
+  }
+
+  public getWarnings(): OpenStorageResult["warnings"] {
+    return this.openResult?.warnings ?? []
+  }
+
+  public getStudies = async (): Promise<Optuna.StudySummary[]> => {
+    await this.waitUntilReady()
+    return this.request<Optuna.StudySummary[]>({ type: "getStudies" })
+  }
+
+  public getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
+    await this.waitUntilReady()
+    return this.request<Optuna.Study | null>({ type: "getStudy", studyId })
+  }
+
+  public close = async (): Promise<void> => {
+    if (this.state === "closed") {
+      return
+    }
+    if (this.closePromise !== null) {
+      return this.closePromise
+    }
+
+    this.closePromise = (async () => {
+      if (this.state === "opening") {
+        try {
+          await this.openPromise
+        } catch {
+          // The failure path below releases the worker resources.
+        }
+      }
+      if (this.state === "ready") {
+        this.state = "closing"
+        try {
+          await this.request<null>({ type: "close" })
+        } catch {
+          // close must release the client even if the worker already failed.
+        }
+      }
+      this.dispose()
+      this.state = "closed"
+    })()
+    return this.closePromise
+  }
+
+  private waitUntilReady = async (): Promise<void> => {
+    if (this.state === "opening") {
+      await this.openPromise
+    }
+    if (this.state !== "ready") {
+      throw new StorageWorkerError(
+        "invalid_state",
+        `Storage worker is ${this.state}`
+      )
+    }
+  }
+
+  private request<T>(
+    request: StorageWorkerRequestWithoutId,
+    transfer: Transferable[] = []
+  ): Promise<T> {
+    if (this.state === "closed" || this.state === "failed") {
+      return Promise.reject(
+        new StorageWorkerError(
+          "invalid_state",
+          `Storage worker is ${this.state}`
+        )
+      )
+    }
+
+    const id = this.nextRequestId++
+    const message = { ...request, id } as StorageWorkerRequest
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (value) => resolve(value as T),
+        reject,
+      })
+      try {
+        this.handle.worker.postMessage(message, transfer)
+      } catch (error) {
+        this.pending.delete(id)
+        reject(error)
+      }
+    })
+  }
+
+  private fail(error: unknown): void {
+    if (this.state === "closed" || this.state === "failed") {
+      return
+    }
+    this.state = "failed"
+    for (const pending of this.pending.values()) {
+      pending.reject(error)
+    }
+    this.pending.clear()
+    this.dispose()
+  }
+
+  private dispose(): void {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    this.handle.worker.removeEventListener("message", this.handleMessage)
+    this.handle.worker.removeEventListener("error", this.handleWorkerFailure)
+    this.handle.worker.removeEventListener(
+      "messageerror",
+      this.handleWorkerFailure
+    )
+    this.handle.worker.terminate()
+    this.handle.dispose()
+  }
+}
+
+export const openStorage = async (
+  buffer: ArrayBuffer,
+  workerFactory: StorageWorkerFactory
+): Promise<StorageWorkerClient> => {
+  return StorageWorkerClient.open(buffer, workerFactory)
+}

--- a/tslib/storage/src/worker_protocol.ts
+++ b/tslib/storage/src/worker_protocol.ts
@@ -1,0 +1,36 @@
+import type * as Optuna from "@optuna/types"
+
+export type StorageWarning = {
+  log: string
+  message: string
+}
+
+export type OpenStorageResult = {
+  format: "journal"
+  warnings: StorageWarning[]
+}
+
+export type StorageWorkerRequestWithoutId =
+  | { type: "open"; buffer: ArrayBuffer }
+  | { type: "getStudies" }
+  | { type: "getStudy"; studyId: number }
+  | { type: "close" }
+
+export type StorageWorkerRequest = StorageWorkerRequestWithoutId & {
+  id: number
+}
+
+export type StorageWorkerResponse =
+  | { id: number; ok: true; result: OpenStorageResult }
+  | { id: number; ok: true; result: Optuna.StudySummary[] }
+  | { id: number; ok: true; result: Optuna.Study | null }
+  | { id: number; ok: true; result: null }
+  | {
+      id: number
+      ok: false
+      error: {
+        code: string
+        message: string
+        details?: unknown
+      }
+    }

--- a/tslib/storage/test/worker_client.test.mjs
+++ b/tslib/storage/test/worker_client.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { StorageWorkerClient } from "../pkg/worker_client.js"
+
+class FakeWorker extends EventTarget {
+  heldRequests = []
+  lastTransfer = []
+  terminated = false
+
+  postMessage(message, transfer) {
+    this.lastTransfer = transfer
+    if (message.type === "open") {
+      this.emitMessage({
+        id: message.id,
+        ok: true,
+        result: { format: "journal", warnings: [] },
+      })
+      return
+    }
+    if (message.type === "getStudies") {
+      this.heldRequests.push(message)
+      return
+    }
+    if (message.type === "getStudy") {
+      this.emitMessage({
+        id: message.id,
+        ok: true,
+        result: {
+          id: message.studyId,
+          name: "study",
+          directions: ["minimize"],
+        },
+      })
+      return
+    }
+    this.emitMessage({ id: message.id, ok: true, result: null })
+  }
+
+  terminate() {
+    this.terminated = true
+  }
+
+  emitMessage(data) {
+    queueMicrotask(() => {
+      const event = new Event("message")
+      Object.defineProperty(event, "data", { value: data })
+      this.dispatchEvent(event)
+    })
+  }
+}
+
+describe("StorageWorkerClient", () => {
+  it("matches responses by request ID and transfers the input buffer", async () => {
+    const worker = new FakeWorker()
+    const buffer = new ArrayBuffer(4)
+    let disposed = false
+    const storage = await StorageWorkerClient.open(buffer, async () => ({
+      worker,
+      dispose: () => {
+        disposed = true
+      },
+    }))
+
+    assert.strictEqual(worker.lastTransfer[0], buffer)
+    assert.deepStrictEqual(await storage.getStudy(42), {
+      id: 42,
+      name: "study",
+      directions: ["minimize"],
+    })
+
+    await storage.close()
+    await storage.close()
+    assert.strictEqual(worker.terminated, true)
+    assert.strictEqual(disposed, true)
+    await assert.rejects(storage.getStudies(), { code: "invalid_state" })
+  })
+
+  it("rejects pending requests when the worker fails", async () => {
+    const worker = new FakeWorker()
+    const storage = await StorageWorkerClient.open(
+      new ArrayBuffer(1),
+      async () => ({
+        worker,
+        dispose: () => {},
+      })
+    )
+    const studiesPromise = storage.getStudies()
+    await new Promise((resolve) => queueMicrotask(resolve))
+
+    worker.dispatchEvent(new Event("error"))
+
+    await assert.rejects(studiesPromise, { code: "worker_failed" })
+    await assert.rejects(storage.getStudies(), { code: "invalid_state" })
+  })
+})

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -69,7 +69,7 @@ function getWebviewContent(indexJsUri: vscode.Uri, cspSource: string): string {
 <head>
   <meta charset="utf-8" />
   <title>Optuna Dashboard (Wasm ver.)</title>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${cspSource} 'nonce-${nonce}'; worker-src blob:; connect-src ${cspSource}; style-src ${cspSource} 'unsafe-inline';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${cspSource} 'nonce-${nonce}' 'wasm-unsafe-eval'; worker-src blob:; connect-src ${cspSource}; style-src ${cspSource} 'unsafe-inline';">
   <script type="module" crossorigin src="${indexJsUri}"></script>
   <script nonce="${nonce}">
     (function() {

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -26,10 +26,15 @@ export function activate(context: vscode.ExtensionContext) {
         "assets",
         "bundle.js"
       )
+      const storageWorkerJsUri = vscode.Uri.joinPath(
+        context.extensionUri,
+        "assets",
+        "storage-worker.js"
+      )
 
       const appPath = panel.webview.asWebviewUri(indexJsUri)
 
-      panel.webview.html = getWebviewContent(appPath)
+      panel.webview.html = getWebviewContent(appPath, panel.webview.cspSource)
       const handleMessage = async (message: { type: string }) => {
         switch (message.type) {
           case "webviewDidLoad": {
@@ -37,6 +42,9 @@ export function activate(context: vscode.ExtensionContext) {
             await panel.webview.postMessage({
               type: "optunaStorage",
               content,
+              workerUri: panel.webview
+                .asWebviewUri(storageWorkerJsUri)
+                .toString(),
             })
             break
           }
@@ -54,14 +62,16 @@ async function readFile(uri: vscode.Uri): Promise<Uint8Array> {
   return vscode.workspace.fs.readFile(uri)
 }
 
-function getWebviewContent(indexJsUri: vscode.Uri): string {
+function getWebviewContent(indexJsUri: vscode.Uri, cspSource: string): string {
+  const nonce = getNonce()
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
   <title>Optuna Dashboard (Wasm ver.)</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src ${cspSource} 'nonce-${nonce}'; worker-src blob:; connect-src ${cspSource}; style-src ${cspSource} 'unsafe-inline';">
   <script type="module" crossorigin src="${indexJsUri}"></script>
-  <script>
+  <script nonce="${nonce}">
     (function() {
       const vscodeApi = acquireVsCodeApi();
       window.addEventListener('DOMContentLoaded', (event) => {
@@ -75,6 +85,16 @@ function getWebviewContent(indexJsUri: vscode.Uri): string {
 </body>
 </html>
 `
+}
+
+function getNonce(): string {
+  const characters =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+  let nonce = ""
+  for (let index = 0; index < 32; index++) {
+    nonce += characters.charAt(Math.floor(Math.random() * characters.length))
+  }
+  return nonce
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary

- Add a request/response protocol and `StorageWorkerClient` for storage workers.
- Move Journal parsing and replay into a self-contained Worker bundle.
- Use the same Worker source from the standalone app and VS Code Webview.
- Transfer storage file buffers and clean up workers on close or unmount.
- Keep SQLite loading on the UI thread for this step.

## Scope

This PR focuses on the Journal backend Worker migration. SQLite Worker migration, OPFS, and the SQLite wasm spike are intentionally left for follow-up work.