### PR TITLE
Add an initial support for Rustuna storages

### DIFF
--- a/optuna_dashboard/_app.py
+++ b/optuna_dashboard/_app.py
@@ -62,6 +62,7 @@ if typing.TYPE_CHECKING:
     from typing import Any
     from typing import Literal
 
+    from rustuna.storages import StorageProtocol
     from _typeshed.wsgi import WSGIApplication
     from optuna.artifacts._protocol import ArtifactStore
     from optuna_dashboard.artifact.protocol import ArtifactBackend
@@ -641,7 +642,7 @@ def create_app(
 
 
 def run_server(
-    storage: str | BaseStorage,
+    storage: str | BaseStorage | StorageProtocol,
     host: str = "localhost",
     port: int = 8080,
     artifact_store: ArtifactStore | ArtifactBackend | None = None,
@@ -682,7 +683,7 @@ def run_server(
 
 
 def wsgi(
-    storage: str | BaseStorage,
+    storage: str | BaseStorage | StorageProtocol,
     artifact_store: ArtifactBackend | ArtifactStore | None = None,
     *,
     artifact_backend: ArtifactBackend | None = None,

--- a/optuna_dashboard/_storage_url.py
+++ b/optuna_dashboard/_storage_url.py
@@ -4,13 +4,20 @@ import os.path
 from pathlib import Path
 import re
 from typing import TYPE_CHECKING
+from types import ModuleType
 
 from optuna.storages import BaseStorage
 from optuna.storages import RDBStorage
 
+rustuna: ModuleType | None
+try:
+    import rustuna
+except ImportError:
+    rustuna = None
 
 if TYPE_CHECKING:
     from optuna.storages import JournalStorage
+    from rustuna.storages import StorageProtocol
 
 
 # The code to declare `rfc1738_pattern` variable is quoted from the source code
@@ -36,20 +43,30 @@ rfc1738_pattern = re.compile(
 )
 
 
-def get_storage(storage: str | BaseStorage, storage_class: str | None = None) -> BaseStorage:
+def get_storage(
+    storage: str | BaseStorage | StorageProtocol, storage_class: str | None = None
+) -> BaseStorage:
     if isinstance(storage, BaseStorage):
         return storage
 
-    if storage_class:
-        if storage_class == "RDBStorage":
-            return get_rdb_storage(storage)
-        if storage_class == "JournalRedisStorage":
-            return get_journal_redis_storage(storage)
-        if storage_class == "JournalFileStorage":
-            return get_journal_file_storage(storage)
-        raise ValueError("Unexpected storage_class")
+    if isinstance(storage, str):
+        if storage_class:
+            if storage_class == "RDBStorage":
+                return get_rdb_storage(storage)
+            if storage_class == "JournalRedisStorage":
+                return get_journal_redis_storage(storage)
+            if storage_class == "JournalFileStorage":
+                return get_journal_file_storage(storage)
+            raise ValueError("Unexpected storage_class")
+        return guess_storage_from_url(storage)
 
-    return guess_storage_from_url(storage)
+    if rustuna is not None:
+        from rustuna.converter import ToOptunaStorage
+
+        if storage.may_omit_trials():
+            raise ValueError("apply_discard option is not supported.")
+        return ToOptunaStorage(storage)
+    raise ValueError("No storage matched.")
 
 
 def _has_sqlite_header(storage_url: str) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
 
 [tool.uv]
 exclude-newer = "5 days"
-exclude-newer-package = { torch = false, optuna = false, optuna-integration = false }
+exclude-newer-package = { torch = false, optuna = false, rustuna = false, optuna-integration = false }
 
 [[tool.uv.index]]
 name = "pytorch-cpu"
@@ -140,5 +140,6 @@ lint = [
     "mypy",
     "mypy-boto3-s3",
     "openai>=3.0.0",
+    "rustuna; python_version >= '3.11'",
 ]
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request!
-->

## Contributor License Agreement

This repository (``optuna-dashboard``) and [Goptuna](https://github.com/c-bata/goptuna) share common code.
This pull request may therefore be ported to Goptuna.
Make sure that you understand the consequences concerning licenses and check the box below if you accept the term before creating this pull request.

* [x] I agree this patch may be ported to [Goptuna](https://github.com/c-bata/goptuna) by other Goptuna contributors.

## Reference Issues/PRs
<!--
Example: Fixes #1234. Close #1234. See also #1234. Follow-up #1234.
Please use keywords (e.g., Fixes) to automatically close referenced issues.
-->
None

## What does this implement/fix? Explain your changes.

<!-- Describe the changes in this PR. A picture or video tells a thousand words. -->
Add an initial support for Rustuna storages.

```python
import rustuna
from optuna_dashboard import run_server

def objective(trial: rustuna.Trial) -> float:
    x1 = trial.suggest_float("x1", 0, 10)
    x2 = trial.suggest_float("x2", 0, 10)
    return (x1 - 2) ** 2 + (x2 - 5) ** 2

storage = rustuna.storages.InMemoryStorage()
study = rustuna.create_study(study_name="rustuna-example", storage=storage)
study.optimize(objective, n_trials=100)
run_server(storage, host="localhost", port=8080)
```