### PR TITLE
Send the storage bytes to the Webview as an ArrayBuffer

### DIFF
--- a/standalone_app/src/vscode_entry.tsx
+++ b/standalone_app/src/vscode_entry.tsx
@@ -8,7 +8,7 @@ import "./index.css"
 
 type WebviewMessage = {
   type: "optunaStorage"
-  content: Uint8Array
+  content: unknown
 }
 
 export const AppWrapper: FC = () => {
@@ -44,15 +44,31 @@ const getStorage = (arrayBuffer: ArrayBuffer): OptunaStorage => {
   return new JournalFileStorage(arrayBuffer)
 }
 
-const toArrayBuffer = (content: Uint8Array): ArrayBuffer => {
-  if (
-    content.buffer instanceof ArrayBuffer &&
-    content.byteOffset === 0 &&
-    content.byteLength === content.buffer.byteLength
-  ) {
-    return content.buffer
+// The extension sends an ArrayBuffer. A typed array is accepted as well, since
+// that is what the Webview message serializer produces for one, but anything
+// else is named rather than left to fail as a missing method on an object of an
+// unexpected shape.
+const toArrayBuffer = (content: unknown): ArrayBuffer => {
+  if (content instanceof ArrayBuffer) {
+    return content
   }
-  return content.slice().buffer as ArrayBuffer
+  if (ArrayBuffer.isView(content)) {
+    const buffer = content.buffer as ArrayBuffer
+    if (content.byteOffset === 0 && content.byteLength === buffer.byteLength) {
+      return buffer
+    }
+    return buffer.slice(
+      content.byteOffset,
+      content.byteOffset + content.byteLength
+    )
+  }
+  const received =
+    content === null || typeof content !== "object"
+      ? typeof content
+      : content.constructor?.name ?? "object"
+  throw new TypeError(
+    `Storage content arrived as ${received}, expected an ArrayBuffer`
+  )
 }
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -33,10 +33,9 @@ export function activate(context: vscode.ExtensionContext) {
       const handleMessage = async (message: { type: string }) => {
         switch (message.type) {
           case "webviewDidLoad": {
-            const content = await readFile(fileUri)
             await panel.webview.postMessage({
               type: "optunaStorage",
-              content,
+              content: toArrayBuffer(await readFile(fileUri)),
             })
             break
           }
@@ -52,6 +51,26 @@ export function activate(context: vscode.ExtensionContext) {
 
 async function readFile(uri: vscode.Uri): Promise<Uint8Array> {
   return vscode.workspace.fs.readFile(uri)
+}
+
+// workspace.fs.readFile() hands back a Node Buffer in the desktop extension
+// host. The Webview message serializer recognizes a typed array by its exact
+// constructor name and passes those bytes out of band, but Buffer is not one of
+// the names it knows: it falls through to JSON.stringify(), which turns the
+// bytes into an object keyed by index. An ArrayBuffer is recognized whatever it
+// came from, so send one.
+function toArrayBuffer(content: Uint8Array): ArrayBuffer {
+  const buffer = content.buffer as ArrayBuffer
+  if (content.byteOffset === 0 && content.byteLength === buffer.byteLength) {
+    return buffer
+  }
+  // A Buffer can be a window onto a larger pooled allocation, so copy out the
+  // bytes that belong to this file. Note that Buffer.slice() would not: unlike
+  // Uint8Array.slice() it returns a view.
+  return buffer.slice(
+    content.byteOffset,
+    content.byteOffset + content.byteLength
+  )
 }
 
 function getWebviewContent(indexJsUri: vscode.Uri): string {


### PR DESCRIPTION
Opening any storage file in the VS Code extension fails with "content.slice is not a function": the Webview receives an object keyed by index rather than the Uint8Array the extension posted.

workspace.fs.readFile() hands back a Node Buffer in the desktop extension host. The Webview message serializer recognizes a typed array by its exact constructor name and passes those bytes out of band, but Buffer is not one of the names it knows, so the value falls through to JSON.stringify(), which turns it into {"0":..,"1":..}. Base64 hid this, since a string survives JSON either way.

An ArrayBuffer is recognized whatever it came from, so send one. The copy that takes only this file's bytes out of a pooled Buffer cannot use Buffer.slice(), which returns a view rather than a copy, so it goes through the ArrayBuffer.

The Webview side accepts an ArrayBuffer or a typed array and names anything else in the error, instead of failing as a missing method on an object of an unexpected shape.

<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Regression from #1244 (`Remove base64 encoding from VS Code storage messages`).

## What does this implement/fix? Explain your changes.

Opening any storage file in the VS Code extension currently fails, for both SQLite and Journal files. The panel stays empty and the Webview developer tools show:

```
Uncaught TypeError: content.slice is not a function
```

The Webview receives an object keyed by index, `{"0":..,"1":..}`, rather than the `Uint8Array` the extension posted.

`workspace.fs.readFile()` hands back a Node `Buffer` in the desktop extension host. The Webview message serializer recognizes a typed array by its exact constructor name:

```js
switch (value.constructor.name) {
  case 'Int8Array': ...
  case 'Uint8Array': ...
```

`Buffer` is not one of those names, so the value falls through to `JSON.stringify()`, which serializes a typed array into an object keyed by index. Base64 hid this, since a string survives JSON either way.

An `ArrayBuffer` is recognized whatever it came from, so the extension now sends one. Taking only this file's bytes out of a pooled `Buffer` cannot use `Buffer.slice()`, which returns a view rather than a copy unlike `Uint8Array.slice()`, so the copy goes through the `ArrayBuffer`.

The Webview side accepts an `ArrayBuffer` or a typed array, and names what it did receive in the error rather than failing as a missing method on an object of an unexpected shape.