### PR TITLE
Load storages in the storage Worker in the VS Code extension

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,7 +326,7 @@ importers:
   tslib/storage:
     dependencies:
       '@sqlite.org/sqlite-wasm':
-        specifier: ^3.45.1-build1
+        specifier: 3.45.1-build1
         version: 3.45.1-build1
     devDependencies:
       '@optuna/types':

--- a/standalone_app/src/components/StorageProvider.tsx
+++ b/standalone_app/src/components/StorageProvider.tsx
@@ -32,11 +32,6 @@ export const StorageContext = createContext<{
   loading: boolean
   error: Error | null
   reportError: (error: unknown) => void
-  // Transitional: the VS Code Webview still builds a backend on the UI thread
-  // and hands it over, because its Worker needs asset plumbing that the Webview
-  // build does not have yet. It goes away once the Webview opens storages the
-  // way the standalone app now does.
-  setStorage: (storage: OptunaStorage) => void
 }>({
   storage: null,
   storageName: null,
@@ -45,7 +40,6 @@ export const StorageContext = createContext<{
   loading: false,
   error: null,
   reportError: () => {},
-  setStorage: () => {},
 })
 
 // A viewer owns at most one storage session at a time. The session is kept in a
@@ -153,19 +147,6 @@ export const StorageProvider: FC<{
     [reportError, sqliteWasm, workerFactory]
   )
 
-  const setStorage = useCallback((nextStorage: OptunaStorage) => {
-    const session = sessionRef.current
-    session.generation += 1
-    const currentStorage = session.storage
-    session.storage = nextStorage
-    setActiveStorage(nextStorage)
-    setStorageName(null)
-    setError(null)
-    if (currentStorage !== null) {
-      void currentStorage.close().catch(() => {})
-    }
-  }, [])
-
   useEffect(() => {
     const session = sessionRef.current
     return () => {
@@ -189,7 +170,6 @@ export const StorageProvider: FC<{
         loading,
         error,
         reportError,
-        setStorage,
       }}
     >
       {children}

--- a/standalone_app/src/vscode_entry.tsx
+++ b/standalone_app/src/vscode_entry.tsx
@@ -1,47 +1,111 @@
-import { JournalFileStorage, SQLite3Storage } from "@optuna/storage"
-import type { OptunaStorage } from "@optuna/storage"
-import React, { FC, useEffect, useContext } from "react"
+import type { StorageWorkerFactory } from "@optuna/storage/worker-client"
+import React, { FC, useContext, useEffect } from "react"
 import ReactDOM from "react-dom/client"
 import { App } from "./components/App"
 import { StorageContext, StorageProvider } from "./components/StorageProvider"
 import "./index.css"
 
+declare function acquireVsCodeApi(): {
+  postMessage: (message: unknown) => void
+}
+
+// acquireVsCodeApi() may only be called once per Webview, so memoize it outside
+// of the component: StrictMode mounts the effect below twice. It throws when
+// something else acquired the API first, which a stale extension build can do,
+// and an effect that throws unmounts the React root, so report it instead.
+let vscodeApi: ReturnType<typeof acquireVsCodeApi> | null = null
+const getVsCodeApi = (): ReturnType<typeof acquireVsCodeApi> | null => {
+  if (vscodeApi === null) {
+    try {
+      vscodeApi = acquireVsCodeApi()
+    } catch (error) {
+      console.error("Failed to acquire the VS Code API", error)
+      return null
+    }
+  }
+  return vscodeApi
+}
+
 type WebviewMessage = {
   type: "optunaStorage"
   content: unknown
+  workerUri: string
+  sqliteWasmUri: string
 }
 
 export const AppWrapper: FC = () => {
-  const { setStorage } = useContext(StorageContext)
+  const { loadStorage, reportError } = useContext(StorageContext)
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       const message = event.data as WebviewMessage
 
       switch (message.type) {
-        case "optunaStorage":
-          setStorage(getStorage(toArrayBuffer(message.content)))
+        case "optunaStorage": {
+          const buffer = toArrayBuffer(message.content)
+          void (async () => {
+            try {
+              await loadStorage(buffer, {
+                workerFactory: createWebviewWorkerFactory(message.workerUri),
+                sqliteWasm: {
+                  buffer: await fetchAsset(
+                    message.sqliteWasmUri,
+                    "SQLite wasm"
+                  ),
+                },
+              })
+            } catch (error) {
+              reportError(error)
+            }
+          })()
           break
+        }
       }
     }
     window.addEventListener("message", handleMessage)
+    // Ask for the storage only once the listener is in place. The extension
+    // answers immediately, and a message posted before this point is dropped.
+    getVsCodeApi()?.postMessage({ type: "webviewDidLoad" })
     return () => window.removeEventListener("message", handleMessage)
-  }, [])
+  }, [loadStorage, reportError])
   return <App />
 }
 
