### PR TITLE
Load storages in the storage Worker in the standalone app

### DIFF
--- a/standalone_app/src/browser_app_entry.tsx
+++ b/standalone_app/src/browser_app_entry.tsx
@@ -1,12 +1,28 @@
+import sqliteWasmUrl from "@optuna/storage/sqlite-wasm"
+import type { StorageWorkerFactory } from "@optuna/storage/worker-client"
 import React from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./components/App"
 import { StorageProvider } from "./components/StorageProvider"
 import "./index.css"
 
+const workerFactory: StorageWorkerFactory = async () => {
+  const worker = new Worker(
+    new URL("../../tslib/storage/src/storage_worker.ts", import.meta.url),
+    { type: "module" }
+  )
+  return {
+    worker,
+    dispose: () => {},
+  }
+}
+
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <StorageProvider>
+    <StorageProvider
+      workerFactory={workerFactory}
+      sqliteWasm={{ url: sqliteWasmUrl }}
+    >
       <App />
     </StorageProvider>
   </React.StrictMode>

--- a/standalone_app/src/components/App.tsx
+++ b/standalone_app/src/components/App.tsx
@@ -11,6 +11,7 @@ import { SnackbarProvider } from "notistack"
 import { FC, useEffect, useMemo, useState } from "react"
 import { HashRouter as Router, Route, Routes } from "react-router-dom"
 
+import { StorageErrorNotifier } from "./StorageErrorNotifier"
 import { StudyDetail } from "./StudyDetail"
 import { StudyList } from "./StudyList"
 
