### PR TITLE
Improve error handling in the hyperparameter importance WASM module

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,22 @@
+name: rust-checks
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/rust-tests.yml'
+      - 'rustlib/**'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Unit tests for rustlib
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Run tests
+        working-directory: rustlib
+        run: cargo test

--- a/rustlib/Cargo.toml
+++ b/rustlib/Cargo.toml
@@ -11,4 +11,4 @@ js-sys = "0.3.77"
 serde-wasm-bindgen = "0.6"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]

--- a/rustlib/src/importance.rs
+++ b/rustlib/src/importance.rs
@@ -1,0 +1,288 @@
+use fanova::{FanovaOptions, RandomForestOptions};
+use std::error::Error;
+use std::fmt;
+
+/// fANOVA needs at least two observations before the objective can have any
+/// variance to attribute to the parameters.
+const MIN_TRIALS: usize = 2;
+
+/// Reason why hyperparameter importance could not be calculated.
+///
+/// Every variant carries the index it complains about, so the message that
+/// reaches the browser says which parameter or trial is at fault.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImportanceError {
+    /// A feature column was not an array of numbers.
+    FeatureNotNumberArray { feature: usize },
+
+    /// A target value was not a number.
+    TargetNotNumber { trial: usize },
+
+    /// Feature columns disagree on how many trials there are.
+    TrialCountMismatch {
+        feature: usize,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// The number of objective values does not match the number of trials.
+    TargetCountMismatch { trials: usize, targets: usize },
+
+    /// A parameter value was NaN or infinite.
+    NonFiniteFeature { feature: usize, trial: usize },
+
+    /// An objective value was NaN or infinite.
+    NonFiniteTarget { trial: usize },
+
+    /// The fANOVA model itself could not be built.
+    Fit(String),
+}
+
+impl fmt::Display for ImportanceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::FeatureNotNumberArray { feature } => write!(
+                f,
+                "features[{feature}] must be of type number[]; features must be of type number[][]"
+            ),
+            Self::TargetNotNumber { trial } => {
+                write!(f, "targets[{trial}] must be a number")
+            }
+            Self::TrialCountMismatch {
+                feature,
+                expected,
+                actual,
+            } => write!(
+                f,
+                "features[{feature}] has {actual} values but features[0] has {expected}; \
+                 every parameter must have one value per trial"
+            ),
+            Self::TargetCountMismatch { trials, targets } => write!(
+                f,
+                "got {targets} targets for {trials} trials; \
+                 there must be one objective value per trial"
+            ),
+            Self::NonFiniteFeature { feature, trial } => write!(
+                f,
+                "features[{feature}][{trial}] is not a finite number"
+            ),
+            Self::NonFiniteTarget { trial } => {
+                write!(f, "targets[{trial}] is not a finite number")
+            }
+            Self::Fit(reason) => write!(f, "failed to build fANOVA model: {reason}"),
+        }
+    }
+}
+
+impl Error for ImportanceError {}
+
+/// Calculates the fANOVA importance of each parameter.
+///
+/// `features` is column-major: one entry per parameter, each holding that
+/// parameter's value for every trial. `targets` holds one objective value per
+/// trial. The returned vector always has one importance per parameter, in the
+/// same order, so callers can zip it with their parameter list.
+///
+/// Malformed input is rejected with an [`ImportanceError`]. Well-formed but
+/// degenerate input (no trials, no variance) yields zeros rather than an error:
+/// there is simply nothing to attribute, and a study can legitimately look like
+/// that early on.
+pub fn calculate_importance(
+    features: &[Vec<f64>],
+    targets: &[f64],
+) -> Result<Vec<f64>, ImportanceError> {
+    if features.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let trials = features[0].len();
+    for (feature, column) in features.iter().enumerate() {
+        if column.len() != trials {
+            return Err(ImportanceError::TrialCountMismatch {
+                feature,
+                expected: trials,
+                actual: column.len(),
+            });
+        }
+        if let Some(trial) = column.iter().position(|v| !v.is_finite()) {
+            return Err(ImportanceError::NonFiniteFeature { feature, trial });
+        }
+    }
+    if targets.len() != trials {
+        return Err(ImportanceError::TargetCountMismatch {
+            trials,
+            targets: targets.len(),
+        });
+    }
+    if let Some(trial) = targets.iter().position(|v| !v.is_finite()) {
+        return Err(ImportanceError::NonFiniteTarget { trial });
+    }
+
+    // fANOVA divides by the variance of the objective. With fewer than two
+    // trials, or with every trial scoring the same, that variance is zero and
+    // the division yields NaN, which then renders as a broken bar chart.
+    // Nothing here is an error, so report "no parameter explains anything".
+    if trials < MIN_TRIALS || is_constant(targets) {
+        return Ok(vec![0.0; features.len()]);
+    }
+
+    // A parameter that took the same value in every trial spans a zero-width
+    // range, and that width is one factor of the feature-space volume that
+    // *every* importance is divided by. Leaving one in makes the whole result
+    // NaN, so fit without them and report them as zero.
+    let varying = (0..features.len())
+        .filter(|&i| !is_constant(&features[i]))
+        .collect::<Vec<_>>();
+    if varying.is_empty() {
+        return Ok(vec![0.0; features.len()]);
+    }
+
+    let columns = varying
+        .iter()
+        .map(|&i| features[i].as_slice())
+        .collect::<Vec<_>>();
+    let mut fanova = FanovaOptions::new()
+        .random_forest(RandomForestOptions::new().seed(0))
+        .fit(columns, targets)
+        .map_err(|e| ImportanceError::Fit(e.to_string()))?;
+
+    let mut importances = vec![0.0; features.len()];
+    for (fitted, &original) in varying.iter().enumerate() {
+        let mean = fanova.quantify_importance(&[fitted]).mean;
+        // Last line of defence: the checks above cover the degenerate cases we
+        // know of, but a stray NaN would poison the plot for every parameter,
+        // and a zero bar is a far cheaper way to be wrong.
+        importances[original] = if mean.is_finite() { mean } else { 0.0 };
+    }
+    Ok(importances)
+}
+
+fn is_constant(values: &[f64]) -> bool {
+    match values.first() {
+        None => true,
+        Some(&first) => values.iter().all(|&v| v == first),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn features(columns: &[&[f64]]) -> Vec<Vec<f64>> {
+        columns.iter().map(|c| c.to_vec()).collect()
+    }
+
+    #[test]
+    fn ranks_the_influential_parameter_higher() {
+        // The objective follows x0 and ignores x1.
+        let x0 = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let x1 = vec![3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0];
+        let targets = x0.iter().map(|v| v * 10.0).collect::<Vec<_>>();
+
+        let importances = calculate_importance(&features(&[&x0, &x1]), &targets).unwrap();
+
+        assert_eq!(importances.len(), 2);
+        assert!(importances.iter().all(|v| v.is_finite()));
+        assert!(importances[0] > importances[1]);
+    }
+
+    #[test]
+    fn no_parameters_gives_no_importances() {
+        assert_eq!(calculate_importance(&[], &[1.0, 2.0]).unwrap(), Vec::new());
+    }
+
+    #[test]
+    fn constant_objective_gives_zeros_not_nan() {
+        let x0 = vec![0.0, 1.0, 2.0, 3.0];
+        let targets = vec![7.0; 4];
+
+        let importances = calculate_importance(&features(&[&x0]), &targets).unwrap();
+
+        assert_eq!(importances, vec![0.0]);
+    }
+
+    #[test]
+    fn single_trial_gives_zeros_not_nan() {
+        let importances = calculate_importance(&features(&[&[1.0], &[2.0]]), &[3.0]).unwrap();
+
+        assert_eq!(importances, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn constant_parameter_does_not_poison_the_others() {
+        let constant = vec![0.5; 8];
+        let varying = vec![0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0];
+        let targets = varying.iter().map(|v| v * 10.0).collect::<Vec<_>>();
+
+        let importances =
+            calculate_importance(&features(&[&constant, &varying]), &targets).unwrap();
+
+        assert!(importances.iter().all(|v| v.is_finite()));
+        assert_eq!(importances[0], 0.0);
+        assert!(importances[1] > 0.0);
+    }
+
+    #[test]
+    fn every_parameter_constant_gives_zeros() {
+        let importances =
+            calculate_importance(&features(&[&[1.0; 4], &[2.0; 4]]), &[1.0, 2.0, 3.0, 4.0])
+                .unwrap();
+
+        assert_eq!(importances, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn rejects_ragged_features() {
+        let err = calculate_importance(&features(&[&[1.0, 2.0], &[1.0]]), &[1.0, 2.0]).unwrap_err();
+
+        assert_eq!(
+            err,
+            ImportanceError::TrialCountMismatch {
+                feature: 1,
+                expected: 2,
+                actual: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_target_count_mismatch() {
+        let err = calculate_importance(&features(&[&[1.0, 2.0]]), &[1.0]).unwrap_err();
+
+        assert_eq!(
+            err,
+            ImportanceError::TargetCountMismatch {
+                trials: 2,
+                targets: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_finite_values() {
+        let nan_feature =
+            calculate_importance(&features(&[&[1.0, f64::NAN]]), &[1.0, 2.0]).unwrap_err();
+        assert_eq!(
+            nan_feature,
+            ImportanceError::NonFiniteFeature {
+                feature: 0,
+                trial: 1,
+            }
+        );
+
+        let infinite_target =
+            calculate_importance(&features(&[&[1.0, 2.0]]), &[1.0, f64::INFINITY]).unwrap_err();
+        assert_eq!(infinite_target, ImportanceError::NonFiniteTarget { trial: 1 });
+    }
+
+    #[test]
+    fn error_messages_name_the_offending_index() {
+        let message = ImportanceError::NonFiniteFeature {
+            feature: 2,
+            trial: 7,
+        }
+        .to_string();
+
+        assert!(message.contains("features[2][7]"), "{message}");
+    }
+}

--- a/rustlib/src/lib.rs
+++ b/rustlib/src/lib.rs
@@ -1,31 +1,31 @@
-use fanova::{FanovaOptions, RandomForestOptions};
+mod importance;
+
+use importance::{calculate_importance, ImportanceError};
 use js_sys::Array;
 use serde_wasm_bindgen::from_value;
 use wasm_bindgen::prelude::*;
 
+/// Calculates the fANOVA importance of each hyperparameter.
+///
+/// `features` is an array of parameters, each an array holding that parameter's
+/// internal value for every trial; `targets` holds one objective value per
+/// trial. Throws a JavaScript `Error` describing the offending index when the
+/// input is malformed.
 #[wasm_bindgen]
 pub fn wasm_fanova_calculate(features: Array, targets: Array) -> Result<Vec<f64>, JsError> {
-    let features_vec: Vec<Vec<f64>> = features
+    let features_vec = features
         .iter()
-        .map(|x| from_value::<Vec<f64>>(x))
-        .collect::<Result<_, _>>()
-        .map_err(|_| JsError::new("features must be of type number[][]"))?;
-    let targets_vec: Vec<f64> = targets
+        .enumerate()
+        .map(|(feature, x)| {
+            from_value::<Vec<f64>>(x)
+                .map_err(|_| ImportanceError::FeatureNotNumberArray { feature })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let targets_vec = targets
         .iter()
-        .map(|x| x.as_f64())
-        .collect::<Option<_>>()
-        .ok_or(JsError::new("targets must be of type number[]"))?;
+        .enumerate()
+        .map(|(trial, x)| x.as_f64().ok_or(ImportanceError::TargetNotNumber { trial }))
+        .collect::<Result<Vec<_>, _>>()?;
 
-    let mut fanova = FanovaOptions::new()
-        .random_forest(RandomForestOptions::new().seed(0))
-        .fit(
-            features_vec.iter().map(|x| x.as_slice()).collect(),
-            &targets_vec,
-        )
-        .map_err(|e| JsError::new(&format!("failed to build fANOVA model: {}", e)))?;
-    let importances = (0..features_vec.len())
-        .map(|i| fanova.quantify_importance(&[i]).mean)
-        .collect::<Vec<_>>();
-
-    Ok(importances)
+    Ok(calculate_importance(&features_vec, &targets_vec)?)
 }

--- a/standalone_app/src/components/StudyDetail.tsx
+++ b/standalone_app/src/components/StudyDetail.tsx
@@ -65,14 +65,18 @@ export const StudyDetail: FC<{
     if (trial.values === undefined) {
       return false
     }
+    // fANOVA has no variance to attribute to a non-finite objective, so such a
+    // trial is skipped here rather than rejected by the WASM module later. NaN
+    // used to slip through the two Infinity comparisons this replaces.
     return (
       trial.values.length > objectiveId &&
-      trial.values[objectiveId] !== Infinity &&
-      trial.values[objectiveId] !== -Infinity
+      Number.isFinite(trial.values[objectiveId])
     )
   }
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
+    let active = true
+
     async function run_wasm() {
       if (study === null) {
         return
@@ -95,17 +99,22 @@ export const StudyDetail: FC<{
           }
 
           const features = study.intersection_search_space.map((s) =>
-            filteredTrials
-              .map(
-                (t) =>
-                  t.params.find((p) => p.name === s.name) as Optuna.TrialParam
-              )
-              .map((p) => p.param_internal_value)
+            filteredTrials.map((t) => {
+              const param = t.params.find((p) => p.name === s.name)
+              if (param === undefined) {
+                // The intersection search space should guarantee this, so a
+                // miss means the study is inconsistent: say so instead of
+                // reading param_internal_value off undefined.
+                throw new Error(
+                  `Trial ${t.number} has no value for the parameter "${s.name}"`
+                )
+              }
+              return param.param_internal_value
+            })
           )
           const values = filteredTrials.map(
             (t) => t.values?.[objectiveId] as number
           )
-          // TODO: handle errors thrown by wasm_fanova_calculate
           const importance = wasm_fanova_calculate(features, values)
           return study.intersection_search_space.map((s, i) => ({
             name: s.name,
@@ -113,11 +122,33 @@ export const StudyDetail: FC<{
           }))
         }
       )
-      setImportance(x)
+      if (active) {
+        setImportance(x)
+      }
     }
 
-    run_wasm()
-  }, [study])
+    // init() rejects when the WASM module cannot be loaded, and
+    // wasm_fanova_calculate() throws when the module rejects the trials it was
+    // given. Neither was handled, so a failure left the panel empty with the
+    // reason visible only in the console.
+    run_wasm().catch((e: unknown) => {
+      if (!active) {
+        return
+      }
+      setImportance([])
+      reportError(
+        new Error(
+          `Failed to calculate hyperparameter importance: ${
+            e instanceof Error ? e.message : String(e)
+          }`
+        )
+      )
+    })
+
+    return () => {
+      active = false
+    }
+  }, [study, reportError])
 
   return (
     <>


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
Fixes #628

## What does this implement/fix? Explain your changes.

The `unwrap` calls described in #628 were removed at some point, but the error handling around them still has gaps in both directions: degenerate input silently produces `NaN`, and real errors never reach the user.

### `NaN` importances on well-formed studies

`Fanova::quantify_importance` computes `variance / partial_size / tree.variance`, where `partial_size` is a product over the widths of all feature ranges. A parameter that took the same value in every trial spans a zero-width range, so that product is zero and **every** parameter's importance becomes `NaN` — not just the constant one. A constant objective zeroes `tree.variance` with the same result.

Running the current code against fanova 0.2.0:

one constant param -> [NaN, NaN]
constant objective -> [NaN]
single trial -> [NaN, NaN]


None of these are error cases; they are ordinary states for a study early in its run. They now yield zeros, with constant columns dropped before fitting so they cannot poison the rest.

### Unhandled errors in the caller

`standalone_app/src/components/StudyDetail.tsx` called `wasm_fanova_calculate` under a `// TODO: handle errors thrown by wasm_fanova_calculate` with no `catch`. Any throw — including a failed `init()` — became an unhandled promise rejection, leaving the importance panel empty with the reason visible only in the console. Errors now go through the existing `reportError` snackbar.

### Changes

- New `rustlib/src/importance.rs` holds the calculation as plain Rust with no wasm glue, making it unit-testable. `lib.rs` is now just the `#[wasm_bindgen]` wrapper.
- A typed `ImportanceError` names the offending index: `features[2][7] is not a finite number` rather than `features must be of type number[][]`. It implements `std::error::Error`, so `?` converts it to `JsError` via wasm-bindgen's blanket impl.
- Ragged columns, target-count mismatches, and non-finite values are rejected up front; `<2` trials, a constant objective, and constant parameters return zeros. A final `is_finite` check keeps any stray `NaN` out of the chart.
- `filterFunc` now uses `Number.isFinite`. This is slightly beyond the scope of the issue: the previous `!== Infinity && !== -Infinity` pair let `NaN` objective values through to the WASM module.
- The unchecked `as Optuna.TrialParam` cast is replaced with an explicit error, and the effect ignores results from a stale `study`.
- 10 unit tests covering each case above, plus `.github/workflows/rust-tests.yml`, since CI currently never runs `cargo test`.

The new workflow is the most opinionated part of this PR and easy to drop if you would rather fold `cargo test` into `typescript-tests.yml`. Happy to split the `filterFunc` change out as well if you would prefer this PR stay strictly within #628.
