### PR TITLE
Add a storage Worker and its client to `@optuna/storage`

### DIFF
--- a/tslib/storage/package.json
+++ b/tslib/storage/package.json
@@ -5,6 +5,16 @@
   "version": "0.0.1",
   "description": "Loaders for Optuna storages",
   "main": "pkg/index.js",
+  "exports": {
+    ".": {
+      "types": "./pkg/index.d.ts",
+      "import": "./pkg/index.js"
+    },
+    "./worker-client": {
+      "types": "./pkg/worker_client.d.ts",
+      "import": "./pkg/worker_client.js"
+    }
+  },
   "scripts": {
     "build": "tsc -d",
     "test": "node --test"

--- a/tslib/storage/src/index.ts
+++ b/tslib/storage/src/index.ts
@@ -1,3 +1,19 @@
+// @optuna/storage has three entry points, one per execution context:
+//
+//   - `@optuna/storage` (index.ts): the storage backends themselves. Importing
+//     it pulls the sqlite-wasm glue into the bundle, so it belongs in the
+//     Worker, or in a consumer that knowingly parses storages on its own
+//     thread.
+//   - `@optuna/storage/worker-client` (worker_client.ts): the client that talks
+//     to the storage Worker. It runs on the UI thread and has no runtime
+//     dependency of its own.
+//   - storage_worker.ts: the Worker entry. It is not part of `exports` because
+//     a Worker is not imported but pointed at: the app hands its path to the
+//     bundler, as `new URL(..., import.meta.url)` for Vite or as an entry point
+//     for webpack.
+//
+// This file is the first of those: the backends.
+
 export { JournalFileStorage } from "./journal.js"
 export { SQLite3Storage } from "./sqlite.js"
 export {
@@ -7,17 +23,10 @@ export {
 } from "./worker_client.js"
 export type { OptunaStorage } from "./storage.js"
 export type { SQLiteWasmOptions } from "./sqlite.js"
-export type {
-  OpenStorageResult,
-  StorageWarning,
-  StorageWorkerErrorPayload,
-  StorageWorkerRequest,
-  StorageWorkerRequestOf,
-  StorageWorkerRequestType,
-  StorageWorkerRequestWithoutId,
-  StorageWorkerResponse,
-  StorageWorkerResultMap,
-} from "./worker_protocol.js"
+// The request and response types stay internal: they describe the wire between
+// the client and the Worker, and a consumer that reaches for them is talking to
+// the Worker without the client.
+export type { OpenStorageResult, StorageWarning } from "./worker_protocol.js"
 export type {
   SQLiteWasmSource,
   StorageWorker,

--- a/tslib/storage/src/index.ts
+++ b/tslib/storage/src/index.ts
@@ -1,3 +1,26 @@
 export { JournalFileStorage } from "./journal.js"
 export { SQLite3Storage } from "./sqlite.js"
+export {
+  openStorage,
+  StorageWorkerClient,
+  StorageWorkerError,
+} from "./worker_client.js"
 export type { OptunaStorage } from "./storage.js"
+export type { SQLiteWasmOptions } from "./sqlite.js"
+export type {
+  OpenStorageResult,
+  StorageWarning,
+  StorageWorkerErrorPayload,
+  StorageWorkerRequest,
+  StorageWorkerRequestOf,
+  StorageWorkerRequestType,
+  StorageWorkerRequestWithoutId,
+  StorageWorkerResponse,
+  StorageWorkerResultMap,
+} from "./worker_protocol.js"
+export type {
+  SQLiteWasmSource,
+  StorageWorker,
+  StorageWorkerFactory,
+  StorageWorkerHandle,
+} from "./worker_client.js"

--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -525,4 +525,5 @@ export class JournalFileStorage implements OptunaStorage {
   getErrors = (): { log: string; message: string }[] => {
     return this.errors
   }
+  close = async (): Promise<void> => {}
 }

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -87,16 +87,22 @@ export class SQLite3Storage implements OptunaStorage {
       print: console.log,
       printErr: console.log,
     }
-    // locateFile is always set, even when the wasm binary is passed in directly.
-    // Without it sqlite-wasm falls back to `new URL("sqlite3.wasm",
-    // import.meta.url).href`, which throws when this module runs in a Worker that
-    // was started from a VS Code blob: URL.
-    initOptions.locateFile = (path: string) =>
-      path === "sqlite3.wasm" && options.sqliteWasmUrl !== undefined
-        ? options.sqliteWasmUrl
-        : path
+    // Without locateFile, sqlite-wasm resolves sqlite3.wasm as `new
+    // URL("sqlite3.wasm", import.meta.url).href`. A bundler rewrites that to the
+    // asset it emitted, which is what makes the default work on the main thread,
+    // so locateFile is only set when this call actually knows better. Setting it
+    // unconditionally would replace that rewritten URL with a bare relative path
+    // that resolves against the page instead.
     if (options.sqliteWasmBuffer !== undefined) {
       initOptions.wasmBinary = options.sqliteWasmBuffer
+      // The binary is already here. locateFile only keeps sqlite-wasm from
+      // evaluating the fallback above, which throws in a Worker started from a
+      // blob: URL because nothing resolves relative to it. What it returns is
+      // never fetched.
+      initOptions.locateFile = (path: string) => path
+    } else if (options.sqliteWasmUrl !== undefined) {
+      initOptions.locateFile = (path: string) =>
+        path === "sqlite3.wasm" ? (options.sqliteWasmUrl as string) : path
     }
 
     const sqlite3 = await sqlite3InitModule(initOptions)

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -1,7 +1,11 @@
 import * as Optuna from "@optuna/types"
-// @ts-ignore
-import sqlite3InitModule from "@sqlite.org/sqlite-wasm"
+import sqlite3InitModule from "./sqlite_init.js"
 import { OptunaStorage } from "./storage"
+
+export type SQLiteWasmOptions = {
+  sqliteWasmUrl?: string
+  sqliteWasmBuffer?: ArrayBuffer
+}
 
 // TODO(porink0424): Refactor to common function with journal.ts (current workaround duplicates code due to missing file extensions in tsc build output).
 const isDistributionEqual = (
@@ -45,40 +49,81 @@ type SQLite3DB = {
 export class SQLite3Storage implements OptunaStorage {
   db: Promise<SQLite3DB>
   summaries_cache: Optuna.StudySummary[] | null
-  constructor(arrayBuffer: ArrayBuffer) {
-    this.db = this.initDB(arrayBuffer)
+  private closed = false
+  constructor(arrayBuffer: ArrayBuffer, options: SQLiteWasmOptions = {}) {
+    this.db = this.initDB(arrayBuffer, options)
+    // A failed open is closed without ever being queried, so keep a rejection
+    // handler attached to avoid an unhandled rejection in the meantime.
+    this.db.catch(() => {})
     this.summaries_cache = null
   }
 
-  async initDB(arrayBuffer: ArrayBuffer): Promise<SQLite3DB> {
-    return sqlite3InitModule({
+  async initDB(
+    arrayBuffer: ArrayBuffer,
+    options: SQLiteWasmOptions
+  ): Promise<SQLite3DB> {
+    const initOptions: Parameters<typeof sqlite3InitModule>[0] & {
+      wasmBinary?: ArrayBuffer
+    } = {
       print: console.log,
       printErr: console.log,
-      // @ts-ignore
-    }).then((sqlite3) => {
+    }
+    // locateFile is always set, even when the wasm binary is passed in directly.
+    // Without it sqlite-wasm falls back to `new URL("sqlite3.wasm",
+    // import.meta.url).href`, which throws when this module runs in a Worker that
+    // was started from a VS Code blob: URL.
+    initOptions.locateFile = (path: string) =>
+      path === "sqlite3.wasm" && options.sqliteWasmUrl !== undefined
+        ? options.sqliteWasmUrl
+        : path
+    if (options.sqliteWasmBuffer !== undefined) {
+      initOptions.wasmBinary = options.sqliteWasmBuffer
+    }
+
+    const sqlite3 = await sqlite3InitModule(initOptions)
+    let db: SQLite3DB | null = null
+    try {
       const p = sqlite3.wasm.allocFromTypedArray(arrayBuffer)
-      const db = new sqlite3.oo1.DB()
+      const sqliteDb = new sqlite3.oo1.DB()
+      db = sqliteDb
       const rc = sqlite3.capi.sqlite3_deserialize(
         // @ts-ignore
-        db.pointer,
+        sqliteDb.pointer,
         "main",
         p,
         arrayBuffer.byteLength,
         arrayBuffer.byteLength,
         sqlite3.capi.SQLITE_DESERIALIZE_FREEONCLOSE
       )
-      db.checkRc(rc)
-      return db
-    })
+      sqliteDb.checkRc(rc)
+      return sqliteDb
+    } catch (error) {
+      try {
+        db?.close()
+      } catch {
+        // Preserve the initialization error.
+      }
+      throw error
+    }
+  }
+
+  async waitUntilReady(): Promise<void> {
+    await this.db
   }
 
   getStudies = async (): Promise<Optuna.StudySummary[]> => {
+    if (this.closed) {
+      throw new Error("Storage is closed")
+    }
     const db = await this.db
     this.summaries_cache = getStudySummaries(db)
     return this.summaries_cache
   }
 
   getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
+    if (this.closed) {
+      throw new Error("Storage is closed")
+    }
     const db = await this.db
     const schemaVersion = getSchemaVersion(db)
     if (!isSupportedSchema(schemaVersion)) {
@@ -94,6 +139,20 @@ export class SQLite3Storage implements OptunaStorage {
       return null
     }
     return getStudy(db, schemaVersion, summary)
+  }
+
+  close = async (): Promise<void> => {
+    if (this.closed) {
+      return
+    }
+    this.closed = true
+    try {
+      const db = await this.db
+      db.close()
+    } catch {
+      // close() is idempotent and never fails. An initialization failure was
+      // already handed to whoever awaited the storage.
+    }
   }
 }
 

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -2,6 +2,25 @@ import * as Optuna from "@optuna/types"
 import sqlite3InitModule from "./sqlite_init.js"
 import { OptunaStorage } from "./storage"
 
+// Where to take sqlite3.wasm from.
+//
+// sqlite-wasm normally derives that URL from its own script URL, which stops
+// working once this backend runs inside a Worker: a Worker started from a blob:
+// URL, which is how a VS Code Webview has to start one, cannot resolve anything
+// relative to itself. The caller therefore says where the wasm is.
+//
+//   - `sqliteWasmUrl`: sqlite-wasm fetches it. Used where the bundler emits
+//     sqlite3.wasm next to the app and the Worker may fetch it.
+//   - `sqliteWasmBuffer`: the bytes, fetched by the caller. A VS Code Webview
+//     needs this: extension assets are served by the Webview's service worker,
+//     which does not answer requests coming from a blob: URL Worker, so the
+//     document fetches the asset and transfers it.
+//
+// A third option is to inline the wasm into the JavaScript as base64, which is
+// what the VS Code build has done so far. It keeps distribution simple, but it
+// turns 931KB into roughly 1.24MB of JavaScript source that has to be parsed on
+// every load, and it rules out WebAssembly.instantiateStreaming() as well as
+// caching the wasm separately from the bundle.
 export type SQLiteWasmOptions = {
   sqliteWasmUrl?: string
   sqliteWasmBuffer?: ArrayBuffer

--- a/tslib/storage/src/sqlite_init.ts
+++ b/tslib/storage/src/sqlite_init.ts
@@ -1,0 +1,12 @@
+// Import the bundler-friendly initializer directly. The package entrypoint
+// also imports the optional Worker API, which is not used by this dashboard
+// and would add an unnecessary nested Worker bundle.
+//
+// The dependency has no exports entry for this path, hence the deep import. It
+// stays valid after `tsc` only because src/ and pkg/ sit at the same depth
+// under the package root: changing outDir breaks the specifier at bundle time
+// rather than at build time.
+// @ts-expect-error the dependency ships no types for this path
+import sqlite3InitModule from "../node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs"
+
+export default sqlite3InitModule

--- a/tslib/storage/src/storage.ts
+++ b/tslib/storage/src/storage.ts
@@ -3,4 +3,5 @@ import * as Optuna from "@optuna/types"
 export type OptunaStorage = {
   getStudies: () => Promise<Optuna.StudySummary[]>
   getStudy: (studyId: number) => Promise<Optuna.Study | null>
+  close: () => Promise<void>
 }

--- a/tslib/storage/src/storage_worker.ts
+++ b/tslib/storage/src/storage_worker.ts
@@ -1,3 +1,19 @@
+// @optuna/storage has three entry points, one per execution context:
+//
+//   - `@optuna/storage` (index.ts): the storage backends themselves. Importing
+//     it pulls the sqlite-wasm glue into the bundle, so it belongs in the
+//     Worker, or in a consumer that knowingly parses storages on its own
+//     thread.
+//   - `@optuna/storage/worker-client` (worker_client.ts): the client that talks
+//     to the storage Worker. It runs on the UI thread and has no runtime
+//     dependency of its own.
+//   - storage_worker.ts: the Worker entry. It is not part of `exports` because
+//     a Worker is not imported but pointed at: the app hands its path to the
+//     bundler, as `new URL(..., import.meta.url)` for Vite or as an entry point
+//     for webpack.
+//
+// This file is the third: the Worker itself.
+
 import { JournalFileStorage } from "./journal.js"
 import { SQLite3Storage } from "./sqlite.js"
 import type {

--- a/tslib/storage/src/storage_worker.ts
+++ b/tslib/storage/src/storage_worker.ts
@@ -1,0 +1,176 @@
+import { JournalFileStorage } from "./journal.js"
+import { SQLite3Storage } from "./sqlite.js"
+import type {
+  StorageWorkerRequest,
+  StorageWorkerRequestType,
+  StorageWorkerResponse,
+  StorageWorkerResultMap,
+} from "./worker_protocol.js"
+
+// sqlite-wasm tries to install an OPFS VFS while it initializes, which starts a
+// nested Worker for its async proxy. This viewer only opens an in-memory
+// database, and the nested Worker cannot be resolved from a Worker that was
+// started from a VS Code blob: URL. Removing the constructor keeps the OPFS
+// installation from getting that far. The storage Worker never starts a Worker
+// of its own, so this is scoped to the Worker instead of patching globals from
+// the SQLite backend, which also runs on the main thread in other consumers.
+;(globalThis as { Worker?: unknown }).Worker = undefined
+
+type WorkerScope = {
+  onmessage: (event: MessageEvent<StorageWorkerRequest>) => void
+  postMessage: (message: StorageWorkerResponse) => void
+}
+
+type WorkerStorage = JournalFileStorage | SQLite3Storage
+
+let storage: WorkerStorage | null = null
+
+const workerScope = self as unknown as WorkerScope
+
+class WorkerRequestError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly details?: unknown
+  ) {
+    super(message)
+  }
+}
+
+const createError = (error: unknown) => {
+  if (error instanceof Error) {
+    return {
+      code: error instanceof WorkerRequestError ? error.code : "request_failed",
+      message: error.message,
+      details: error instanceof WorkerRequestError ? error.details : undefined,
+    }
+  }
+  return {
+    code: "request_failed",
+    message: "Unknown worker error",
+  }
+}
+
+const postResult = <K extends StorageWorkerRequestType>(
+  id: number,
+  type: K,
+  result: StorageWorkerResultMap[K]
+): void => {
+  workerScope.postMessage({
+    id,
+    type,
+    ok: true,
+    result,
+  } as StorageWorkerResponse)
+}
+
+const postError = (id: number, type: string, error: unknown): void => {
+  workerScope.postMessage({
+    id,
+    type,
+    ok: false,
+    error: createError(error),
+  })
+}
+
+const isSQLiteFile = (buffer: ArrayBuffer): boolean => {
+  const headerLength = Math.min(buffer.byteLength, 16)
+  const header = new TextDecoder().decode(
+    new Uint8Array(buffer, 0, headerLength)
+  )
+  return header === "SQLite format 3\u0000"
+}
+
+const closeStorage = async (): Promise<void> => {
+  const currentStorage = storage
+  storage = null
+  if (currentStorage !== null) {
+    await currentStorage.close()
+  }
+}
+
+workerScope.onmessage = async (event) => {
+  const request = event.data
+
+  try {
+    switch (request.type) {
+      case "open": {
+        if (storage !== null) {
+          throw new WorkerRequestError(
+            "invalid_state",
+            "Storage is already open"
+          )
+        }
+        if (isSQLiteFile(request.buffer)) {
+          if (
+            request.sqliteWasmUrl === undefined &&
+            request.sqliteWasmBuffer === undefined
+          ) {
+            throw new WorkerRequestError(
+              "missing_sqlite_wasm",
+              "SQLite wasm URL or buffer is required"
+            )
+          }
+          const sqliteStorage = new SQLite3Storage(request.buffer, {
+            sqliteWasmUrl: request.sqliteWasmUrl,
+            sqliteWasmBuffer: request.sqliteWasmBuffer,
+          })
+          try {
+            await sqliteStorage.waitUntilReady()
+          } catch (error) {
+            await sqliteStorage.close()
+            throw error
+          }
+          storage = sqliteStorage
+          postResult(request.id, "open", {
+            format: "sqlite3",
+            warnings: [],
+          })
+          break
+        }
+
+        const journalStorage = new JournalFileStorage(request.buffer)
+        storage = journalStorage
+        postResult(request.id, "open", {
+          format: "journal",
+          warnings: journalStorage.getErrors(),
+        })
+        break
+      }
+      case "getStudies": {
+        if (storage === null) {
+          throw new WorkerRequestError("invalid_state", "Storage is not open")
+        }
+        postResult(request.id, "getStudies", await storage.getStudies())
+        break
+      }
+      case "getStudy": {
+        if (storage === null) {
+          throw new WorkerRequestError("invalid_state", "Storage is not open")
+        }
+        postResult(
+          request.id,
+          "getStudy",
+          await storage.getStudy(request.studyId)
+        )
+        break
+      }
+      case "close": {
+        await closeStorage()
+        postResult(request.id, "close", null)
+        break
+      }
+      default: {
+        // `request` is never here as long as every request type is handled.
+        // Answering keeps a client of a different version from waiting forever.
+        const unsupported = request as { id: number; type: string }
+        throw new WorkerRequestError(
+          "unsupported_request",
+          `Unsupported request: ${unsupported.type}`
+        )
+      }
+    }
+  } catch (error) {
+    postError(request.id, request.type, error)
+  }
+}

--- a/tslib/storage/src/worker_client.ts
+++ b/tslib/storage/src/worker_client.ts
@@ -1,0 +1,265 @@
+import type * as Optuna from "@optuna/types"
+import type { OptunaStorage } from "./storage"
+import type {
+  OpenStorageResult,
+  StorageWorkerRequest,
+  StorageWorkerRequestOf,
+  StorageWorkerRequestType,
+  StorageWorkerResponse,
+  StorageWorkerResultMap,
+} from "./worker_protocol"
+
+// Re-exported so that a UI can depend on this subpath alone: importing the
+// package root would pull the SQLite backend into the bundle.
+export type { OptunaStorage } from "./storage"
+
+export type StorageWorker = {
+  postMessage: (message: StorageWorkerRequest, transfer: Transferable[]) => void
+  addEventListener: (type: string, listener: (event: Event) => void) => void
+  removeEventListener: (type: string, listener: (event: Event) => void) => void
+  terminate: () => void
+}
+
+export type StorageWorkerHandle = {
+  worker: StorageWorker
+  dispose: () => void
+}
+
+export type StorageWorkerFactory = () => Promise<StorageWorkerHandle>
+
+// Where the storage Worker takes sqlite-wasm from. The two are exclusive: a URL
+// is fetched by sqlite-wasm itself, bytes are transferred to the Worker. Bytes
+// are what a VS Code Webview needs, where the Worker cannot fetch extension
+// assets itself.
+export type SQLiteWasmSource = { url: string } | { buffer: ArrayBuffer }
+
+export class StorageWorkerError extends Error {
+  readonly code: string
+  readonly details: unknown
+
+  constructor(code: string, message: string, details?: unknown) {
+    super(message)
+    this.name = "StorageWorkerError"
+    this.code = code
+    this.details = details
+  }
+}
+
+type ClientState = "opening" | "ready" | "closing" | "closed" | "failed"
+
+type PendingRequest = {
+  type: StorageWorkerRequestType
+  resolve: (value: never) => void
+  reject: (reason: unknown) => void
+}
+
+export class StorageWorkerClient implements OptunaStorage {
+  private state: ClientState = "opening"
+  private nextRequestId = 0
+  private readonly pending = new Map<number, PendingRequest>()
+  private readonly handle: StorageWorkerHandle
+  private readonly openPromise: Promise<OpenStorageResult>
+  private closePromise: Promise<void> | null = null
+  private openResult: OpenStorageResult | null = null
+  private disposed = false
+
+  private readonly handleMessage = (event: Event): void => {
+    const response = (event as MessageEvent<StorageWorkerResponse>).data
+    const pending = this.pending.get(response.id)
+    if (pending === undefined) {
+      return
+    }
+    this.pending.delete(response.id)
+    if (response.ok) {
+      if (response.type !== pending.type) {
+        pending.reject(
+          new StorageWorkerError(
+            "protocol_mismatch",
+            `Storage worker answered ${pending.type} with ${response.type}`
+          )
+        )
+        return
+      }
+      pending.resolve(response.result as never)
+    } else {
+      pending.reject(
+        new StorageWorkerError(
+          response.error.code,
+          response.error.message,
+          response.error.details
+        )
+      )
+    }
+  }
+
+  private readonly handleWorkerFailure = (event: Event): void => {
+    const errorEvent = event as ErrorEvent
+    const message = errorEvent.message || "Storage worker failed"
+    this.fail(new StorageWorkerError("worker_failed", message))
+  }
+
+  private constructor(
+    handle: StorageWorkerHandle,
+    buffer: ArrayBuffer,
+    sqliteWasm?: SQLiteWasmSource
+  ) {
+    this.handle = handle
+    handle.worker.addEventListener("message", this.handleMessage)
+    handle.worker.addEventListener("error", this.handleWorkerFailure)
+    handle.worker.addEventListener("messageerror", this.handleWorkerFailure)
+
+    const sqliteWasmUrl =
+      sqliteWasm !== undefined && "url" in sqliteWasm
+        ? sqliteWasm.url
+        : undefined
+    const sqliteWasmBuffer =
+      sqliteWasm !== undefined && "buffer" in sqliteWasm
+        ? sqliteWasm.buffer
+        : undefined
+    this.openPromise = this.request(
+      { type: "open", buffer, sqliteWasmUrl, sqliteWasmBuffer },
+      sqliteWasmBuffer === undefined ? [buffer] : [buffer, sqliteWasmBuffer]
+    )
+  }
+
+  public static async open(
+    buffer: ArrayBuffer,
+    workerFactory: StorageWorkerFactory,
+    sqliteWasm?: SQLiteWasmSource
+  ): Promise<StorageWorkerClient> {
+    const client = new StorageWorkerClient(
+      await workerFactory(),
+      buffer,
+      sqliteWasm
+    )
+    try {
+      client.openResult = await client.openPromise
+      client.state = "ready"
+      return client
+    } catch (error) {
+      client.fail(error)
+      throw error
+    }
+  }
+
+  public getWarnings(): OpenStorageResult["warnings"] {
+    return this.openResult?.warnings ?? []
+  }
+
+  public getStudies = async (): Promise<Optuna.StudySummary[]> => {
+    await this.waitUntilReady()
+    return this.request({ type: "getStudies" })
+  }
+
+  public getStudy = async (studyId: number): Promise<Optuna.Study | null> => {
+    await this.waitUntilReady()
+    return this.request({ type: "getStudy", studyId })
+  }
+
+  public close = async (): Promise<void> => {
+    if (this.state === "closed") {
+      return
+    }
+    if (this.closePromise !== null) {
+      return this.closePromise
+    }
+
+    this.closePromise = (async () => {
+      if (this.state === "opening") {
+        try {
+          await this.openPromise
+        } catch {
+          // The failure path below releases the worker resources.
+        }
+      }
+      if (this.state === "ready") {
+        this.state = "closing"
+        try {
+          await this.request({ type: "close" })
+        } catch {
+          // close must release the client even if the worker already failed.
+        }
+      }
+      this.dispose()
+      this.state = "closed"
+    })()
+    return this.closePromise
+  }
+
+  private waitUntilReady = async (): Promise<void> => {
+    if (this.state === "opening") {
+      await this.openPromise
+    }
+    if (this.state !== "ready") {
+      throw new StorageWorkerError(
+        "invalid_state",
+        `Storage worker is ${this.state}`
+      )
+    }
+  }
+
+  private request<K extends StorageWorkerRequestType>(
+    request: StorageWorkerRequestOf<K>,
+    transfer: Transferable[] = []
+  ): Promise<StorageWorkerResultMap[K]> {
+    if (this.state === "closed" || this.state === "failed") {
+      return Promise.reject(
+        new StorageWorkerError(
+          "invalid_state",
+          `Storage worker is ${this.state}`
+        )
+      )
+    }
+
+    const id = this.nextRequestId++
+    const message = { ...request, id } as StorageWorkerRequest
+    return new Promise<StorageWorkerResultMap[K]>((resolve, reject) => {
+      this.pending.set(id, {
+        type: request.type,
+        resolve: resolve as (value: never) => void,
+        reject,
+      })
+      try {
+        this.handle.worker.postMessage(message, transfer)
+      } catch (error) {
+        this.pending.delete(id)
+        reject(error)
+      }
+    })
+  }
+
+  private fail(error: unknown): void {
+    if (this.state === "closed" || this.state === "failed") {
+      return
+    }
+    this.state = "failed"
+    for (const pending of this.pending.values()) {
+      pending.reject(error)
+    }
+    this.pending.clear()
+    this.dispose()
+  }
+
+  private dispose(): void {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    this.handle.worker.removeEventListener("message", this.handleMessage)
+    this.handle.worker.removeEventListener("error", this.handleWorkerFailure)
+    this.handle.worker.removeEventListener(
+      "messageerror",
+      this.handleWorkerFailure
+    )
+    this.handle.worker.terminate()
+    this.handle.dispose()
+  }
+}
+
+export const openStorage = async (
+  buffer: ArrayBuffer,
+  workerFactory: StorageWorkerFactory,
+  sqliteWasm?: SQLiteWasmSource
+): Promise<StorageWorkerClient> => {
+  return StorageWorkerClient.open(buffer, workerFactory, sqliteWasm)
+}

--- a/tslib/storage/src/worker_client.ts
+++ b/tslib/storage/src/worker_client.ts
@@ -1,9 +1,25 @@
+// @optuna/storage has three entry points, one per execution context:
+//
+//   - `@optuna/storage` (index.ts): the storage backends themselves. Importing
+//     it pulls the sqlite-wasm glue into the bundle, so it belongs in the
+//     Worker, or in a consumer that knowingly parses storages on its own
+//     thread.
+//   - `@optuna/storage/worker-client` (worker_client.ts): the client that talks
+//     to the storage Worker. It runs on the UI thread and has no runtime
+//     dependency of its own.
+//   - storage_worker.ts: the Worker entry. It is not part of `exports` because
+//     a Worker is not imported but pointed at: the app hands its path to the
+//     bundler, as `new URL(..., import.meta.url)` for Vite or as an entry point
+//     for webpack.
+//
+// This file is the second: the UI thread client.
+
 import type * as Optuna from "@optuna/types"
 import type { OptunaStorage } from "./storage"
 import type {
   OpenStorageResult,
   StorageWorkerRequest,
-  StorageWorkerRequestOf,
+  StorageWorkerRequestBody,
   StorageWorkerRequestType,
   StorageWorkerResponse,
   StorageWorkerResultMap,
@@ -199,7 +215,7 @@ export class StorageWorkerClient implements OptunaStorage {
   }
 
   private request<K extends StorageWorkerRequestType>(
-    request: StorageWorkerRequestOf<K>,
+    request: Extract<StorageWorkerRequestBody, { type: K }>,
     transfer: Transferable[] = []
   ): Promise<StorageWorkerResultMap[K]> {
     if (this.state === "closed" || this.state === "failed") {

--- a/tslib/storage/src/worker_protocol.ts
+++ b/tslib/storage/src/worker_protocol.ts
@@ -10,7 +10,7 @@ export type OpenStorageResult = {
   warnings: StorageWarning[]
 }
 
-export type StorageWorkerRequestWithoutId =
+export type StorageWorkerRequestBody =
   | {
       type: "open"
       buffer: ArrayBuffer
@@ -21,14 +21,13 @@ export type StorageWorkerRequestWithoutId =
   | { type: "getStudy"; studyId: number }
   | { type: "close" }
 
-export type StorageWorkerRequest = StorageWorkerRequestWithoutId & {
+// The body plus its correlation ID. The two are separate types because Omit<>
+// over a discriminated union collapses it into a single object type.
+export type StorageWorkerRequest = StorageWorkerRequestBody & {
   id: number
 }
 
-export type StorageWorkerRequestType = StorageWorkerRequestWithoutId["type"]
-
-export type StorageWorkerRequestOf<K extends StorageWorkerRequestType> =
-  Extract<StorageWorkerRequestWithoutId, { type: K }>
+export type StorageWorkerRequestType = StorageWorkerRequestBody["type"]
 
 // The result each request answers with. Both ends derive their types from this
 // map, so adding a request type cannot leave the two sides disagreeing.

--- a/tslib/storage/src/worker_protocol.ts
+++ b/tslib/storage/src/worker_protocol.ts
@@ -1,0 +1,57 @@
+import type * as Optuna from "@optuna/types"
+
+export type StorageWarning = {
+  log: string
+  message: string
+}
+
+export type OpenStorageResult = {
+  format: "journal" | "sqlite3"
+  warnings: StorageWarning[]
+}
+
+export type StorageWorkerRequestWithoutId =
+  | {
+      type: "open"
+      buffer: ArrayBuffer
+      sqliteWasmUrl?: string
+      sqliteWasmBuffer?: ArrayBuffer
+    }
+  | { type: "getStudies" }
+  | { type: "getStudy"; studyId: number }
+  | { type: "close" }
+
+export type StorageWorkerRequest = StorageWorkerRequestWithoutId & {
+  id: number
+}
+
+export type StorageWorkerRequestType = StorageWorkerRequestWithoutId["type"]
+
+export type StorageWorkerRequestOf<K extends StorageWorkerRequestType> =
+  Extract<StorageWorkerRequestWithoutId, { type: K }>
+
+// The result each request answers with. Both ends derive their types from this
+// map, so adding a request type cannot leave the two sides disagreeing.
+export type StorageWorkerResultMap = {
+  open: OpenStorageResult
+  getStudies: Optuna.StudySummary[]
+  getStudy: Optuna.Study | null
+  close: null
+}
+
+export type StorageWorkerErrorPayload = {
+  code: string
+  message: string
+  details?: unknown
+}
+
+type SuccessResponse<K extends StorageWorkerRequestType> =
+  K extends StorageWorkerRequestType
+    ? { id: number; type: K; ok: true; result: StorageWorkerResultMap[K] }
+    : never
+
+export type StorageWorkerResponse =
+  | SuccessResponse<StorageWorkerRequestType>
+  // The type of a failed request is not narrowed: a request the Worker does not
+  // know about is reported back with the type it was sent with.
+  | { id: number; type: string; ok: false; error: StorageWorkerErrorPayload }

--- a/tslib/storage/test/storage_worker.test.mjs
+++ b/tslib/storage/test/storage_worker.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict"
+import { readFile } from "node:fs/promises"
+import { describe, it } from "node:test"
+import { Worker as NodeWorker } from "node:worker_threads"
+
+import { StorageWorkerClient } from "../pkg/worker_client.js"
+
+const workerModuleUrl = new URL("../pkg/storage_worker.js", import.meta.url)
+const sqliteAssetUrl = new URL("./asset/db.sqlite3", import.meta.url)
+const journalAssetUrl = new URL("./asset/journal.log", import.meta.url)
+const sqliteWasmUrl = new URL(
+  "../node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm",
+  import.meta.url
+)
+
+class WorkerAdapter extends EventTarget {
+  constructor(worker) {
+    super()
+    this.worker = worker
+    worker.on("message", (data) => {
+      const event = new Event("message")
+      Object.defineProperty(event, "data", { value: data })
+      this.dispatchEvent(event)
+    })
+    worker.on("error", (error) => {
+      const event = new Event("error")
+      Object.defineProperty(event, "message", { value: error.message })
+      this.dispatchEvent(event)
+    })
+    worker.on("messageerror", () => {
+      this.dispatchEvent(new Event("messageerror"))
+    })
+  }
+
+  postMessage(message, transfer) {
+    this.worker.postMessage(message, transfer)
+  }
+
+  terminate() {
+    void this.worker.terminate()
+  }
+}
+
+const createWorkerFactory = () => async () => {
+  const worker = new NodeWorker(
+    `
+      import { parentPort } from "node:worker_threads"
+      globalThis.self = globalThis
+      globalThis.postMessage = (message) => parentPort.postMessage(message)
+      parentPort.on("message", (message) => globalThis.onmessage({ data: message }))
+      await import(${JSON.stringify(workerModuleUrl.href)})
+    `,
+    { eval: true, type: "module" }
+  )
+  const adapter = new WorkerAdapter(worker)
+  return { worker: adapter, dispose: () => {} }
+}
+
+const readAsset = async (url) => {
+  const bytes = await readFile(url)
+  return Uint8Array.from(bytes).buffer
+}
+
+describe("storage worker", () => {
+  it("opens Journal storage in the common worker", async () => {
+    const storage = await StorageWorkerClient.open(
+      await readAsset(journalAssetUrl),
+      createWorkerFactory()
+    )
+    try {
+      const studies = await storage.getStudies()
+      assert.equal(studies.length, 6)
+      assert.equal(
+        (await storage.getStudy(studies[0].id))?.name,
+        studies[0].name
+      )
+    } finally {
+      await storage.close()
+    }
+  })
+
+  it("opens SQLite storage with a transferred wasm binary", async () => {
+    const storage = await StorageWorkerClient.open(
+      await readAsset(sqliteAssetUrl),
+      createWorkerFactory(),
+      { buffer: await readAsset(sqliteWasmUrl) }
+    )
+    try {
+      const studies = await storage.getStudies()
+      assert.equal(studies.length, 6)
+      const study = await storage.getStudy(studies[0].id)
+      assert.ok(study)
+      assert.equal(study.name, studies[0].name)
+    } finally {
+      await storage.close()
+    }
+  })
+
+  it("answers an unsupported request instead of leaving it pending", async () => {
+    const { worker, dispose } = await createWorkerFactory()()
+    try {
+      const response = await new Promise((resolve) => {
+        worker.addEventListener("message", (event) => resolve(event.data), {
+          once: true,
+        })
+        worker.postMessage({ id: 7, type: "bogus" }, [])
+      })
+      assert.equal(response.id, 7)
+      assert.equal(response.ok, false)
+      assert.equal(response.error.code, "unsupported_request")
+    } finally {
+      worker.terminate()
+      dispose()
+    }
+  })
+
+  it("reports a missing SQLite wasm asset after transferring the database", async () => {
+    await assert.rejects(
+      StorageWorkerClient.open(
+        await readAsset(sqliteAssetUrl),
+        createWorkerFactory()
+      ),
+      { code: "missing_sqlite_wasm" }
+    )
+  })
+})

--- a/tslib/storage/test/worker_client.test.mjs
+++ b/tslib/storage/test/worker_client.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { StorageWorkerClient } from "../pkg/worker_client.js"
+
+class FakeWorker extends EventTarget {
+  heldRequests = []
+  lastTransfer = []
+  terminated = false
+
+  postMessage(message, transfer) {
+    this.lastTransfer = transfer
+    if (message.type === "open") {
+      this.emitMessage({
+        id: message.id,
+        type: message.type,
+        ok: true,
+        result: { format: "journal", warnings: [] },
+      })
+      return
+    }
+    if (message.type === "getStudies") {
+      this.heldRequests.push(message)
+      return
+    }
+    if (message.type === "getStudy") {
+      this.emitMessage({
+        id: message.id,
+        type: message.type,
+        ok: true,
+        result: {
+          id: message.studyId,
+          name: "study",
+          directions: ["minimize"],
+        },
+      })
+      return
+    }
+    this.emitMessage({
+      id: message.id,
+      type: message.type,
+      ok: true,
+      result: null,
+    })
+  }
+
+  terminate() {
+    this.terminated = true
+  }
+
+  emitMessage(data) {
+    queueMicrotask(() => {
+      const event = new Event("message")
+      Object.defineProperty(event, "data", { value: data })
+      this.dispatchEvent(event)
+    })
+  }
+}
+
+describe("StorageWorkerClient", () => {
+  it("matches responses by request ID and transfers the input buffer", async () => {
+    const worker = new FakeWorker()
+    const buffer = new ArrayBuffer(4)
+    let disposed = false
+    const storage = await StorageWorkerClient.open(buffer, async () => ({
+      worker,
+      dispose: () => {
+        disposed = true
+      },
+    }))
+
+    assert.strictEqual(worker.lastTransfer[0], buffer)
+    assert.deepStrictEqual(await storage.getStudy(42), {
+      id: 42,
+      name: "study",
+      directions: ["minimize"],
+    })
+
+    await storage.close()
+    await storage.close()
+    assert.strictEqual(worker.terminated, true)
+    assert.strictEqual(disposed, true)
+    await assert.rejects(storage.getStudies(), { code: "invalid_state" })
+  })
+
+  it("rejects pending requests when the worker fails", async () => {
+    const worker = new FakeWorker()
+    const storage = await StorageWorkerClient.open(
+      new ArrayBuffer(1),
+      async () => ({
+        worker,
+        dispose: () => {},
+      })
+    )
+    const studiesPromise = storage.getStudies()
+    await new Promise((resolve) => queueMicrotask(resolve))
+
+    worker.dispatchEvent(new Event("error"))
+
+    await assert.rejects(studiesPromise, { code: "worker_failed" })
+    await assert.rejects(storage.getStudies(), { code: "invalid_state" })
+  })
+
+  it("rejects a response that answers another request type", async () => {
+    const worker = new FakeWorker()
+    const storage = await StorageWorkerClient.open(
+      new ArrayBuffer(1),
+      async () => ({
+        worker,
+        dispose: () => {},
+      })
+    )
+    const studiesPromise = storage.getStudies()
+    await new Promise((resolve) => queueMicrotask(resolve))
+
+    const held = worker.heldRequests.pop()
+    worker.emitMessage({
+      id: held.id,
+      type: "getStudy",
+      ok: true,
+      result: null,
+    })
+
+    await assert.rejects(studiesPromise, { code: "protocol_mismatch" })
+  })
+})


### PR DESCRIPTION
## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Follow-up of #1319. First step of moving SQLite / Journal parsing off the UI thread.

## What does this implement/fix? Explain your changes.

`SQLite3Storage` and `JournalFileStorage` run entirely in the caller's context:
sqlite-wasm initialization, `sqlite3_deserialize()`, every query, the UTF-8 decode and JSON parse of a whole Journal file, and the replay that rebuilds the Optuna objects. In the standalone app and in the VS Code Webview that caller is the UI thread, so selecting a large storage file freezes the page until parsing finishes.

This PR adds the pieces needed to run that work in a Web Worker. **Nothing calls them yet**.

### `OptunaStorage.close()`

Nothing releases a storage today: selecting another file in the standalone app replaces a React state reference and leaves the SQLite connection and the parsed Journal model behind.

A Worker session has to be endable, so the interface gains `close()` and both backends implement it. It is idempotent and does not fail, including after a failed open.

### An explicit sqlite-wasm source

`SQLite3Storage` relied on the URL sqlite-wasm derives from `import.meta.url`, which does not survive bundling into a Worker: a Worker started from a `blob:` URL cannot resolve anything relative to itself.

The constructor now takes the wasm as a URL or as bytes, `locateFile` is always set so the fallback is never evaluated, and a failed initialization closes the half-open database instead of leaking it.

The initializer is imported from the dependency's bundler-friendly entrypoint rather than its package entrypoint, which would pull in the optional Worker API this dashboard does not use.

### The Worker and its client

`storage_worker.ts` owns one storage session. It detects the format from the first bytes of the transferred buffer, so callers no longer decide which backend to build, and answers `getStudies()` / `getStudy()` / `close()`. Backend errors cross the boundary as structured errors rather than exception objects.

`StorageWorkerClient` implements `OptunaStorage`, so a UI can use it like any other storage. It takes the Worker through a factory, because how a Worker is started differs per platform — a module Worker where the bundler supports one, a `blob:` URL in a VS Code Webview — and the factory returns a `dispose()` so the client releases whatever the platform allocated. The storage buffer is transferred, not copied.

Request and response types are derived from a single request-type-to-result map, responses carry the request type so a mismatch is reported instead of being handed to the caller as the wrong shape, and an unknown request is answered with an error rather than leaving the caller's promise pending forever.

### Tests

* `worker_client.test.mjs` drives the client against a fake Worker: request ID matching, buffer transfer, double close, terminate, rejecting everything pending when the Worker fails, and rejecting a response that answers a different request type.
* `storage_worker.test.mjs` runs the real Worker on `node:worker_threads` with the existing fixtures: opening both formats, study summaries and details, transferring the wasm binary, an unsupported request, and a missing wasm asset.

### Follow-ups (not in this PR)

* the standalone app opening storages through the Worker
* the VS Code Webview doing the same, plus the asset plumbing its Webview needs
* surfacing the Journal parse warnings that `OpenStorageResult` already carries