-// Transitional: the Webview parses the storage on the UI thread, as it did
-// before the standalone app moved to the storage Worker. Starting the Worker
-// here needs the Webview build to emit it as an asset the Webview may load,
-// which is the next change.
-const getStorage = (arrayBuffer: ArrayBuffer): OptunaStorage => {
-  const header = new Uint8Array(arrayBuffer, 0, 16)
-  const headerString = new TextDecoder().decode(header)
-  if (headerString === "SQLite format 3\u0000") {
-    return new SQLite3Storage(arrayBuffer)
+// Extension assets are served by the Webview's service worker, which does not
+// answer a request coming from a Worker that was started from a blob: URL: those
+// come back with an error status. Everything the storage Worker needs is
+// therefore fetched here, in the document, and handed over as bytes.
+const fetchAsset = async (uri: string, label: string): Promise<ArrayBuffer> => {
+  const response = await fetch(uri)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${label}: ${response.status}`)
   }
-  return new JournalFileStorage(arrayBuffer)
+  return response.arrayBuffer()
+}
+
+// A Webview cannot point a Worker at an extension asset, so the Worker bundle is
+// fetched and started from a blob: URL. Revoking that URL is the factory's
+// business, which is what the disposer is for.
+const createWebviewWorkerFactory = (
+  workerUri: string
+): StorageWorkerFactory => {
+  return async () => {
+    const response = await fetch(workerUri)
+    if (!response.ok) {
+      throw new Error(`Failed to fetch storage worker: ${response.status}`)
+    }
+    const blobUrl = URL.createObjectURL(await response.blob())
+    try {
+      const worker = new Worker(blobUrl)
+      return {
+        worker,
+        dispose: () => URL.revokeObjectURL(blobUrl),
+      }
+    } catch (error) {
+      URL.revokeObjectURL(blobUrl)
+      throw error
+    }
+  }
 }
 
 // The extension sends an ArrayBuffer. A typed array is accepted as well, since

--- a/standalone_app/webpack.config.js
+++ b/standalone_app/webpack.config.js
@@ -1,6 +1,39 @@
+const fs = require('fs');
 const webpack = require('webpack');
 const path = require('path');
 const CompressionPlugin = require("compression-webpack-plugin");
+
+// sqlite3.wasm is loaded by the storage Worker through a URL that the extension
+// resolves with asWebviewUri(), so nothing in the bundles imports it. Emit it
+// explicitly instead of relying on an otherwise unused `*.wasm?url` import.
+const sqliteWasmPath = path.join(
+    path.dirname(require.resolve('@sqlite.org/sqlite-wasm/package.json', {
+        paths: [path.resolve(__dirname, '../tslib/storage')],
+    })),
+    'sqlite-wasm/jswasm/sqlite3.wasm'
+);
+
+class EmitSqliteWasmPlugin {
+    apply(compiler) {
+        const pluginName = 'EmitSqliteWasmPlugin';
+        compiler.hooks.thisCompilation.tap(pluginName, (compilation) => {
+            compilation.hooks.processAssets.tapPromise(
+                {
+                    name: pluginName,
+                    stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
+                },
+                async () => {
+                    compilation.fileDependencies.add(sqliteWasmPath);
+                    const content = await fs.promises.readFile(sqliteWasmPath);
+                    compilation.emitAsset(
+                        'sqlite3.wasm',
+                        new compiler.webpack.sources.RawSource(content)
+                    );
+                }
+            );
+        });
+    }
+}
 
 module.exports = {
     mode: "production",
@@ -15,11 +48,19 @@ module.exports = {
             config: [__filename],
         }
     },
-    entry: [__dirname + '/src/vscode_entry.tsx'],
+    entry: {
+        bundle: __dirname + '/src/vscode_entry.tsx',
+        'storage-worker': path.resolve(__dirname, '../tslib/storage/src/storage_worker.ts'),
+    },
     output: {
         path: path.resolve(__dirname, '../vscode/assets/'),
-        filename: 'bundle.js',
-        publicPath: '/'
+        filename: '[name].js',
+        publicPath: '/',
+        clean: true,
+    },
+    optimization: {
+        splitChunks: false,
+        runtimeChunk: false,
     },
     module: {
         rules: [
@@ -33,7 +74,11 @@ module.exports = {
                 }
             }] },
             {
+                // `*.wasm?url` is a Vite-only entrypoint of @optuna/storage. Keep it
+                // out of the inline rule so that importing it here fails loudly
+                // instead of silently inlining sqlite3.wasm as base64.
                 test: /\.wasm$/,
+                resourceQuery: { not: [/url/] },
                 type: "asset/inline",
             },
             {
@@ -41,14 +86,22 @@ module.exports = {
                 resolve: {
                     fullySpecified: false
                 }
+            },
+            {
+                test: /sqlite3-bundler-friendly\.mjs$/,
+                use: path.resolve(__dirname, '../tslib/storage/build/sqlite-wasm-bundler-loader.cjs'),
             }
         ]
     },
     resolve: {
-        extensions: ['.ts', '.tsx', '.js']
+        extensions: ['.ts', '.tsx', '.js'],
+        extensionAlias: {
+            '.js': ['.ts', '.js'],
+        },
     },
     plugins: [
         new webpack.DefinePlugin({ 'IS_VSCODE': JSON.stringify(true) }),
+        new EmitSqliteWasmPlugin(),
         new CompressionPlugin()
     ]
 };

--- a/tslib/storage/build/sqlite-wasm-bundler-loader.cjs
+++ b/tslib/storage/build/sqlite-wasm-bundler-loader.cjs
@@ -1,0 +1,36 @@
+// webpack loader for @sqlite.org/sqlite-wasm's sqlite3-bundler-friendly.mjs.
+//
+// The two `new URL(..., import.meta.url)` expressions below are asset references
+// for webpack, so it would emit sqlite3.wasm and the OPFS proxy into the storage
+// Worker bundle even though neither is fetched relatively: the wasm is passed in
+// as a URL or as bytes (see SQLiteWasmOptions), and the OPFS VFS is not used.
+// Replacing them with plain strings keeps the Worker bundle self-contained.
+//
+// This is tied to the exact version pinned in ../package.json. The occurrence
+// check below fails the build when an update moves the code, so review both
+// sites in the new release before bumping the dependency.
+const replacements = [
+  // Only reachable when locateFile is unset, which SQLite3Storage never does.
+  ["new URL('sqlite3.wasm', import.meta.url).href", "'sqlite3.wasm'"],
+  // Only reachable when the OPFS APIs are available; storage_worker.ts also
+  // removes globalThis.Worker so the nested Worker is never constructed.
+  [
+    "new URL('sqlite3-opfs-async-proxy.js', import.meta.url)",
+    "'sqlite3-opfs-async-proxy.js'",
+  ],
+]
+
+module.exports = function sqliteWasmBundlerLoader(source) {
+  this.cacheable()
+  let transformed = source
+  for (const [from, to] of replacements) {
+    const occurrences = transformed.split(from).length - 1
+    if (occurrences !== 1) {
+      throw new Error(
+        `Expected exactly one ${JSON.stringify(from)} in sqlite-wasm, found ${occurrences}`
+      )
+    }
+    transformed = transformed.replaceAll(from, to)
+  }
+  return transformed
+}

--- a/tslib/storage/package.json
+++ b/tslib/storage/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/optuna/optuna-dashboard#readme",
   "dependencies": {
-    "@sqlite.org/sqlite-wasm": "^3.45.1-build1"
+    "@sqlite.org/sqlite-wasm": "3.45.1-build1"
   },
   "devDependencies": {
     "@optuna/types": "workspace:*",

--- a/vscode/.vscodeignore
+++ b/vscode/.vscodeignore
@@ -12,3 +12,6 @@ pnpm-lock.yaml
 **/.eslintrc.json
 **/*.map
 **/*.ts
+# The Webview does not negotiate content-encoding, so the gzipped copies that
+# CompressionPlugin writes next to the assets are dead weight in the package.
+assets/**/*.gz

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -49,7 +49,10 @@ export function activate(context: vscode.ExtensionContext) {
       panel.onDidDispose(() => messageDisposable.dispose())
       // Last: the Webview asks for the storage as soon as it has loaded, and the
       // listener above has to be in place by then.
-      panel.webview.html = getWebviewContent(asset("bundle.js"))
+      panel.webview.html = getWebviewContent(
+        asset("bundle.js"),
+        panel.webview.cspSource
+      )
     }
   )
 
@@ -83,11 +86,25 @@ function toArrayBuffer(content: Uint8Array): ArrayBuffer {
 // 'webviewDidLoad' is posted by the bundle once it listens for messages, rather
 // than from an inline script on DOMContentLoaded: React schedules the effect that
 // installs that listener, so it can run after the event and miss the answer.
-function getWebviewContent(indexJsUri: vscode.Uri): string {
+function getWebviewContent(indexJsUri: vscode.Uri, cspSource: string): string {
+  // Starting from default-src 'none', every source the dashboard needs is listed:
+  // the bundle and the assets it fetches, 'wasm-unsafe-eval' to compile
+  // sqlite3.wasm, blob: for the storage Worker, inline styles for emotion, and
+  // data: images, which the Webview host itself loads to probe webp support.
+  const csp = [
+    "default-src 'none'",
+    `script-src ${cspSource} 'wasm-unsafe-eval'`,
+    "worker-src blob:",
+    `connect-src ${cspSource}`,
+    `img-src ${cspSource} data: blob:`,
+    `font-src ${cspSource}`,
+    `style-src ${cspSource} 'unsafe-inline'`,
+  ].join("; ")
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <meta http-equiv="Content-Security-Policy" content="${csp};">
   <title>Optuna Dashboard (Wasm ver.)</title>
   <script type="module" crossorigin src="${indexJsUri}"></script>
 </head>

--- a/vscode/src/web/extension.ts
+++ b/vscode/src/web/extension.ts
@@ -21,28 +21,35 @@ export function activate(context: vscode.ExtensionContext) {
         }
       )
 
-      const indexJsUri = vscode.Uri.joinPath(
-        context.extensionUri,
-        "assets",
-        "bundle.js"
-      )
+      const asset = (name: string) =>
+        panel.webview.asWebviewUri(
+          vscode.Uri.joinPath(context.extensionUri, "assets", name)
+        )
 
-      const appPath = panel.webview.asWebviewUri(indexJsUri)
-
-      panel.webview.html = getWebviewContent(appPath)
       const handleMessage = async (message: { type: string }) => {
         switch (message.type) {
           case "webviewDidLoad": {
-            await panel.webview.postMessage({
-              type: "optunaStorage",
-              content: toArrayBuffer(await readFile(fileUri)),
-            })
+            try {
+              await panel.webview.postMessage({
+                type: "optunaStorage",
+                content: toArrayBuffer(await readFile(fileUri)),
+                // The Webview starts the Worker and loads the wasm from these,
+                // since it may not hand an extension path to a Worker.
+                workerUri: asset("storage-worker.js").toString(),
+                sqliteWasmUri: asset("sqlite3.wasm").toString(),
+              })
+            } catch (error: unknown) {
+              console.error("Failed to load Optuna storage", error)
+            }
             break
           }
         }
       }
       const messageDisposable = panel.webview.onDidReceiveMessage(handleMessage)
       panel.onDidDispose(() => messageDisposable.dispose())
+      // Last: the Webview asks for the storage as soon as it has loaded, and the
+      // listener above has to be in place by then.
+      panel.webview.html = getWebviewContent(asset("bundle.js"))
     }
   )
 
@@ -73,6 +80,9 @@ function toArrayBuffer(content: Uint8Array): ArrayBuffer {
   )
 }
 
+// 'webviewDidLoad' is posted by the bundle once it listens for messages, rather
+// than from an inline script on DOMContentLoaded: React schedules the effect that
+// installs that listener, so it can run after the event and miss the answer.
 function getWebviewContent(indexJsUri: vscode.Uri): string {
   return `<!DOCTYPE html>
 <html lang="en">
@@ -80,14 +90,6 @@ function getWebviewContent(indexJsUri: vscode.Uri): string {
   <meta charset="utf-8" />
   <title>Optuna Dashboard (Wasm ver.)</title>
   <script type="module" crossorigin src="${indexJsUri}"></script>
-  <script>
-    (function() {
-      const vscodeApi = acquireVsCodeApi();
-      window.addEventListener('DOMContentLoaded', (event) => {
-        vscodeApi.postMessage({ type: 'webviewDidLoad' })
-      })
-    }())
-  </script>
 </head>
 <body>
   <div id="root"></div>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
Follow-up of #1322 (the Worker and its client) and #1323 (the standalone app).


## What does this implement/fix? Explain your changes.

The Webview parsed the storage where it rendered: sqlite-wasm initialization, every query, and for a Journal file the whole decode, split, parse and replay ran on the UI thread, so the panel stopped responding until it finished. It now opens the storage through the storage Worker, the same way the standalone app does.

### Getting the Worker into a Webview

A Webview cannot hand an extension path to a Worker, so the extension passes the Webview URI of the Worker bundle and of `sqlite3.wasm`, and the Webview:

* fetches the bundle and starts it from a `blob:` URL
* fetches the wasm itself and transfers the bytes to the Worker

The second one is not an optimization but a requirement: extension assets are served by the Webview's service worker, and a Worker started from a `blob:` URL is not a client it answers, so a fetch from inside the Worker comes back with an error status. Doing it in the document is also where the same fetch already works for the Worker bundle.

The Worker bundle therefore has to be self contained, with no import and no chunk to load afterwards, which is what `splitChunks: false` and the sqlite-wasm loader are for: the two `new URL(..., import.meta.url)` expressions in sqlite-wasm are asset references webpack would follow, pulling `sqlite3.wasm` and the OPFS proxy into the Worker bundle although neither is fetched relatively.

The loader replaces them with plain strings and fails the build if either stops matching, which is why the dependency is pinned to an exact version.

`sqlite3.wasm` is now emitted as a file rather than inlined into the JavaScript as base64. `bundle.js` goes from 6.87MB to 5.42MB, and the wasm can be compiled from a response instead of decoded from a data URI.

### The handshake

`webviewDidLoad` was posted from an inline script on `DOMContentLoaded`, while the listener for the answer was installed by a React effect. The scheduler can run that effect afterwards, so the extension would post the storage into a Webview that was not listening yet: an empty panel, and no error anywhere. It is now posted from the effect that installs the listener, which orders the two. For the same reason the extension registers its own listener before setting the HTML.

### CSP

The Webview ran with no policy of its own. Starting from `default-src 'none'`, it now allows the extension's own resources, `'wasm-unsafe-eval'` for compiling sqlite3.wasm, `blob:` for the Worker, inline styles for emotion, and `data:` images, which the Webview host loads itself to probe webp support. No nonce is needed since the inline script is gone.