### PR TITLE
Always render parameter importances on the frontend

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -342,8 +342,6 @@ def create_app(
             fig = optuna.visualization.plot_edf(study)
         elif plot_type == "timeline":
             fig = optuna.visualization.plot_timeline(study)
-        elif plot_type == "param_importances":
-            fig = optuna.visualization.plot_param_importances(study)
         elif plot_type == "pareto_front":
             fig = optuna.visualization.plot_pareto_front(study)
         else:

--- a/optuna_dashboard/ts/apiClient.ts
+++ b/optuna_dashboard/ts/apiClient.ts
@@ -131,7 +131,6 @@ export enum PlotType {
   Rank = "rank",
   EDF = "edf",
   Timeline = "timeline",
-  ParamImportances = "param_importances",
   ParetoFront = "pareto_front",
 }
 

--- a/optuna_dashboard/ts/components/GraphHyperparameterImportances.tsx
+++ b/optuna_dashboard/ts/components/GraphHyperparameterImportances.tsx
@@ -1,15 +1,10 @@
-import { Box, Card, CardContent, useTheme } from "@mui/material"
-import * as plotly from "plotly.js-dist-min"
-import { FC, useEffect } from "react"
+import { Card, CardContent, useTheme } from "@mui/material"
+import { FC } from "react"
 
 import { PlotImportance } from "@optuna/react"
 import { StudyDetail } from "ts/types/optuna"
-import { PlotType } from "../apiClient"
 import { useParamImportance } from "../hooks/useParamImportance"
-import { usePlot } from "../hooks/usePlot"
-import { useBackendRender, usePlotlyColorTheme } from "../state"
-
-const plotDomId = "graph-hyperparameter-importances"
+import { usePlotlyColorTheme } from "../state"
 
 export const GraphHyperparameterImportance: FC<{
   studyId: number
@@ -26,53 +21,16 @@ export const GraphHyperparameterImportance: FC<{
   const theme = useTheme()
   const colorTheme = usePlotlyColorTheme(theme.palette.mode)
 
-  if (useBackendRender()) {
-    return (
-      <GraphHyperparameterImportanceBackend
-        studyId={studyId}
-        study={study}
-        graphHeight={graphHeight}
-      />
-    )
-  } else {
-    return (
-      <Card>
-        <CardContent>
-          <PlotImportance
-            study={study}
-            importance={importances}
-            graphHeight={graphHeight}
-            colorTheme={colorTheme}
-          />
-        </CardContent>
-      </Card>
-    )
-  }
-}
-
-const GraphHyperparameterImportanceBackend: FC<{
-  studyId: number
-  study: StudyDetail | null
-  graphHeight: string
-}> = ({ studyId, study = null, graphHeight }) => {
-  const numCompletedTrials =
-    study?.trials.filter((t) => t.state === "Complete").length || 0
-  const { data, layout, error } = usePlot({
-    numCompletedTrials,
-    studyId,
-    plotType: PlotType.ParamImportances,
-  })
-
-  useEffect(() => {
-    if (data && layout) {
-      plotly.react(plotDomId, data, layout)
-    }
-  }, [data, layout])
-  useEffect(() => {
-    if (error) {
-      console.error(error)
-    }
-  }, [error])
-
-  return <Box component="div" id={plotDomId} sx={{ height: graphHeight }} />
+  return (
+    <Card>
+      <CardContent>
+        <PlotImportance
+          study={study}
+          importance={importances}
+          graphHeight={graphHeight}
+          colorTheme={colorTheme}
+        />
+      </CardContent>
+    </Card>
+  )
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Summary

refs #1327 

- Always render hyperparameter importances using `@optuna/react`
- Remove the unused backend `param_importances` plot route
- Remove the corresponding `PlotType` entry and Plotly Python rendering logic

## Motivation

The dashboard already calculates parameter importances through its dedicated API. Using Optuna's `plot_param_importances` when backend rendering is enabled can require optional `scikit-learn` dependencies, so the existing frontend implementation should be used consistently.