@@ -42,6 +43,7 @@ export const App: FC = () => {
       <CssBaseline />
       <Box>
         <SnackbarProvider maxSnack={3}>
+          <StorageErrorNotifier />
           <Router>
             <Routes>
               <Route

--- a/standalone_app/src/components/StorageErrorNotifier.tsx
+++ b/standalone_app/src/components/StorageErrorNotifier.tsx
@@ -1,0 +1,21 @@
+import { useSnackbar } from "notistack"
+import { FC, useContext, useEffect } from "react"
+import { StorageContext } from "./StorageProvider"
+
+// Storage failures used to be visible only while the loader was on screen, so a
+// query that failed after the storage had opened, or anything at all in the VS
+// Code Webview where the loader is never rendered, left the page empty without
+// telling why.
+export const StorageErrorNotifier: FC = () => {
+  const { error } = useContext(StorageContext)
+  const { enqueueSnackbar } = useSnackbar()
+
+  useEffect(() => {
+    if (error === null) {
+      return
+    }
+    enqueueSnackbar(error.message, { variant: "error" })
+  }, [enqueueSnackbar, error])
+
+  return null
+}

--- a/standalone_app/src/components/StorageLoader.tsx
+++ b/standalone_app/src/components/StorageLoader.tsx
@@ -25,7 +25,7 @@ export const StorageLoader: FC = () => {
   const inputRef = useRef<HTMLInputElement>(null)
 
   const loadStorageFromFile = async (file: File): Promise<void> => {
-    await loadStorage(await file.arrayBuffer())
+    await loadStorage(await file.arrayBuffer(), { name: file.name })
   }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/standalone_app/src/components/StorageLoader.tsx
+++ b/standalone_app/src/components/StorageLoader.tsx
@@ -15,35 +15,33 @@ import {
   useRef,
   useState,
 } from "react"
-import { StorageContext, getStorage } from "./StorageProvider"
+import { StorageContext } from "./StorageProvider"
 
 export const StorageLoader: FC = () => {
   const theme = useTheme()
   const [dragOver, setDragOver] = useState<boolean>(false)
-  const { setStorage } = useContext(StorageContext)
+  const { loadStorage, loading, error } = useContext(StorageContext)
 
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const loadStorageFromFile = (file: File): void => {
-    const r = new FileReader()
-    r.addEventListener("load", () => {
-      const arrayBuffer = r.result as ArrayBuffer | null
-      if (arrayBuffer !== null) {
-        const s = getStorage(arrayBuffer)
-        setStorage(s)
-      }
-    })
-    r.readAsArrayBuffer(file)
+  const loadStorageFromFile = async (file: File): Promise<void> => {
+    await loadStorage(await file.arrayBuffer())
   }
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (loading) {
+      return
+    }
     const f = e.target.files?.[0]
     if (!f) {
       return
     }
-    loadStorageFromFile(f)
+    void loadStorageFromFile(f)
   }
   const handleClick: MouseEventHandler = () => {
+    if (loading) {
+      return
+    }
     if (!inputRef || !inputRef.current) {
       return
     }
@@ -52,12 +50,15 @@ export const StorageLoader: FC = () => {
   const handleDrop: DragEventHandler = (e) => {
     e.stopPropagation()
     e.preventDefault()
+    if (loading) {
+      return
+    }
     const file = e.dataTransfer.files?.[0]
     setDragOver(false)
     if (!file) {
       return
     }
-    loadStorageFromFile(file)
+    void loadStorageFromFile(file)
   }
   const handleDragOver: DragEventHandler = (e) => {
     e.stopPropagation()
@@ -84,7 +85,7 @@ export const StorageLoader: FC = () => {
       onDragLeave={handleDragLeave}
       onDrop={handleDrop}
     >
-      <CardActionArea onClick={handleClick}>
+      <CardActionArea onClick={handleClick} disabled={loading}>
         <CardContent
           sx={{
             display: "flex",
@@ -104,12 +105,17 @@ export const StorageLoader: FC = () => {
             onChange={handleFileChange}
             style={{ display: "none" }}
           />
-          <Typography>Load an Optuna Storage</Typography>
+          <Typography>
+            {loading ? "Loading an Optuna Storage" : "Load an Optuna Storage"}
+          </Typography>
           <Typography
             sx={{ textAlign: "center", color: theme.palette.grey.A400 }}
           >
             Drag your SQLite3/JournalStorage file here or click to browse.
           </Typography>
+          {error !== null && (
+            <Typography color="error">{error.message}</Typography>
+          )}
         </CardContent>
       </CardActionArea>
     </Card>

--- a/standalone_app/src/components/StorageProvider.tsx
+++ b/standalone_app/src/components/StorageProvider.tsx
@@ -1,31 +1,187 @@
-import { JournalFileStorage } from "@optuna/storage"
-import { SQLite3Storage } from "@optuna/storage"
-import type { OptunaStorage } from "@optuna/storage"
-import React, { FC, createContext, useState } from "react"
+import {
+  type OptunaStorage,
+  type SQLiteWasmSource,
+  type StorageWorkerFactory,
+  openStorage,
+} from "@optuna/storage/worker-client"
+import React, {
+  FC,
+  createContext,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+export type StorageOpenOptions = {
+  workerFactory?: StorageWorkerFactory
+  sqliteWasm?: SQLiteWasmSource
+}
 
 export const StorageContext = createContext<{
   storage: OptunaStorage | null
+  loadStorage: (
+    arrayBuffer: ArrayBuffer,
+    options?: StorageOpenOptions
+  ) => Promise<void>
+  closeStorage: () => Promise<void>
+  loading: boolean
+  error: Error | null
+  reportError: (error: unknown) => void
+  // Transitional: the VS Code Webview still builds a backend on the UI thread
+  // and hands it over, because its Worker needs asset plumbing that the Webview
+  // build does not have yet. It goes away once the Webview opens storages the
+  // way the standalone app now does.
   setStorage: (storage: OptunaStorage) => void
 }>({
   storage: null,
+  loadStorage: async () => {},
+  closeStorage: async () => {},
+  loading: false,
+  error: null,
+  reportError: () => {},
   setStorage: () => {},
 })
 
-export const getStorage = (arrayBuffer: ArrayBuffer): OptunaStorage => {
-  const header = new Uint8Array(arrayBuffer, 0, 16)
-  const headerString = new TextDecoder().decode(header)
-  if (headerString === "SQLite format 3\u0000") {
-    return new SQLite3Storage(arrayBuffer)
-  }
-  return new JournalFileStorage(arrayBuffer)
+// A viewer owns at most one storage session at a time. The session is kept in a
+// ref because every transition has to read the current one without waiting for
+// a re-render: a second drop must be rejected before React commits `loading`.
+//
+// `generation` invalidates work in flight. Closing, unmounting, or starting
+// another load bumps it, and a load that finds its generation stale closes the
+// storage it just opened instead of publishing it.
+type StorageSession = {
+  generation: number
+  storage: OptunaStorage | null
+  loading: boolean
 }
 
 export const StorageProvider: FC<{
   children: React.ReactNode
-}> = ({ children }) => {
-  const [storage, setStorage] = useState<OptunaStorage | null>(null)
+  workerFactory?: StorageWorkerFactory
+  sqliteWasm?: SQLiteWasmSource
+}> = ({ children, workerFactory, sqliteWasm }) => {
+  const [storage, setActiveStorage] = useState<OptunaStorage | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const sessionRef = useRef<StorageSession>({
+    generation: 0,
+    storage: null,
+    loading: false,
+  })
+
+  const reportError = useCallback((loadError: unknown) => {
+    const normalizedError =
+      loadError instanceof Error
+        ? loadError
+        : new Error("Storage request failed")
+    // StorageErrorNotifier only shows the message; keep the original error
+    // around for the Webview developer tools.
+    console.error("Optuna storage error", loadError)
+    setError(normalizedError)
+  }, [])
+
+  const closeStorage = useCallback(async () => {
+    const session = sessionRef.current
+    session.generation += 1
+    const currentStorage = session.storage
+    session.storage = null
+    setActiveStorage(null)
+    setLoading(false)
+    setError(null)
+    if (currentStorage !== null) {
+      try {
+        await currentStorage.close()
+      } catch (closeError) {
+        reportError(closeError)
+      }
+    }
+  }, [reportError])
+
+  const loadStorage = useCallback(
+    async (arrayBuffer: ArrayBuffer, options: StorageOpenOptions = {}) => {
+      const session = sessionRef.current
+      if (session.loading) {
+        return
+      }
+      if (session.storage !== null) {
+        reportError(new Error("Storage is already open"))
+        return
+      }
+
+      session.loading = true
+      const generation = ++session.generation
+      setLoading(true)
+      setError(null)
+      try {
+        const factory = options.workerFactory ?? workerFactory
+        if (factory === undefined) {
+          throw new Error("A storage worker factory is required")
+        }
+        const nextStorage = await openStorage(
+          arrayBuffer,
+          factory,
+          options.sqliteWasm ?? sqliteWasm
+        )
+
+        if (generation !== session.generation) {
+          await nextStorage.close()
+          return
+        }
+
+        session.storage = nextStorage
+        setActiveStorage(nextStorage)
+      } catch (loadError) {
+        if (generation === session.generation) {
+          reportError(loadError)
+        }
+      } finally {
+        session.loading = false
+        if (generation === session.generation) {
+          setLoading(false)
+        }
+      }
+    },
+    [reportError, sqliteWasm, workerFactory]
+  )
+
+  const setStorage = useCallback((nextStorage: OptunaStorage) => {
+    const session = sessionRef.current
+    session.generation += 1
+    const currentStorage = session.storage
+    session.storage = nextStorage
+    setActiveStorage(nextStorage)
+    setError(null)
+    if (currentStorage !== null) {
+      void currentStorage.close().catch(() => {})
+    }
+  }, [])
+
+  useEffect(() => {
+    const session = sessionRef.current
+    return () => {
+      session.generation += 1
+      session.loading = false
+      const currentStorage = session.storage
+      session.storage = null
+      if (currentStorage !== null) {
+        void currentStorage.close().catch(() => {})
+      }
+    }
+  }, [])
+
   return (
-    <StorageContext.Provider value={{ storage, setStorage }}>
+    <StorageContext.Provider
+      value={{
+        storage,
+        loadStorage,
+        closeStorage,
+        loading,
+        error,
+        reportError,
+        setStorage,
+      }}
+    >
       {children}
     </StorageContext.Provider>
   )

--- a/standalone_app/src/components/StorageProvider.tsx
+++ b/standalone_app/src/components/StorageProvider.tsx
@@ -14,12 +14,16 @@ import React, {
 } from "react"
 
 export type StorageOpenOptions = {
+  // Shown next to the button that closes this storage, so that the UI can say
+  // which file it is holding.
+  name?: string
   workerFactory?: StorageWorkerFactory
   sqliteWasm?: SQLiteWasmSource
 }
 
 export const StorageContext = createContext<{
   storage: OptunaStorage | null
+  storageName: string | null
   loadStorage: (
     arrayBuffer: ArrayBuffer,
     options?: StorageOpenOptions
@@ -35,6 +39,7 @@ export const StorageContext = createContext<{
   setStorage: (storage: OptunaStorage) => void
 }>({
   storage: null,
+  storageName: null,
   loadStorage: async () => {},
   closeStorage: async () => {},
   loading: false,
@@ -62,6 +67,7 @@ export const StorageProvider: FC<{
   sqliteWasm?: SQLiteWasmSource
 }> = ({ children, workerFactory, sqliteWasm }) => {
   const [storage, setActiveStorage] = useState<OptunaStorage | null>(null)
+  const [storageName, setStorageName] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<Error | null>(null)
   const sessionRef = useRef<StorageSession>({
@@ -87,6 +93,7 @@ export const StorageProvider: FC<{
     const currentStorage = session.storage
     session.storage = null
     setActiveStorage(null)
+    setStorageName(null)
     setLoading(false)
     setError(null)
     if (currentStorage !== null) {
@@ -131,6 +138,7 @@ export const StorageProvider: FC<{
 
         session.storage = nextStorage
         setActiveStorage(nextStorage)
+        setStorageName(options.name ?? null)
       } catch (loadError) {
         if (generation === session.generation) {
           reportError(loadError)
@@ -151,6 +159,7 @@ export const StorageProvider: FC<{
     const currentStorage = session.storage
     session.storage = nextStorage
     setActiveStorage(nextStorage)
+    setStorageName(null)
     setError(null)
     if (currentStorage !== null) {
       void currentStorage.close().catch(() => {})
@@ -174,6 +183,7 @@ export const StorageProvider: FC<{
     <StorageContext.Provider
       value={{
         storage,
+        storageName,
         loadStorage,
         closeStorage,
         loading,

--- a/standalone_app/src/components/StudyDetail.tsx
+++ b/standalone_app/src/components/StudyDetail.tsx
@@ -32,18 +32,30 @@ export const StudyDetail: FC<{
   const { studyId } = useParams<{ studyId: string }>()
   const studyIdNumber = Number(studyId)
 
-  const { storage } = useContext(StorageContext)
+  const { storage, reportError } = useContext(StorageContext)
   const [study, setStudy] = useState<Optuna.Study | null>(null)
   useEffect(() => {
+    let active = true
     const fetchStudy = async () => {
       if (storage === null) {
         return
       }
-      const study = await storage.getStudy(studyIdNumber)
-      setStudy(study)
+      try {
+        const study = await storage.getStudy(studyIdNumber)
+        if (active) {
+          setStudy(study)
+        }
+      } catch (error) {
+        if (active) {
+          reportError(error)
+        }
+      }
     }
-    fetchStudy()
-  }, [storage, studyIdNumber])
+    void fetchStudy()
+    return () => {
+      active = false
+    }
+  }, [reportError, storage, studyIdNumber])
 
   const [importance, setImportance] = useState<Optuna.ParamImportance[][]>([])
   const filterFunc = (trial: Optuna.Trial, objectiveId: number): boolean => {

--- a/standalone_app/src/components/StudyList.tsx
+++ b/standalone_app/src/components/StudyList.tsx
@@ -1,6 +1,7 @@
 import { Search } from "@mui/icons-material"
 import Brightness4Icon from "@mui/icons-material/Brightness4"
 import Brightness7Icon from "@mui/icons-material/Brightness7"
+import CloseIcon from "@mui/icons-material/Close"
 import SortIcon from "@mui/icons-material/Sort"
 import {
   AppBar,
@@ -36,22 +37,35 @@ export const StudyList: FC<{
   toggleColorMode: () => void
 }> = ({ toggleColorMode }) => {
   const theme = useTheme()
-  const { storage } = useContext(StorageContext)
+  const { storage, closeStorage, reportError } = useContext(StorageContext)
   const [studies, setStudies] = useState<Optuna.StudySummary[]>([])
 
   const [_studyFilterText, setStudyFilterText] = useState<string>("")
   const [sortBy, setSortBy] = useState<"id-asc" | "id-desc">("id-asc")
   const studyFilterText = useDeferredValue(_studyFilterText)
   useEffect(() => {
+    let active = true
     const fetchStudies = async () => {
       if (storage === null) {
+        setStudies([])
         return
       }
-      const studies = await storage.getStudies()
-      setStudies(studies)
+      try {
+        const studies = await storage.getStudies()
+        if (active) {
+          setStudies(studies)
+        }
+      } catch (error) {
+        if (active) {
+          reportError(error)
+        }
+      }
     }
-    fetchStudies()
-  }, [storage])
+    void fetchStudies()
+    return () => {
+      active = false
+    }
+  }, [reportError, storage])
   const filteredStudies = useMemo(() => {
     const studyFilter = (row: Optuna.StudySummary): boolean => {
       const keywords = studyFilterText.split(" ")
@@ -124,6 +138,17 @@ export const StudyList: FC<{
           <Toolbar>
             <Typography variant="h6">Optuna Dashboard (Wasm ver.)</Typography>
             <Box sx={{ flexGrow: 1 }} />
+            {!IS_VSCODE && storage !== null && (
+              <IconButton
+                onClick={() => {
+                  void closeStorage()
+                }}
+                color="inherit"
+                title="Close the current storage file"
+              >
+                <CloseIcon />
+              </IconButton>
+            )}
             <IconButton
               onClick={() => {
                 toggleColorMode()
@@ -203,7 +228,7 @@ export const StudyList: FC<{
             </Card>
           ))}
         </Box>
-        {!IS_VSCODE && <StorageLoader />}
+        {!IS_VSCODE && storage === null && <StorageLoader />}
       </Container>
     </div>
   )

--- a/standalone_app/src/components/StudyList.tsx
+++ b/standalone_app/src/components/StudyList.tsx
@@ -1,7 +1,6 @@
 import { Search } from "@mui/icons-material"
 import Brightness4Icon from "@mui/icons-material/Brightness4"
 import Brightness7Icon from "@mui/icons-material/Brightness7"
-import CloseIcon from "@mui/icons-material/Close"
 import SortIcon from "@mui/icons-material/Sort"
 import {
   AppBar,
@@ -9,6 +8,7 @@ import {
   Card,
   CardActionArea,
   CardContent,
+  Chip,
   Container,
   IconButton,
   InputAdornment,
@@ -16,6 +16,7 @@ import {
   SvgIcon,
   TextField,
   Toolbar,
+  Tooltip,
   Typography,
   useTheme,
 } from "@mui/material"
@@ -37,7 +38,8 @@ export const StudyList: FC<{
   toggleColorMode: () => void
 }> = ({ toggleColorMode }) => {
   const theme = useTheme()
-  const { storage, closeStorage, reportError } = useContext(StorageContext)
+  const { storage, storageName, closeStorage, reportError } =
+    useContext(StorageContext)
   const [studies, setStudies] = useState<Optuna.StudySummary[]>([])
 
   const [_studyFilterText, setStudyFilterText] = useState<string>("")
@@ -138,16 +140,29 @@ export const StudyList: FC<{
           <Toolbar>
             <Typography variant="h6">Optuna Dashboard (Wasm ver.)</Typography>
             <Box sx={{ flexGrow: 1 }} />
-            {!IS_VSCODE && storage !== null && (
-              <IconButton
-                onClick={() => {
-                  void closeStorage()
-                }}
-                color="inherit"
-                title="Close the current storage file"
-              >
-                <CloseIcon />
-              </IconButton>
+            {!IS_VSCODE && storageName !== null && (
+              // Says which file the studies below come from, and closing it is
+              // how another file is opened: the loader comes back with it.
+              <Tooltip title="Close this file">
+                <Chip
+                  label={storageName}
+                  variant="outlined"
+                  onDelete={() => {
+                    void closeStorage()
+                  }}
+                  sx={{
+                    marginRight: theme.spacing(1),
+                    maxWidth: "16rem",
+                    color: "inherit",
+                    borderColor: "currentColor",
+                    "& .MuiChip-deleteIcon": {
+                      color: "inherit",
+                      opacity: 0.7,
+                      "&:hover": { opacity: 1 },
+                    },
+                  }}
+                />
+              </Tooltip>
             )}
             <IconButton
               onClick={() => {

--- a/standalone_app/src/vscode_entry.tsx
+++ b/standalone_app/src/vscode_entry.tsx
@@ -1,11 +1,9 @@
+import { JournalFileStorage, SQLite3Storage } from "@optuna/storage"
+import type { OptunaStorage } from "@optuna/storage"
 import React, { FC, useEffect, useContext } from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./components/App"
-import {
-  StorageContext,
-  StorageProvider,
-  getStorage,
-} from "./components/StorageProvider"
+import { StorageContext, StorageProvider } from "./components/StorageProvider"
 import "./index.css"
 
 type WebviewMessage = {
@@ -31,6 +29,19 @@ export const AppWrapper: FC = () => {
     return () => window.removeEventListener("message", handleMessage)
   }, [])
   return <App />
+}
+
+// Transitional: the Webview parses the storage on the UI thread, as it did
+// before the standalone app moved to the storage Worker. Starting the Worker
+// here needs the Webview build to emit it as an asset the Webview may load,
+// which is the next change.
+const getStorage = (arrayBuffer: ArrayBuffer): OptunaStorage => {
+  const header = new Uint8Array(arrayBuffer, 0, 16)
+  const headerString = new TextDecoder().decode(header)
+  if (headerString === "SQLite format 3\u0000") {
+    return new SQLite3Storage(arrayBuffer)
+  }
+  return new JournalFileStorage(arrayBuffer)
 }
 
 const toArrayBuffer = (content: Uint8Array): ArrayBuffer => {

--- a/tslib/storage/package.json
+++ b/tslib/storage/package.json
@@ -13,6 +13,10 @@
     "./worker-client": {
       "types": "./pkg/worker_client.d.ts",
       "import": "./pkg/worker_client.js"
+    },
+    "./sqlite-wasm": {
+      "types": "./pkg/sqlite_wasm.d.ts",
+      "import": "./pkg/sqlite_wasm.js"
     }
   },
   "scripts": {

--- a/tslib/storage/src/journal.ts
+++ b/tslib/storage/src/journal.ts
@@ -408,12 +408,14 @@ const loadJournalStorage = (
 ): {
   studies: Optuna.Study[]
   errors: { log: string; message: string }[]
+  appliedRecords: number
 } => {
   const decoder = new TextDecoder("utf-8")
   const logs = decoder.decode(arrayBuffer).split("\n")
 
   const journalStorage = new JournalStorage()
   const errors: { log: string; message: string }[] = []
+  let appliedRecords = 0
 
   for (const log of logs) {
     if (log === "") {
@@ -455,6 +457,12 @@ const loadJournalStorage = (
 
     if (parsedLog === undefined) {
       continue
+    }
+
+    // Counted so that a caller can tell a storage with no study from a file
+    // that is not a storage at all.
+    if (parsedLog.op_code in JournalOperation) {
+      appliedRecords++
     }
 
     switch (parsedLog.op_code) {
@@ -504,17 +512,25 @@ const loadJournalStorage = (
   return {
     studies: journalStorage.getStudies(),
     errors,
+    appliedRecords,
   }
 }
 
 export class JournalFileStorage implements OptunaStorage {
   studies: Optuna.Study[]
   errors: { log: string; message: string }[]
+  // How many lines were understood as Journal records, whether or not they left
+  // a study behind. Zero means this file is not a Journal storage.
+  appliedRecords: number
   constructor(arrayBuffer: ArrayBuffer) {
-    const { studies: studiesFromStorage, errors: errorsFromStorage } =
-      loadJournalStorage(arrayBuffer)
+    const {
+      studies: studiesFromStorage,
+      errors: errorsFromStorage,
+      appliedRecords,
+    } = loadJournalStorage(arrayBuffer)
     this.studies = studiesFromStorage
     this.errors = errorsFromStorage
+    this.appliedRecords = appliedRecords
   }
   getStudies = async (): Promise<Optuna.StudySummary[]> => {
     return this.studies

--- a/tslib/storage/src/sqlite.ts
+++ b/tslib/storage/src/sqlite.ts
@@ -136,6 +136,23 @@ export class SQLite3Storage implements OptunaStorage {
     await this.db
   }
 
+  // Whether this database is an Optuna storage at all. Any SQLite file
+  // deserializes, so a database that Optuna never wrote would open here and only
+  // fail on the first query.
+  hasOptunaSchema = async (): Promise<boolean> => {
+    const db = await this.db
+    let tables = 0
+    db.exec({
+      sql:
+        "SELECT name FROM sqlite_master WHERE type = 'table'" +
+        " AND name IN ('studies', 'alembic_version')",
+      callback: () => {
+        tables++
+      },
+    })
+    return tables === 2
+  }
+
   getStudies = async (): Promise<Optuna.StudySummary[]> => {
     if (this.closed) {
       throw new Error("Storage is closed")

--- a/tslib/storage/src/sqlite_wasm.ts
+++ b/tslib/storage/src/sqlite_wasm.ts
@@ -1,0 +1,7 @@
+// Deep import for the same reason as sqlite_init.ts: the dependency exports
+// only ".", and the specifier assumes src/ and pkg/ are at the same depth.
+// Resolved by the bundler, so this entrypoint is only usable from a build that
+// understands `?url` (Vite). The VS Code build emits the asset explicitly.
+import sqliteWasmUrl from "../node_modules/@sqlite.org/sqlite-wasm/sqlite-wasm/jswasm/sqlite3.wasm?url"
+
+export default sqliteWasmUrl

--- a/tslib/storage/src/storage_worker.ts
+++ b/tslib/storage/src/storage_worker.ts
@@ -117,6 +117,12 @@ workerScope.onmessage = async (event) => {
             "Storage is already open"
           )
         }
+        // Neither format can say anything about a file with no bytes, and
+        // creating a storage does leave one behind, so name that case rather
+        // than opening it as a storage with nothing in it.
+        if (request.buffer.byteLength === 0) {
+          throw new WorkerRequestError("empty_file", "This file is empty")
+        }
         if (isSQLiteFile(request.buffer)) {
           if (
             request.sqliteWasmUrl === undefined &&
@@ -133,6 +139,12 @@ workerScope.onmessage = async (event) => {
           })
           try {
             await sqliteStorage.waitUntilReady()
+            if (!(await sqliteStorage.hasOptunaSchema())) {
+              throw new WorkerRequestError(
+                "unsupported_format",
+                "Not an Optuna storage: this SQLite database has no Optuna tables"
+              )
+            }
           } catch (error) {
             await sqliteStorage.close()
             throw error
@@ -146,10 +158,23 @@ workerScope.onmessage = async (event) => {
         }
 
         const journalStorage = new JournalFileStorage(request.buffer)
+        const warnings = journalStorage.getErrors()
+        // A Journal file is read line by line, and a line that cannot be read is
+        // collected as a warning rather than raised, which is what keeps a
+        // partially written file usable. A file that is not a storage at all
+        // would then open as an empty one, so require at least one record. A
+        // Journal storage whose studies were all deleted still has records.
+        if (journalStorage.appliedRecords === 0) {
+          throw new WorkerRequestError(
+            "unsupported_format",
+            "Not an Optuna storage: no SQLite header and no Journal record",
+            { unreadableLines: warnings.length }
+          )
+        }
         storage = journalStorage
         postResult(request.id, "open", {
           format: "journal",
-          warnings: journalStorage.getErrors(),
+          warnings,
         })
         break
       }

--- a/tslib/storage/src/wasm_url.d.ts
+++ b/tslib/storage/src/wasm_url.d.ts
@@ -1,0 +1,4 @@
+declare module "*.wasm?url" {
+  const url: string
+  export default url
+}

--- a/tslib/storage/test/storage_worker.test.mjs
+++ b/tslib/storage/test/storage_worker.test.mjs
@@ -61,6 +61,25 @@ const readAsset = async (url) => {
   return Uint8Array.from(bytes).buffer
 }
 
+// A SQLite database that Optuna never wrote, built with the same library the
+// backend uses so that it is a real one, header and page layout included.
+const createForeignSQLiteFile = async () => {
+  const { default: sqlite3InitModule } = await import("../pkg/sqlite_init.js")
+  const sqlite3 = await sqlite3InitModule({
+    print: () => {},
+    printErr: () => {},
+    wasmBinary: await readAsset(sqliteWasmUrl),
+    locateFile: (path) => path,
+  })
+  const db = new sqlite3.oo1.DB()
+  try {
+    db.exec("CREATE TABLE unrelated (a)")
+    return sqlite3.capi.sqlite3_js_db_export(db.pointer).slice().buffer
+  } finally {
+    db.close()
+  }
+}
+
 describe("storage worker", () => {
   it("opens Journal storage in the common worker", async () => {
     const storage = await StorageWorkerClient.open(
@@ -91,6 +110,63 @@ describe("storage worker", () => {
       const study = await storage.getStudy(studies[0].id)
       assert.ok(study)
       assert.equal(study.name, studies[0].name)
+    } finally {
+      await storage.close()
+    }
+  })
+
+  it("rejects a file that is neither SQLite nor a Journal", async () => {
+    for (const [label, content] of [
+      [
+        "pretty printed JSON",
+        '{\n  "formatter": {\n    "indentWidth": 2\n  }\n}\n',
+      ],
+      ["JSON on one line", '{"formatter":{"indentWidth":2}}\n'],
+      ["plain text", "hello\n"],
+    ]) {
+      await assert.rejects(
+        StorageWorkerClient.open(
+          new TextEncoder().encode(content).buffer,
+          createWorkerFactory()
+        ),
+        { code: "unsupported_format" },
+        label
+      )
+    }
+  })
+
+  it("rejects an empty file", async () => {
+    await assert.rejects(
+      StorageWorkerClient.open(new ArrayBuffer(0), createWorkerFactory()),
+      { code: "empty_file" }
+    )
+  })
+
+  it("rejects a SQLite database that Optuna never wrote", async () => {
+    await assert.rejects(
+      StorageWorkerClient.open(
+        await createForeignSQLiteFile(),
+        createWorkerFactory(),
+        { buffer: await readAsset(sqliteWasmUrl) }
+      ),
+      { code: "unsupported_format" }
+    )
+  })
+
+  it("opens a Journal storage that has no study left", async () => {
+    // Creating and deleting a study leaves records but no study, which is a
+    // storage with nothing in it rather than a file of the wrong format.
+    const content = [
+      '{"op_code": 0, "workder_id": "0", "study_name": "gone", "directions": [1]}',
+      '{"op_code": 1, "workder_id": "0", "study_id": 0}',
+      "",
+    ].join("\n")
+    const storage = await StorageWorkerClient.open(
+      new TextEncoder().encode(content).buffer,
+      createWorkerFactory()
+    )
+    try {
+      assert.deepEqual(await storage.getStudies(), [])
     } finally {
       await storage.close()
     }


### PR DESCRIPTION
## Contributor License Agreement

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs

Follow-up of #1322, which added the storage Worker and its client without any caller. This is the first caller.

## What does this implement/fix? Explain your changes.

Selecting a storage file in the standalone app blocked the page. sqlite-wasm initialization, `sqlite3_deserialize()` and every query ran on the UI thread, and a Journal file was decoded, split, JSON-parsed and replayed there as well, so nothing responded until parsing finished.

The app now reads the file with `File.arrayBuffer()` and transfers the buffer to the storage Worker, which detects the format, opens the backend and answers queries. The UI thread only sends requests and renders the results.

### Session handling

`StorageProvider` owns the session instead of holding whatever storage it was handed:

* one storage at a time, and a second file is refused while one is open, rather than silently replacing it
* the loader disappears once a storage is open, and the study list gains a button to close the current one, which is the supported way to open another file
* the storage is closed on unmount, and a load whose session was replaced while it ran closes the storage it just opened rather than publishing it
* loading and error state are tracked, so the UI can show both

### Failures are visible

A rejected storage request used to leave the page as it was, since nothing caught it and nothing rendered it. The study list and the study page now survive one, ignore a response that arrives after they stopped caring about it, and report it to a snackbar. This is the first time any of these errors are visible.

### Bundle

The UI bundle no longer contains the SQLite backend: it is only reachable from the Worker entry. `vite build` before and after:

```
before  index-*.js  5,538.73 kB │ gzip: 1,672.55 kB
after   index-*.js  5,308.73 kB │ gzip: 1,610.26 kB
        storage_worker-*.js       220.61 kB
```

### The VS Code Webview is unchanged

Starting the Worker in a Webview needs assets that the Webview build does not emit yet, so `vscode_entry.tsx` keeps parsing on the UI thread and hands the result to the provider through `setStorage()`.

The format detection moved from the provider into that entry point: left where it was, it would keep pulling the SQLite backend into the standalone bundle. Both go away in the follow-up that moves the Webview over.